### PR TITLE
New split_history and vector2matrix utils

### DIFF
--- a/tudatpy/kernel/expose_numerical_simulation.cpp
+++ b/tudatpy/kernel/expose_numerical_simulation.cpp
@@ -55,6 +55,10 @@ void expose_numerical_simulation(py::module &m) {
         &tp::getIntegratedTypeAndBodyList<double>,
         py::arg("propagator_settings") );
 
+  m.def("get_single_integration_size",
+        &tp::getSingleIntegrationSize,
+        py::arg("state_type") );
+
   py::class_<
           tp::SingleArcDynamicsSimulator<double, double>,
           std::shared_ptr<tp::SingleArcDynamicsSimulator<double, double>>>(m,

--- a/tudatpy/kernel/expose_numerical_simulation.cpp
+++ b/tudatpy/kernel/expose_numerical_simulation.cpp
@@ -51,6 +51,9 @@ void expose_numerical_simulation(py::module &m) {
   auto estimation_setup_submodule = m.def_submodule("estimation_setup");
   estimation_setup::expose_estimation_setup(estimation_setup_submodule);
 
+  m.def("get_integrated_type_and_body_list",
+        &tp::getIntegratedTypeAndBodyList<double>,
+        py::arg("propagator_settings") );
 
   py::class_<
           tp::SingleArcDynamicsSimulator<double, double>,

--- a/tudatpy/util/__init__.py
+++ b/tudatpy/util/__init__.py
@@ -1,3 +1,3 @@
 from ._support import *
 
-__all__ = ["result2array", "compare_results", "redirect_std", "pareto_optimums"]
+__all__ = ["result2array", "compare_results", "redirect_std", "pareto_optimums", "split_history", "vector2matrix"]

--- a/tudatpy/util/_support.py
+++ b/tudatpy/util/_support.py
@@ -259,10 +259,7 @@ def split_history(state_history: Dict[float, np.array], propagator_settings: pro
     -----------
     state_history_book : Dict[str,[Dict[float, numpy.ndarray]]]
         Dictionnary containing the name of the propagated body as key, and the state history as value.
-    """
-    # Define the state size of the implemented state types.
-    state_type_infos = {1: 6, 2: 7, 3: 1} # Translational (6), Rotational (7), Mass (1)
-    
+    """    
     # Get the propagated state types and names of the propagated bodies from the integrator settings.
     integrated_type_and_body_list = numerical_simulation.get_integrated_type_and_body_list(propagator_settings)
 
@@ -274,14 +271,12 @@ def split_history(state_history: Dict[float, np.array], propagator_settings: pro
     n_bodies, body_names = None, None
     propagated_states_sizes = []
     for state_type, body_list in integrated_type_and_body_list.items():
-        try:
-            if n_bodies is None:
-                n_bodies = len(body_list)
-                body_names = [body_list[i][0] for i in range(n_bodies)]
-            propagated_states_sizes.append(state_type_infos[state_type])
-        # Raise an error if the state type is not recognised (most likely custom).
-        except KeyError:
-            raise NotImplementedError("The split history algorithm does not know the state size of the following type:", state_type)
+        if n_bodies is None:
+            n_bodies = len(body_list)
+            body_names = [body_list[i][0] for i in range(n_bodies)]
+        # Get the state size for the current state type.
+        state_size = numerical_simulation.get_single_integration_size(state_type)
+        propagated_states_sizes.append(state_size)
 
     # Create the empty state history book.
     state_history_book = {body_name: {epoch: [] for epoch in epochs} for body_name in body_names}

--- a/tudatpy/util/_support.py
+++ b/tudatpy/util/_support.py
@@ -1,5 +1,7 @@
 import numpy as np
 from ..kernel.math import interpolators
+from ..kernel import numerical_simulation
+from ..kernel.numerical_simulation import propagation_setup
 import os
 from typing import List, Dict, Union
 
@@ -236,3 +238,84 @@ def pareto_optimums(points: list, operator:Union[None,List[Union[min,max]]]=None
         if pareto_optimal[i]:
             pareto_optimal[pareto_optimal] = np.any(points[pareto_optimal]<=c, axis=1)
     return pareto_optimal
+
+def split_history(state_history: Dict[float, np.array], propagator_settings: propagation_setup.propagator.PropagatorSettings):
+    """Split the state history into a distinct state histories for each body.
+
+    Creates a dictionnary of state histories based on the unified `state_history`
+    from the propagation of multiple bodies. Each dictionnary key contains the name of a propagated body,
+    and the value is the state history for the given propagated body.
+
+    Parameters
+    -----------
+    state_history : Dict[float, numpy.ndarray]
+        Dictionary mapping the simulation time steps to the propagated
+        state time series.
+
+    propagator_settings : tudatpy.kernel.numerical_simulation.propagation_setup.propagator.PropagatorSettings
+        Settings used for the propagation.
+
+    Returns
+    -----------
+    state_history_book : Dict[str,[Dict[float, numpy.ndarray]]]
+        Dictionnary containing the name of the propagated body as key, and the state history as value.
+    """
+    # Define the state size of the implemented state types.
+    state_type_infos = {1: 6, 2: 7, 3: 1} # Translational (6), Rotational (7), Mass (1)
+    
+    # Get the propagated state types and names of the propagated bodies from the integrator settings.
+    integrated_type_and_body_list = numerical_simulation.get_integrated_type_and_body_list(propagator_settings)
+
+    # Extract the states and epochs from the state history.
+    states_list = np.asarray(list(state_history.values()))
+    epochs = list(state_history.keys())
+    
+    # Loop trough the state types and bodies name to save them beforehand.
+    n_bodies, body_names = None, None
+    propagated_states_sizes = []
+    for state_type, body_list in integrated_type_and_body_list.items():
+        try:
+            if n_bodies is None:
+                n_bodies = len(body_list)
+                body_names = [body_list[i][0] for i in range(n_bodies)]
+            propagated_states_sizes.append(state_type_infos[state_type])
+        # Raise an error if the state type is not recognised (most likely custom).
+        except KeyError:
+            raise NotImplementedError("The split history algorithm does not know the state size of the following type:", state_type)
+
+    # Create the empty state history book.
+    state_history_book = {body_name: {epoch: [] for epoch in epochs} for body_name in body_names}
+
+    # Loop through the epochs and states to fill the state history book.
+    for epoch, state in zip(epochs, states_list):
+        state_idx = 0
+        # Loop trough the state types by their propagated vector size.
+        for propagated_state_size in propagated_states_sizes:
+            # Loop trough the propagated bodies names.
+            for body_name in body_names:
+                # Add the section of the state related to the current state type and body to the state history book.
+                state_history_book[body_name][epoch].extend(state[state_idx:state_idx+propagated_state_size])
+                # Update the state index cursor.
+                state_idx += propagated_state_size
+
+    # Return the state history book.
+    return state_history_book
+
+def vector2matrix(flat_matrix: np.ndarray) :
+    """Convert a flattened matrix into a matrix.
+
+    Following Tudat standards, a rotation matrix is returned as a nine-entry vector in the dependent variable output,
+    where entry (i,j) of the matrix is stored in entry (3i+j) of the vector with i,j = 0,1,2.
+    This is detailled in the :func:`~tudatpy.numerical_simulation.propagation_setup.dependent_variable.inertial_to_body_fixed_rotation_frame` docs.
+
+    Parameters
+    -----------
+    flat_matrix : numpy.ndarray
+        Vector containing a flattened rotation matrix.
+
+    Returns
+    -----------
+    rotation_matrix: numpy.ndarray
+        Rotation matrix (3x3 orthogonal matrix).
+    """
+    return flat_matrix.reshape(3,3)


### PR DESCRIPTION
This branch implements the two utilities that @Marchesini010126 suggested in [this issue](https://github.com/tudat-team/tudat-space/issues/65).

I exposed `getIntegratedTypeAndBodyList` from `tudat::propagators` as `tudatpy.kernel.numerical_simulation.get_integrated_type_and_body_list` to make the `split_history` function work (as we need to know what bodies are propagated, and most importantly what type of states). I didn't make docstrings for it, as I don't think it should be too visible to tudatpy users.

The docstrings of the two new functions can be found directly in the function definitions. I will push directly to `tudat-multidoc` to make them active in the API docs when this pull request is approved.