### PR TITLE
exposed CustomStatePropagator settings

### DIFF
--- a/tudatpy/kernel/expose_numerical_simulation/expose_propagation_setup/expose_propagator_setup.cpp
+++ b/tudatpy/kernel/expose_numerical_simulation/expose_propagation_setup/expose_propagator_setup.cpp
@@ -283,6 +283,12 @@ void expose_propagator_setup(py::module &m) {
             tp::SingleArcPropagatorSettings<double>>(m, "MassPropagatorSettings",
                                                      get_docstring("MassPropagatorSettings").c_str());
 
+    py::class_<
+            tp::CustomStatePropagatorSettings<double, double>,
+            std::shared_ptr<tp::CustomStatePropagatorSettings<double, double>>,
+            tp::SingleArcPropagatorSettings<double>>(m, "CustomStatePropagatorSettings",
+                                                     get_docstring("CustomStatePropagatorSettings").c_str());
+
 
 
     m.def("translational",


### PR DESCRIPTION
Exposed the `CustomStatePropagatorSettings` class in the same way the other propagator settings are exposed.