### PR TITLE
Feature/low thrust (spherical shaping)

### DIFF
--- a/tudatpy/CMakeLists.txt
+++ b/tudatpy/CMakeLists.txt
@@ -69,6 +69,7 @@ YACMA_PYTHON_MODULE(kernel
         kernel/expose_reference_frames.cpp
         kernel/expose_aerodynamics.cpp
         kernel/expose_basic_astrodynamics.cpp
+        kernel/expose_low_thrust.cpp
         kernel/expose_gravitation.cpp
         kernel/expose_numerical_integrators.cpp
         kernel/expose_orbital_element_conversions.cpp
@@ -82,6 +83,9 @@ YACMA_PYTHON_MODULE(kernel
 target_link_libraries(kernel PRIVATE
         ${Boost_LIBRARIES}
         ${Boost_SYSTEM_LIBRARY}
+        Tudat::tudat_low_thrust
+        Tudat::tudat_shape_based
+        Tudat::tudat_numerical_quadrature
         ${Tudat_PROPAGATION_LIBRARIES})
 
 target_include_directories(kernel PUBLIC

--- a/tudatpy/kernel/expose_ephemerides.cpp
+++ b/tudatpy/kernel/expose_ephemerides.cpp
@@ -11,8 +11,35 @@ namespace tudatpy {
 
     void expose_ephemerides(py::module &m) {
 
+    	py::enum_<ApproximatePlanetPositionsBase::BodiesWithEphemerisData>(m, "BodiesWithEphemerisData")
+    	        .value("mercury", ApproximatePlanetPositionsBase::BodiesWithEphemerisData::mercury)
+				.value("venus", ApproximatePlanetPositionsBase::BodiesWithEphemerisData::venus)
+				.value("earth_moon_barycenter", ApproximatePlanetPositionsBase::BodiesWithEphemerisData::earthMoonBarycenter)
+				.value("mars", ApproximatePlanetPositionsBase::BodiesWithEphemerisData::mars)
+				.value("jupiter", ApproximatePlanetPositionsBase::BodiesWithEphemerisData::jupiter)
+				.value("saturn", ApproximatePlanetPositionsBase::BodiesWithEphemerisData::saturn)
+				.value("uranus", ApproximatePlanetPositionsBase::BodiesWithEphemerisData::uranus)
+				.value("neptune", ApproximatePlanetPositionsBase::BodiesWithEphemerisData::neptune)
+				.value("pluto", ApproximatePlanetPositionsBase::BodiesWithEphemerisData::pluto)
+				.export_values();
+
         py::class_<RotationalEphemeris,
                 std::shared_ptr<RotationalEphemeris>> RotationalEphemeris_(m, "RotationalEphemeris");
+
+		py::class_<ApproximatePlanetPositions, std::shared_ptr<ApproximatePlanetPositions>>(m, "ApproximatePlanetPositionsEphemeris")
+		.def(py::init<
+		        ApproximatePlanetPositionsBase::BodiesWithEphemerisData,
+		        const double
+		        >(),
+		        py::arg("body_with_ephemeris_data"),
+		        py::arg("sun_gravitational_parameter") = 1.32712440018e20
+			)
+		.def("get_cartesian_state", &ApproximatePlanetPositions::getCartesianState,
+				py::arg("seconds_since_epoch")
+			)
+		.def("get_keplerian_state", &ApproximatePlanetPositions::getKeplerianStateFromEphemeris,
+				py::arg("seconds_since_epoch")
+			);
 
         m.def("transform_state_to_global_frame",
               &tudat::ephemerides::transformStateToGlobalFrame<double, double>,

--- a/tudatpy/kernel/expose_ephemerides.h
+++ b/tudatpy/kernel/expose_ephemerides.h
@@ -8,6 +8,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/eigen.h>
 #include "tudat/astro/ephemerides/rotationalEphemeris.h"
+#include "tudat/astro/ephemerides/approximatePlanetPositions.h"
 
 namespace py = pybind11;
 

--- a/tudatpy/kernel/expose_low_thrust.cpp
+++ b/tudatpy/kernel/expose_low_thrust.cpp
@@ -21,7 +21,10 @@ namespace tudatpy {
 		m.def("create_low_thrust_leg", &tltt::createLowThrustLeg, py::arg("low_thrust_leg_settings"),
 			  py::arg("state_at_departure"), py::arg("state_at_arrival"), py::arg("time_of_flight"));
 
-		py::class_<tltt::SphericalShapingLegSettings, std::shared_ptr<tltt::SphericalShapingLegSettings>>(m, "SphericalShapingLegSettings")
+		py::class_<tltt::LowThrustLegSettings, std::shared_ptr<tltt::LowThrustLegSettings>>(m, "LowThrustLegSettings");
+
+		py::class_<tltt::SphericalShapingLegSettings, std::shared_ptr<tltt::SphericalShapingLegSettings>, tltt::LowThrustLegSettings>
+		        (m, "SphericalShapingLegSettings")
 		.def(py::init<
 		        const int,
 		        const double,

--- a/tudatpy/kernel/expose_low_thrust.cpp
+++ b/tudatpy/kernel/expose_low_thrust.cpp
@@ -1,0 +1,67 @@
+//
+// Created by elmar on 13-07-20.
+//
+
+#include "expose_low_thrust.h"
+
+namespace py = pybind11;
+namespace tltt = tudat::low_thrust_trajectories;
+namespace sbm = tudat::shape_based_methods;
+
+namespace tudatpy {
+
+	void expose_low_thrust( py::module &m )
+	{
+
+		py::enum_<tltt::LowThrustLegTypes>(m, "LowThrustLegTypes")
+				.value("hodographic_shaping_leg", tltt::hodographic_shaping_leg)
+				.value("spherical_shaping_leg", tltt::spherical_shaping_leg)
+				.export_values();
+
+		m.def("create_low_thrust_leg", &tltt::createLowThrustLeg, py::arg("low_thrust_leg_settings"),
+			  py::arg("state_at_departure"), py::arg("state_at_arrival"), py::arg("time_of_flight"));
+
+		py::class_<tltt::SphericalShapingLegSettings, std::shared_ptr<tltt::SphericalShapingLegSettings>>(m, "SphericalShapingLegSettings")
+		.def(py::init<
+		        const int,
+		        const double,
+		        const double,
+				const std::shared_ptr< tudat::root_finders::RootFinderSettings >,
+				const std::pair< double, double >
+		        >(),
+		        py::arg("number_of_revolutions"),
+		        py::arg("central_body_gravitational_parameter"),
+		        py::arg("initial_value_free_coefficient"),
+		        py::arg("root_finder_settings"),
+		        py::arg("bounds_free_coefficient") = std::make_pair( TUDAT_NAN, TUDAT_NAN )
+			);
+
+		py::class_<sbm::SphericalShaping, std::shared_ptr<sbm::SphericalShaping>>(m, "SphericalShaping")
+		.def(py::init<
+		        const Eigen::Vector6d&,
+		        const Eigen::Vector6d&,
+		        const double,
+		        const double,
+		        const int,
+		        const double,
+		        const std::shared_ptr<tudat::root_finders::RootFinderSettings>,
+				const double,
+				const double,
+				const double
+				>(),
+				py::arg("initial_state"),
+				py::arg("final_state"),
+				py::arg("required_time_of_flight"),
+				py::arg("central_body_gravitational_parameter"),
+				py::arg("number_of_revolutions"),
+				py::arg("initial_value_free_coefficient"),
+				py::arg("root_finder_settings"),
+				py::arg("lower_bound_free_coefficient") = TUDAT_NAN,
+			 	py::arg("upper_bound_free_coefficient") = TUDAT_NAN,
+			 	py::arg("initial_body_mass") = TUDAT_NAN
+			)
+		.def("compute_delta_V", &sbm::SphericalShaping::computeDeltaV)
+		.def("compute_time_of_flight", &sbm::SphericalShaping::computeTimeOfFlight);
+
+	}
+}

--- a/tudatpy/kernel/expose_low_thrust.h
+++ b/tudatpy/kernel/expose_low_thrust.h
@@ -6,6 +6,10 @@
 #define TUDATPY_EXPOSE_LOW_THRUST_H
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/eigen.h>
+#include <pybind11/numpy.h>
+
 #include <tudat/astro/low_thrust/lowThrustLeg.h>
 #include <tudat/astro/low_thrust/lowThrustLegSettings.h>
 #include <tudat/astro/low_thrust/shape_based/sphericalShaping.h>

--- a/tudatpy/kernel/expose_low_thrust.h
+++ b/tudatpy/kernel/expose_low_thrust.h
@@ -1,0 +1,22 @@
+//
+// Created by elmar on 13-07-20.
+//
+
+#ifndef TUDATPY_EXPOSE_LOW_THRUST_H
+#define TUDATPY_EXPOSE_LOW_THRUST_H
+
+#include <pybind11/pybind11.h>
+#include <tudat/astro/low_thrust/lowThrustLeg.h>
+#include <tudat/astro/low_thrust/lowThrustLegSettings.h>
+#include <tudat/astro/low_thrust/shape_based/sphericalShaping.h>
+#include <tudat/math/root_finders/createRootFinder.h>
+
+namespace py = pybind11;
+
+namespace tudatpy {
+
+	void expose_low_thrust(py::module &m);
+
+};
+
+#endif //TUDATPY_EXPOSE_LOW_THRUST_H

--- a/tudatpy/kernel/expose_root_finders.cpp
+++ b/tudatpy/kernel/expose_root_finders.cpp
@@ -10,8 +10,23 @@ using namespace tudat::root_finders;
 namespace tudatpy {
     void expose_root_finders(py::module &m) {
 
-        py::class_<RootFinderSettings,
-                std::shared_ptr<RootFinderSettings>> RootFinderSettings_(m, "RootFinderSettings");
+    	py::enum_<RootFinderType>(m, "RootFinderType")
+    	        .value("bisection_root_finder", bisection_root_finder)
+				.value("halley_root_finder", halley_root_finder)
+				.value("newton_raphson_root_finder", newton_raphson_root_finder)
+				.value("secant_root_finder", secant_root_finder)
+				.export_values();
+
+        py::class_<RootFinderSettings, std::shared_ptr<RootFinderSettings>>(m, "RootFinderSettings")
+        	.def(py::init<
+        	        const RootFinderType,
+        	        const double,
+        	        const unsigned int
+        	        >(),
+        	        py::arg("root_finder_type"),
+        	        py::arg("termination_tolerance"),
+        	        py::arg("maximum_number_of_iterations")
+				);
 
     }
 }

--- a/tudatpy/kernel/expose_spice_interface.cpp
+++ b/tudatpy/kernel/expose_spice_interface.cpp
@@ -6,7 +6,6 @@
 #include "docstrings.h"
 
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 
 namespace py = pybind11;
 namespace tsi = tudat::spice_interface;
@@ -32,6 +31,17 @@ namespace tudatpy {
               &tudat::spice_interface::getAverageRadius,
               "<no_doc>");
 
+        m.def("get_body_gravitational_parameter",
+			  &tudat::spice_interface::getBodyGravitationalParameter,
+			  "<no_doc>");
+
+        m.def("get_body_cartesian_state_at_epoch",
+			  &tudat::spice_interface::getBodyCartesianStateAtEpoch,
+			  py::arg("target_body_name"),
+			  py::arg("observer_body_name"),
+			  py::arg("reference_frame_name"),
+			  py::arg("aberration_corrections"),
+			  py::arg("ephemeris_time"));
 
     };
 }

--- a/tudatpy/kernel/kernel.cpp
+++ b/tudatpy/kernel/kernel.cpp
@@ -5,6 +5,7 @@
 
 #include "expose_aerodynamics.h"
 #include "expose_basic_astrodynamics.h"
+#include "expose_low_thrust.h"
 #include "expose_constants.h"
 #include "expose_ephemerides.h"
 #include "expose_gravitation.h"
@@ -68,6 +69,10 @@ PYBIND11_MODULE(kernel, m) {
   // basic_astrodynamics module
   auto basic_astrodynamics = m.def_submodule("basic_astrodynamics");
   tudatpy::expose_basic_astrodynamics(basic_astrodynamics);
+
+  // low_thrust module
+  auto low_thrust = m.def_submodule("low_thrust");
+  tudatpy::expose_low_thrust(low_thrust);
 
   // gravitation module
   auto gravitation = m.def_submodule("gravitation");


### PR DESCRIPTION
This feature branch implements the exposure of the spherical shaping class along with some helper classes/functions like RootFinderSettings, createLowThrustLeg(), getBodyGravitationalParameter() and some enums that are used in these functions.

The main issue with this version is that the code currently produces Eigen alignment issues when a simple Python application using spherical shaping is run. The testing platform was Ubuntu 20.04 x64 with Python 3.8 in a separate (non-system) environment.