### PR TITLE
Porkchop plots and hybrid C++/Python kernel modules v2

### DIFF
--- a/tests/test_hybrid_module_exposure.py
+++ b/tests/test_hybrid_module_exposure.py
@@ -1,0 +1,54 @@
+# General imports
+import inspect
+import unittest
+from importlib import import_module
+
+
+def _recursively_find_children(module):
+    """
+    Recursively find all children of a module.
+    """
+
+    children = inspect.getmembers(module, inspect.ismodule)
+
+    if children:
+        for (name, child) in children:
+            children += _recursively_find_children(child)
+        return children
+    else:
+        return []
+
+
+def test_tudatpy_kernel_module_exposure():
+
+    import tudatpy.kernel as kernel
+
+    exposed_kernel_modules = [
+        # 'utils',
+        'astro',
+        'trajectory_design',
+        'constants',
+        'interface',
+        # 'io',
+        'math',
+        'numerical_simulation'
+    ]
+
+    module_methods = lambda module: inspect.getmembers(module, inspect.isroutine)
+
+    module_variables = lambda module: [
+        (name, value) for name, value in inspect.getmembers(module)
+        if (not inspect.isroutine(value) and not inspect.ismodule(value) and not name.startswith('__'))
+    ]
+
+    for (submodule_name, submodule) in _recursively_find_children(kernel):
+
+        if submodule.__name__.split('.')[2] in exposed_kernel_modules:
+            kernel_module  = import_module(submodule.__name__)
+            exposed_module = import_module(submodule.__name__.replace('kernel.', ''))
+
+            # Assert both modules contain the same methods
+            assert all([method in module_methods(kernel_module) for method in module_methods(exposed_module)])
+
+            # Assert both modules contain the same variables
+            assert all([variable in module_variables(kernel_module) for variable in module_variables(exposed_module)])

--- a/tudatpy/__init__.py
+++ b/tudatpy/__init__.py
@@ -1,12 +1,12 @@
 from ._version import *
