### PR TITLE
Fix bump version workflow

### DIFF
--- a/.github/workflows/bump_dev_version_nightly.yml
+++ b/.github/workflows/bump_dev_version_nightly.yml
@@ -18,7 +18,7 @@ name: Bump dev version in tudatpy and tudatpy-feedstock if new commit in last 24
 
 on:
     schedule:
-        - cron: '0 5 * * *'  # This triggers the workflow daily at 5:00 AM UTC. 
+        - cron: '0 5 * * *'  # This triggers the workflow daily at 5:00 AM UTC.
     workflow_dispatch:       # This facilitates manual triggering of the workflow from the Actions tab of the repository in case the scheduled run fails.
 
 
@@ -63,17 +63,16 @@ jobs:
         with:
           ref: develop
 
-      - name: Install bump2version
-        run: pip install bump2version
-
-      - name: Bump version
-        id: bump_version
+      - name: Install bump2version and run bumpversion
         run: |
-          git config --global user.email "actions@github.com"
-          git config --global user.name "GitHub Actions"
-          bump2version dev --config-file .bumpversion.cfg --verbose
+            python3 -m venv venv
+            source venv/bin/activate
+            pip install bump2version
+            git config --global user.email "actions@github.com"
+            git config --global user.name "GitHub Actions"
+            bump2version dev --config-file .bumpversion.cfg --verbose
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push tag to tudatpy repository
         run: git push origin --follow-tags
@@ -94,14 +93,16 @@ jobs:
             token: ${{ secrets.BUMP_VERSION_NIGHTLY }}
             ref: develop
 
-        - name: Install bump2version
-          run: pip install bump2version
-
-        - name: Bump version on feedstock
+        - name: Install bump2version and run bumpversion
           run: |
-              git config --global user.email "actions@github.com"
-              git config --global user.name "GitHub Actions"
-              bump2version dev --config-file .bumpversion.cfg --verbose
+               python3 -m venv venv
+               source venv/bin/activate
+               pip install bump2version
+               git config --global user.email "actions@github.com"
+               git config --global user.name "GitHub Actions"
+               bump2version dev --config-file .bumpversion.cfg --verbose
+          env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
         - name: Reset build number in meta.yml to 0
           shell: bash

--- a/.github/workflows/bump_dev_version_nightly.yml
+++ b/.github/workflows/bump_dev_version_nightly.yml
@@ -71,8 +71,6 @@ jobs:
             git config --global user.email "actions@github.com"
             git config --global user.name "GitHub Actions"
             bump2version dev --config-file .bumpversion.cfg --verbose
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push tag to tudatpy repository
         run: git push origin --follow-tags
@@ -101,8 +99,6 @@ jobs:
                git config --global user.email "actions@github.com"
                git config --global user.name "GitHub Actions"
                bump2version dev --config-file .bumpversion.cfg --verbose
-          env:
-              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
         - name: Reset build number in meta.yml to 0
           shell: bash


### PR DESCRIPTION
Closes #181 

### Summary of changes

- Fix for the bug described in #181 : Install python dependency (nump2version) inside a python virtual environment instead of system-wide installation
- GITHUB_TOKEN is not needed for running the bumpversion command. This was mistakenly added previously, and now removed.



### Testing
Changes are tested here:  https://github.com/niketagrawal/tudat/actions/workflows/bump_dev_version_tudat_and_tudat_feedstock.yml 