### PR TITLE
Feature/github_action

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,57 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+AllowShortFunctionsOnASingleLine: Empty
+
+NamespaceIndentation: None
+
+BraceWrapping:
+  AfterNamespace: true
+  AfterFunction: true
+  AfterControlStatement: true
+  AfterClass: true
+  SplitEmptyFunction: false
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: false
+
+AlignAfterOpenBracket: Align
+AlignOperands: false
+AccessModifierOffset: -4
+
+BreakBeforeBraces: Custom
+
+BinPackParameters: false
+BinPackArguments: false
+Cpp11BracedListStyle: false
+
+PointerAlignment: Left
+
+SpacesInContainerLiterals: true
+SpaceBeforeParens: Never
+SpaceBeforeRangeBasedForLoopColon: false
+
+AllowAllParametersOfDeclarationOnNextLine: false
+
+CommentPragmas: '^!|^@'
+SpaceAfterTemplateKeyword: false
+SpacesInTemplateDeclarations: true
+
+ContinuationIndentWidth: 8
+ConstructorInitializerIndentWidth: 4
+BreakConstructorInitializers: AfterColon
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+
+SpaceBeforeCtorInitializerColon: false
+SpacesInAngles: true
+SpacesInParentheses: true
+SpacesInSquareBrackets: true
+SpaceInEmptyParentheses: true
+SpaceInEmptySquareBrackets: true
+SpaceInEmptyBlock: true
+
+ColumnLimit: 140
+---

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,52 @@
+name: Clang-Format Check and Fix
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  format-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2  # Fetch enough history for PR diffing
+
+      - name: Install Clang-Format
+        run: sudo apt-get install -y clang-format
+
+      - name: Display Clang-Format Version
+        run: clang-format --version
+
+      - name: Identify Changed Files in PR
+        run: |
+          echo "Changed files in PR:"
+          git diff --name-only --diff-filter=ACM origin/${{ github.base_ref }}...${{ github.head_ref }} | grep -E '\.(cpp|hpp|c|h)$' || echo "No matching files changed."
+
+      - name: Run Clang-Format on Changed Files
+        run: |
+          git diff --name-only --diff-filter=ACM origin/${{ github.base_ref }}...${{ github.head_ref }} | grep -E '\.(cpp|hpp|c|h)$' | xargs -r clang-format -style=file -i
+
+      - name: Check for Formatting Differences
+        id: check_diff
+        run: git diff --exit-code || echo "Formatting issues detected."
+
+      - name: Auto-commit Formatting Changes
+        if: failure()
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Apply clang-format"
+          git push origin HEAD:${{ github.head_ref }}
+
+      - name: Report Success or Failure
+        run: |
+          if [ "${{ steps.check_diff.outcome }}" == "failure" ]; then
+            echo "Formatting issues were detected and fixed."
+          else
+            echo "Code is properly formatted."
+          fi


### PR DESCRIPTION
Add a new github action that will format the cpp code when a pull request is merged. 

Note that since the project is split into multiple github repositories, we need to include the `.clang-format` setup file in the root of each github repository.