-from .kernel import constants
-from .kernel import astro
-from .kernel import interface
-from .kernel import math
-from .kernel import utils
-from .kernel import numerical_simulation
-from .kernel import trajectory_design
-#from .kernel import io
+from tudatpy.kernel import constants
+from tudatpy.kernel import astro
+from tudatpy.kernel import interface
+from tudatpy.kernel import math
+from tudatpy.kernel import utils
+from tudatpy.kernel import numerical_simulation
+from tudatpy.kernel import trajectory_design
+#from tudatpy.kernel import io
 
 __all__ = [
     '__version__',

--- a/tudatpy/kernel_hybrid/trajectory_design/porkchop/porkchop.py
+++ b/tudatpy/kernel_hybrid/trajectory_design/porkchop/porkchop.py
@@ -24,7 +24,6 @@ from tudatpy.trajectory_design.porkchop._lambert import calculate_lambert_arc_im
 
 def determine_shape_of_delta_v(
         bodies: environment.SystemOfBodies,
-        global_frame_orientation: str,
         departure_body: str,
         target_body: str,
         departure_epoch: float,
@@ -41,8 +40,6 @@ def determine_shape_of_delta_v(
     ----------
     bodies: environment.SystemOfBodies
         Body objects defining the physical simulation environment
-    global_frame_orientation: str
-        Orientation of the global reference frame at J2000
     departure_body: str
         The name of the body from which the transfer is to be computed
     target_body: str
@@ -62,7 +59,7 @@ def determine_shape_of_delta_v(
     """
 
     ΔV_sample = function_to_calculate_delta_v(
-        bodies, global_frame_orientation,
+        bodies,
         departure_body,
         target_body,
         departure_epoch,
@@ -94,7 +91,6 @@ def determine_shape_of_delta_v(
 
 def calculate_delta_v_time_map(
         bodies: environment.SystemOfBodies,
-        global_frame_orientation: str,
         departure_body: str,
         target_body: str,
         earliest_departure_time: time_conversion.DateTime,
@@ -111,8 +107,6 @@ def calculate_delta_v_time_map(
     ----------
     bodies: environment.SystemOfBodies
         Body objects defining the physical simulation environment
-    global_frame_orientation: str
-        Orientation of the global reference frame at J2000
     departure_body: str
         The name of the body from which the transfer is to be computed
     target_body: str
@@ -140,12 +134,6 @@ def calculate_delta_v_time_map(
         Array containing the ΔV of all coordinates of the grid of departure/arrival epochs
     """
 
-    # Input validation
-    supported_global_frame_orientations = ['J2000', 'ECLIPJ2000']
-    assert global_frame_orientation in supported_global_frame_orientations, \
-        f'\n    The `global_frame_orientation` provided ("{global_frame_orientation}") is not supported by Tudat.\n' \
-        f'\n    Please provide a `global_frame_orientation` in {supported_global_frame_orientations}'
-
     # Departure and arrival epoch discretizations
     n_dep = int(
         (latest_departure_time.epoch() - earliest_departure_time.epoch()) / (time_resolution * constants.JULIAN_DAY)
@@ -166,7 +154,7 @@ def calculate_delta_v_time_map(
 
     # Determine the shape of the ΔV returned by the user-provided `function_to_calculate_delta_v`
     ΔV_shape = determine_shape_of_delta_v(
-        bodies, global_frame_orientation,
+        bodies,
         departure_body,
         target_body,
         departure_epochs[0],
@@ -182,7 +170,7 @@ def calculate_delta_v_time_map(
             # Calculate ΔV, only if the arrival epoch is greater than the departure epoch
             if arrival_epochs[i_arr] > departure_epochs[i_dep]:
                 ΔV[i_dep, i_arr, :] = function_to_calculate_delta_v(
-                    bodies, global_frame_orientation,
+                    bodies,
                     departure_body,
                     target_body,
                     departure_epochs[i_dep],
@@ -195,7 +183,6 @@ def calculate_delta_v_time_map(
 def porkchop(
         # ΔV calculation arguments
         bodies: environment.SystemOfBodies,
-        global_frame_orientation: str,
         departure_body: str,
         target_body: str,
         earliest_departure_time: time_conversion.DateTime,
@@ -224,8 +211,6 @@ def porkchop(
     ----------
     bodies: environment.SystemOfBodies
         Body objects defining the physical simulation environment
-    global_frame_orientation: str
-        Orientation of the global reference frame at J2000
     departure_body: str
         The name of the body from which the transfer is to be computed
     target_body: str
@@ -276,7 +261,6 @@ def porkchop(
     # Calculate ΔV map
     [departure_epochs, arrival_epochs, ΔV] = calculate_delta_v_time_map(
         bodies                        = bodies,
-        global_frame_orientation      = global_frame_orientation,
         departure_body                = departure_body,
         target_body                   = target_body,
         earliest_departure_time       = earliest_departure_time,

--- a/tudatpy/setup_hybrid_modules.py
+++ b/tudatpy/setup_hybrid_modules.py
@@ -119,13 +119,16 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Expose hybrid kernel modules.')
     parser.add_argument('modules', metavar='module', type=str, nargs='+',
                         help='a list of hybrid kernel modules to expose')
+    parser.add_argument('-v', '--verbose', action=argparse.BooleanOptionalAction,
+                        help='whether to announce the module and submodule being exposed')
     args = parser.parse_args()
 
     for module_name in args.modules:
 
-        message = f"EXPOSING MODULE: {module_name}"
-        message_width = 100
-        print(f"\n{' ' + message + ' ':=^100}")
+        if args.verbose:
+            message = f"EXPOSING MODULE: {module_name}"
+            message_width = 100
+            print(f"\n{' ' + message + ' ':=^100}")
 
         # Identify and expose module
         module = getattr(kernel, module_name)
@@ -135,4 +138,5 @@ if __name__ == '__main__':
             # Expose module
             expose_hybrid_module(submodule)
             # Report completion
-            print(f"{'-':>40} {submodule_name}")
+            if args.verbose:
+                print(f"{'-':>40} {submodule_name}")


### PR DESCRIPTION
This pull request

- Implements the feedback provided in https://github.com/tudat-team/tudatpy/pull/115 
- Provides a test to verify the exposure of C++ modules has been successful
- Modifies the top-level `__init__.y` kernel imports to attempt to fix the observed build issues for the MacOS and Windows builds. As the root of the issues seemed to be `.kernel.<modules>` imports[1], and the module exposure process does not at any point create such imports, it could be that the culprit is this file

[1]:
![Screenshot_20231014-151831](https://github.com/tudat-team/tudatpy/assets/47611105/8d39f43f-8728-4c15-965e-4fbb163ba733)

