### PR TITLE
Improved dependent variable access

### DIFF
--- a/tudatpy/kernel/expose_numerical_simulation/expose_propagation.cpp
+++ b/tudatpy/kernel/expose_numerical_simulation/expose_propagation.cpp
@@ -267,6 +267,12 @@ void expose_propagation(py::module &m)
             .def_property_readonly("dependent_variable_ids",
                                    &tp::SingleArcSimulationResults<double, TIME_TYPE>::getDependentVariableId,
                                    get_docstring("SingleArcSimulationResults.dependent_variable_ids").c_str() )
+            .def_property_readonly("ordered_dependent_variable_settings",
+                                   &tp::SingleArcSimulationResults<double, TIME_TYPE>::getOrderedDependentVariableSettings,
+                                   get_docstring("SingleArcSimulationResults.ordered_dependent_variable_settings").c_str() )
+            .def_property_readonly("unordered_dependent_variable_settings",
+                                   &tp::SingleArcSimulationResults<double, TIME_TYPE>::getOriginalDependentVariableSettings,
+                                   get_docstring("SingleArcSimulationResults.unordered_dependent_variable_settings").c_str() )
             .def_property_readonly("processed_state_ids",
                                    &tp::SingleArcSimulationResults<double, TIME_TYPE>::getProcessedStateIds,
                                    get_docstring("SingleArcSimulationResults.state_ids").c_str() )

--- a/tudatpy/kernel/expose_numerical_simulation/expose_propagation_setup/expose_dependent_variable_setup.cpp
+++ b/tudatpy/kernel/expose_numerical_simulation/expose_propagation_setup/expose_dependent_variable_setup.cpp
@@ -278,7 +278,15 @@ namespace dependent_variable {
               py::arg("dependent_variable_settings"),
               get_docstring("get_dependent_variable_id").c_str());
 
+        m.def("get_dependent_variable_size",
+              &tp::getDependentVariableSaveSize,
+              py::arg("dependent_variable_settings"),
+              get_docstring("get_dependent_variable_size").c_str());
 
+        m.def("get_dependent_variable_shape",
+              &tp::getDependentVariableShape,
+              py::arg("dependent_variable_settings"),
+              get_docstring("get_dependent_variable_shape").c_str());
         //////////////////////////////////////////////////////////////////////////////////////
         /// FREE FUNCTIONS ///////////////////////////////////////////////////////////////////
         //////////////////////////////////////////////////////////////////////////////////////

--- a/tudatpy/kernel/expose_numerical_simulation/expose_propagation_setup/expose_propagator_setup.cpp
+++ b/tudatpy/kernel/expose_numerical_simulation/expose_propagation_setup/expose_propagator_setup.cpp
@@ -110,8 +110,8 @@ void expose_propagator_setup(py::module &m) {
                           &tp::PropagatorProcessingSettings::setClearNumericalSolutions,
                           get_docstring("PropagatorProcessingSettings.clear_numerical_solution").c_str() )
             .def_property("create_dependent_variable_interface",
-                          &tp::PropagatorProcessingSettings::getCreateDependentVariablesInterface,
-                          &tp::PropagatorProcessingSettings::setCreateDependentVariablesInterface,
+                          &tp::PropagatorProcessingSettings::getUpdateDependentVariableInterpolator,
+                          &tp::PropagatorProcessingSettings::setUpdateDependentVariableInterpolator,
                           get_docstring("PropagatorProcessingSettings.create_dependent_variable_interface").c_str() );
 
     py::class_<tp::SingleArcPropagatorProcessingSettings,


### PR DESCRIPTION
Functionality to address: https://github.com/tudat-team/tudat/issues/179

Main new functionality:
* The original list of dependent variable settings can now be retrieved from the SingleArcSimulationResults
* A dictionary with the (start index, size) as value and the associated dependent variable save settings as value can now be accessed from the SingleArcSimulationResults
* Free functions to get the size (int) and shape (int: rows, int: cols) are now exposed

The associated tudat pull request is here:

https://github.com/tudat-team/tudat/pull/181