### PR TITLE
Minor fixes

### DIFF
--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -52,6 +52,8 @@ Enumerations
    AtmosphericCompositionSpecies
 
 
+.. autoclass:: tudatpy.numerical_simulation.environment.AerodynamicsReferenceFrameAngles
+   :members:
 
 .. autoclass:: tudatpy.numerical_simulation.environment.AerodynamicsReferenceFrames
    :members:

--- a/docs/source/time_conversion.rst
+++ b/docs/source/time_conversion.rst
@@ -197,7 +197,8 @@ Classes
    TimeScaleConverter
 
 .. autoclass:: tudatpy.astro.time_conversion.DateTime
-   :members:   
+   :members:
+   :special-members: __init__
 
 .. autoclass:: tudatpy.astro.time_conversion.TimeScaleConverter
    :members:

--- a/tudatpy/kernel/expose_astro/expose_element_conversion.cpp
+++ b/tudatpy/kernel/expose_astro/expose_element_conversion.cpp
@@ -448,36 +448,6 @@ numpy.ndarray
 
     )doc" );
 
-    m.def( "keplerian_to_cartesian",
-           py::overload_cast< const Eigen::Vector6d&, double >( &toec::convertKeplerianToCartesianElements< double > ),
-           py::arg( "keplerian_elements" ),
-           py::arg( "gravitational_parameter" ),
-           R"doc(
-
-Convert Keplerian elements to Cartesian.
-
-.. note:: See module level documentation for the standard ordering
-          convention of Keplerian elements used.
-
-
-Parameters
-----------
-keplerian_elements : numpy.ndarray
-    Keplerian state that is to be converted to Cartesian elements
-gravitational_parameter : float
-    Gravitational parameter of central body used for conversion
-Returns
--------
-numpy.ndarray
-    Cartesian elements, as computed from Keplerian element input.
-
-
-
-
-
-
-    )doc" );
-
     m.def( "mean_to_true_anomaly",
            &toec::convertMeanAnomalyToTrueAnomaly< double >,
            py::arg( "eccentricity" ),

--- a/tudatpy/kernel/expose_astro/expose_time_conversion.cpp
+++ b/tudatpy/kernel/expose_astro/expose_time_conversion.cpp
@@ -1022,9 +1022,9 @@ TimeScaleConverter
         Class to convert between different time scales (TAI, TT, TDB, UTC, UT1), as per algorithms described in (for instance) IERS 2010 Conventions and USNO circular no. 179.
         The algorithms used for the conversion are (where there is any choice in models):
 
-         * Conversion between TDB and TT uses the SOFA function ``iauDtdb`` function (equivalently to :func:`TT_to_TDB` and :func:`TDB_to_TT`)
-         * Conversion between UTC and UT1 applies (semi-)diurnal and daily measured variations depending on settings during object creation (typically as per :func:`~default_time_scale_converter`)
-         * Leap seconds as per the latest SOFA package
+        * Conversion between TDB and TT uses the SOFA function ``iauDtdb`` function (equivalently to :func:`TT_to_TDB` and :func:`TDB_to_TT`)
+        * Conversion between UTC and UT1 applies (semi-)diurnal and daily measured variations depending on settings during object creation (typically as per :func:`~default_time_scale_converter`)
+        * Leap seconds as per the latest SOFA package
 
     )doc" )
             .def( "convert_time",

--- a/tudatpy/kernel/expose_astro/expose_time_conversion.cpp
+++ b/tudatpy/kernel/expose_astro/expose_time_conversion.cpp
@@ -135,6 +135,215 @@ void expose_time_conversion( py::module& m )
     //    m.attr("default_time_converter") =
     //    tudat::earth_orientation::defaultTimeConverter;
 
+    py::enum_< tba::TimeScales >( m,
+                                  "TimeScales",
+                                  R"doc(
+
+Enumeration of available time scales between which the :class:`~TimeScaleConverter` can automaticaly convert.
+
+)doc" )
+            .value( "tai_scale", tba::tai_scale, R"doc(
+)doc" )
+            .value( "tt_scale", tba::tt_scale, R"doc(
+)doc" )
+            .value( "tdb_scale", tba::tdb_scale, R"doc(
+)doc" )
+            .value( "utc_scale", tba::utc_scale, R"doc(
+)doc" )
+            .value( "ut1_scale", tba::ut1_scale, R"doc(
+)doc" )
+            .export_values( );
+
+    py::class_< teo::TerrestrialTimeScaleConverter, std::shared_ptr< teo::TerrestrialTimeScaleConverter > >( m,
+                                                                                                             "TimeScaleConverter",
+                                                                                                             R"doc(
+
+Class to convert between different time scales (TAI, TT, TDB, UTC, UT1)
+
+Class to convert between different time scales (TAI, TT, TDB, UTC, UT1), as per algorithms described in (for instance) IERS 2010 Conventions and USNO circular no. 179.
+The algorithms used for the conversion are (where there is any choice in models):
+
+* Conversion between TDB and TT uses the SOFA function ``iauDtdb`` function (equivalently to :func:`TT_to_TDB` and :func:`TDB_to_TT`)
+* Conversion between UTC and UT1 applies (semi-)diurnal and daily measured variations depending on settings during object creation (typically as per :func:`~default_time_scale_converter`)
+* Leap seconds as per the latest SOFA package
+
+)doc" )
+            .def( "convert_time",
+                  &teo::TerrestrialTimeScaleConverter::getCurrentTime< TIME_TYPE >,
+                  py::arg( "input_scale" ),
+                  py::arg( "output_scale" ),
+                  py::arg( "input_value" ),
+                  py::arg( "earth_fixed_position" ) = Eigen::Vector3d::Zero( ) )
+            .def( "get_time_difference",
+                  &teo::TerrestrialTimeScaleConverter::getCurrentTimeDifference< double >,
+                  py::arg( "input_scale" ),
+                  py::arg( "output_scale" ),
+                  py::arg( "input_value" ),
+                  py::arg( "earth_fixed_position" ) = Eigen::Vector3d::Zero( ) );
+
+    py::class_< tba::DateTime >( m, "DateTime", R"doc(
+
+Class to store a calendar date and time of day, with high resolution.
+
+Class to store a calendar date and time of day, with high resolution compared to Python datetime.datetime. This class
+stores the seconds as a ``long double`` variable in the C++ implementation, corresponding to about
+16 or 19 digits of precision (depending on the compiler used). In either case, this will be sufficient for sub-femtosecond
+resolution. In addition, this class allows easy conversion to typical time representations in astrodynamics (seconds since J2000,
+Julian day, and modified Julian day).
+
+
+
+
+
+)doc" )
+            .def( py::init< const int, const int, const int, const int, const int, const long double >( ),
+                  py::arg( "year" ),
+                  py::arg( "month" ),
+                  py::arg( "day" ),
+                  py::arg( "hour" ) = 12,
+                  py::arg( "minute" ) = 0,
+                  py::arg( "seconds" ) = 0.0L )
+            .def_property( "year", &tba::DateTime::getYear, &tba::DateTime::setYear, R"doc(
+
+Calendar year
+
+
+:type: int
+)doc" )
+            .def_property( "month", &tba::DateTime::getMonth, &tba::DateTime::setMonth, R"doc(
+
+Calendar month (value must be 1-12)
+
+
+:type: int
+)doc" )
+            .def_property( "day", &tba::DateTime::getDay, &tba::DateTime::setDay, R"doc(
+
+Calendar day in current month, value must be larger than 0, and smaller or equal to the number of days in the month
+
+
+:type: int
+)doc" )
+            .def_property( "hour", &tba::DateTime::getHour, &tba::DateTime::setHour, R"doc(
+
+Full hours into the current day (value must be 0-23)
+
+
+:type: int
+)doc" )
+            .def_property( "minute", &tba::DateTime::getMinute, &tba::DateTime::setMinute, R"doc(
+
+Full minutes into the current hour (value must be 0-59)
+
+
+:type: int
+)doc" )
+            .def_property( "seconds", &tba::DateTime::getSeconds, &tba::DateTime::setSeconds, R"doc(
+
+Number of seconds into the current minute. Note that this value is stored as ``long double`` in Tudat, which may be 64-bit or 80-bit (16 or 19 digits) depending on the compiler used.
+
+
+:type: float
+)doc" )
+            .def( "iso_string",
+                  &tba::DateTime::isoString,
+                  py::arg( "add_T" ) = false,
+                  py::arg( "number_of_digits_seconds" ) = 15,
+                  R"doc(
+
+Function to get the ISO-compatible string.
+
+
+Function to get the current date and time as an ISO-compatible string ("YYYY-MM-DDTHH:MM:SS.SSSSS..") where the seconds may be provided with any number of digits. The 'T' entry separating the date from the time may be omitted by setting the ``add_T`` parameter to false
+
+
+Parameters
+----------
+add_T : bool
+Boolean denoting whether to use a 'T' or a blank space to separate the date from the time
+
+number_of_digits_seconds : int, default = 15
+Number of digits to use after the decimal separator (trailing zeros will be truncated)
+
+Returns
+-------
+str
+    ISO-compatible string representing the date and time
+
+
+
+
+
+)doc" )
+            .def( "day_of_year",
+                  &tba::DateTime::dayOfYear,
+                  R"doc(
+
+Function to get the day number in the current year
+
+
+Returns
+-------
+int
+    Day number in the current year
+
+
+
+
+
+)doc" )
+            .def( "epoch",
+                  &tba::DateTime::epoch< TIME_TYPE >,
+                  R"doc(
+
+Function to get the epoch in seconds since J2000 for the current date and time
+
+
+Returns
+-------
+float
+    Current epoch in seconds since J2000
+
+
+
+
+
+)doc" )
+            .def( "julian_day",
+                  &tba::DateTime::julianDay< double >,
+                  R"doc(
+
+Function to get the epoch as Julian day for the current date and time
+
+
+Returns
+-------
+float
+    Current Julian day
+
+
+
+
+
+)doc" )
+            .def( "modified_julian_day",
+                  &tba::DateTime::modifiedJulianDay< double >,
+                  R"doc(
+
+Function to get the epoch as modified Julian day for the current date and time
+
+
+Returns
+-------
+float
+    Current modified Julian day
+
+
+
+
+
+)doc" );
+
     m.def( "datetime_to_tudat",
            &timePointToDateTime,
            py::arg( "datetime" ),
@@ -971,25 +1180,6 @@ float
 
     )doc" );
 
-    py::enum_< tba::TimeScales >( m,
-                                  "TimeScales",
-                                  R"doc(
-
-        Enumeration of available time scales between which the :class:`~TimeScaleConverter` can automaticaly convert.
-
-     )doc" )
-            .value( "tai_scale", tba::tai_scale, R"doc(
-     )doc" )
-            .value( "tt_scale", tba::tt_scale, R"doc(
-     )doc" )
-            .value( "tdb_scale", tba::tdb_scale, R"doc(
-     )doc" )
-            .value( "utc_scale", tba::utc_scale, R"doc(
-     )doc" )
-            .value( "ut1_scale", tba::ut1_scale, R"doc(
-     )doc" )
-            .export_values( );
-
     m.def( "default_time_scale_converter",
            &teo::createDefaultTimeConverterPy,
            R"doc(
@@ -1006,196 +1196,6 @@ Returns
 -------
 TimeScaleConverter
     Object to convert between different terrestrial time scales.
-
-
-
-
-
-    )doc" );
-
-    py::class_< teo::TerrestrialTimeScaleConverter, std::shared_ptr< teo::TerrestrialTimeScaleConverter > >( m,
-                                                                                                             "TimeScaleConverter",
-                                                                                                             R"doc(
-
-        Class to convert between different time scales (TAI, TT, TDB, UTC, UT1)
-
-        Class to convert between different time scales (TAI, TT, TDB, UTC, UT1), as per algorithms described in (for instance) IERS 2010 Conventions and USNO circular no. 179.
-        The algorithms used for the conversion are (where there is any choice in models):
-
-        * Conversion between TDB and TT uses the SOFA function ``iauDtdb`` function (equivalently to :func:`TT_to_TDB` and :func:`TDB_to_TT`)
-        * Conversion between UTC and UT1 applies (semi-)diurnal and daily measured variations depending on settings during object creation (typically as per :func:`~default_time_scale_converter`)
-        * Leap seconds as per the latest SOFA package
-
-    )doc" )
-            .def( "convert_time",
-                  &teo::TerrestrialTimeScaleConverter::getCurrentTime< TIME_TYPE >,
-                  py::arg( "input_scale" ),
-                  py::arg( "output_scale" ),
-                  py::arg( "input_value" ),
-                  py::arg( "earth_fixed_position" ) = Eigen::Vector3d::Zero( ) )
-            .def( "get_time_difference",
-                  &teo::TerrestrialTimeScaleConverter::getCurrentTimeDifference< double >,
-                  py::arg( "input_scale" ),
-                  py::arg( "output_scale" ),
-                  py::arg( "input_value" ),
-                  py::arg( "earth_fixed_position" ) = Eigen::Vector3d::Zero( ) );
-
-    py::class_< tba::DateTime >( m, "DateTime", R"doc(
-
-        Class to store a calendar date and time of day, with high resolution.
-
-        Class to store a calendar date and time of day, with high resolution compared to Python datetime.datetime. This class
-        stores the seconds as a ``long double`` variable in the C++ implementation, corresponding to about
-        16 or 19 digits of precision (depending on the compiler used). In either case, this will be sufficient for sub-femtosecond
-        resolution. In addition, this class allows easy conversion to typical time representations in astrodynamics (seconds since J2000,
-        Julian day, and modified Julian day).
-
-
-
-
-
-     )doc" )
-            .def( py::init< const int, const int, const int, const int, const int, const long double >( ),
-                  py::arg( "year" ),
-                  py::arg( "month" ),
-                  py::arg( "day" ),
-                  py::arg( "hour" ) = 12,
-                  py::arg( "minute" ) = 0,
-                  py::arg( "seconds" ) = 0.0L )
-            .def_property( "year", &tba::DateTime::getYear, &tba::DateTime::setYear, R"doc(
-
-        Calendar year
-
-
-        :type: int
-     )doc" )
-            .def_property( "month", &tba::DateTime::getMonth, &tba::DateTime::setMonth, R"doc(
-
-        Calendar month (value must be 1-12)
-
-
-        :type: int
-     )doc" )
-            .def_property( "day", &tba::DateTime::getDay, &tba::DateTime::setDay, R"doc(
-
-        Calendar day in current month, value must be larger than 0, and smaller or equal to the number of days in the month
-
-
-        :type: int
-     )doc" )
-            .def_property( "hour", &tba::DateTime::getHour, &tba::DateTime::setHour, R"doc(
-
-        Full hours into the current day (value must be 0-23)
-
-
-        :type: int
-     )doc" )
-            .def_property( "minute", &tba::DateTime::getMinute, &tba::DateTime::setMinute, R"doc(
-
-        Full minutes into the current hour (value must be 0-59)
-
-
-        :type: int
-     )doc" )
-            .def_property( "seconds", &tba::DateTime::getSeconds, &tba::DateTime::setSeconds, R"doc(
-
-        Number of seconds into the current minute. Note that this value is stored as ``long double`` in Tudat, which may be 64-bit or 80-bit (16 or 19 digits) depending on the compiler used.
-
-
-        :type: float
-     )doc" )
-            .def( "iso_string",
-                  &tba::DateTime::isoString,
-                  py::arg( "add_T" ) = false,
-                  py::arg( "number_of_digits_seconds" ) = 15,
-                  R"doc(
-
-        Function to get the ISO-compatible string.
-
-
-        Function to get the current date and time as an ISO-compatible string ("YYYY-MM-DDTHH:MM:SS.SSSSS..") where the seconds may be provided with any number of digits. The 'T' entry separating the date from the time may be omitted by setting the ``add_T`` parameter to false
-
-
-        Parameters
-        ----------
-        add_T : bool
-            Boolean denoting whether to use a 'T' or a blank space to separate the date from the time
-
-        number_of_digits_seconds : int, default = 15
-            Number of digits to use after the decimal separator (trailing zeros will be truncated)
-
-        Returns
-        -------
-        str
-            ISO-compatible string representing the date and time
-
-
-
-
-
-    )doc" )
-            .def( "day_of_year",
-                  &tba::DateTime::dayOfYear,
-                  R"doc(
-
-        Function to get the day number in the current year
-
-
-        Returns
-        -------
-        int
-            Day number in the current year
-
-
-
-
-
-    )doc" )
-            .def( "epoch",
-                  &tba::DateTime::epoch< TIME_TYPE >,
-                  R"doc(
-
-        Function to get the epoch in seconds since J2000 for the current date and time
-
-
-        Returns
-        -------
-        float
-            Current epoch in seconds since J2000
-
-
-
-
-
-    )doc" )
-            .def( "julian_day",
-                  &tba::DateTime::julianDay< double >,
-                  R"doc(
-
-        Function to get the epoch as Julian day for the current date and time
-
-
-        Returns
-        -------
-        float
-            Current Julian day
-
-
-
-
-
-    )doc" )
-            .def( "modified_julian_day",
-                  &tba::DateTime::modifiedJulianDay< double >,
-                  R"doc(
-
-        Function to get the epoch as modified Julian day for the current date and time
-
-
-        Returns
-        -------
-        float
-            Current modified Julian day
 
 
 

--- a/tudatpy/kernel/expose_interface/expose_spice.cpp
+++ b/tudatpy/kernel/expose_interface/expose_spice.cpp
@@ -484,6 +484,12 @@ Get gravitational parameter of a body.
 This function retrieves the gravitational parameter of a body.
 Wraps the `bodvrd_c`_ spice function with "GM" as property type.
 
+.. note::
+
+    The gravitational parameter returned is directly retrieved from the loaded SPICE kernels.
+    This value does *not* necessarily correspond to the gravitational parameter used in Tudat's default models, as retrieved from e.g. :func:`~tudatpy.numerical_simulation.environment_setup.get_default_body_settings`.
+    For more information on the default gravity models, see the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/default_env_models.html#gravity-field>`_.
+
 .. _`bodvrd_c`: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/bodvrd_c.html
 
 

--- a/tudatpy/kernel/expose_math/expose_interpolators.cpp
+++ b/tudatpy/kernel/expose_math/expose_interpolators.cpp
@@ -538,8 +538,8 @@ data_to_interpolate : dict[float, float]
     Key-value container with pairs of independent variables (key) and dependent variables (value) from which the interpolation is to be performed
 interpolator_settings : InterpolatorSettings
     Settings that define the type of interpolator that is to be used
-data_first_derivatives : dict[float, float] = dict()
-    Key-value container with pairs of independent variables (key) and first derivative dependent variables w.r.t. independent variable (value) from which the interpolation is to be performed. This input is *only* required if the requested interpolation algorithm requires first derivatives as input (such as the Hermite spline interpolator
+data_first_derivatives : list[float] = []
+    List of first derivative dependent variables w.r.t. independent variable from which the interpolation is to be performed. Must be of the same size as the number of data points in ``data_to_interpolate``. This input is *only* required if the requested interpolation algorithm requires first derivatives as input (such as the Hermite spline interpolator).
 Returns
 -------
 OneDimensionalInterpolatorScalar
@@ -570,8 +570,8 @@ data_to_interpolate : dict[float, np.array]
     Key-value container with pairs of independent variables (key) and dependent variables (value) from which the interpolation is to be performed
 interpolator_settings : InterpolatorSettings
     Settings that define the type of interpolator that is to be used
-data_first_derivatives : dict[float, np.array] = dict()
-    Key-value container with pairs of independent variables (key) and first derivative dependent variables w.r.t. independent variable (value) from which the interpolation is to be performed. This input is *only* required if the requested interpolation algorithm requires first derivatives as input (such as the Hermite spline interpolator).
+data_first_derivatives : list[np.ndarray] = []
+    List of first derivative dependent variables w.r.t. independent variable from which the interpolation is to be performed. Must be of the same size as the number of data points in ``data_to_interpolate``. This input is *only* required if the requested interpolation algorithm requires first derivatives as input (such as the Hermite spline interpolator).
 Returns
 -------
 OneDimensionalInterpolatorVector
@@ -602,8 +602,8 @@ data_to_interpolate : dict[float, np.array]
     Key-value container with pairs of independent variables (key) and dependent variables (value) from which the interpolation is to be performed
 interpolator_settings : InterpolatorSettings
     Settings that define the type of interpolator that is to be used
-data_first_derivatives : dict[float, np.array] = dict()
-    Key-value container with pairs of independent variables (key) and first derivative dependent variables w.r.t. independent variable (value) from which the interpolation is to be performed. This input is *only* required if the requested interpolation algorithm requires first derivatives as input (such as the Hermite spline interpolator
+data_first_derivatives : list[np.ndarray] = []
+    List of first derivative dependent variables w.r.t. independent variable from which the interpolation is to be performed. Must be of the same size as the number of data points in ``data_to_interpolate``. This input is *only* required if the requested interpolation algorithm requires first derivatives as input (such as the Hermite spline interpolator).
 Returns
 -------
 OneDimensionalInterpolatorMatrix

--- a/tudatpy/kernel/expose_numerical_simulation/expose_environment_setup.cpp
+++ b/tudatpy/kernel/expose_numerical_simulation/expose_environment_setup.cpp
@@ -330,7 +330,7 @@ void expose_environment_setup( py::module &m )
 Function that retrieves the default settings for the given set of input bodies.
 
 Function that retrieves the default settings for the given set of input bodies. Default settings are described in
-detail `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/default_env_models.html>`_ .
+detail `in the user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/default_env_models.html>`_ .
 Note that if a body is provided as input for which default settings do not exist, an exception is thrown. In addition
 to settings for each separate body, this function returns an object that defines the global frame origin and orientation.
 
@@ -345,7 +345,7 @@ Parameters
 bodies : list[str]
     List of name of bodies for which default settings are to be retrieved and created.
 base_frame_origin : str, default = 'SSB'
-    Base frame origin of the set of bodies that is to be created. It defaults to the solar system barycenter (SSB), but it can by any of the bodies in `bodies_to_create` (provided it has an ephemeris defined).
+    Base frame origin of the set of bodies that is to be created. It defaults to the solar system barycenter (SSB), but it can by any of the bodies in `bodies` (provided it has an ephemeris defined).
 base_frame_orientation : str, default = 'ECLIPJ2000'
     Base frame orientation of the set of bodies that is to be created. It can be either ECLIPJ2000 (default) or J2000.
 Returns

--- a/tudatpy/kernel/expose_numerical_simulation/expose_environment_setup.cpp
+++ b/tudatpy/kernel/expose_numerical_simulation/expose_environment_setup.cpp
@@ -332,7 +332,12 @@ Function that retrieves the default settings for the given set of input bodies.
 Function that retrieves the default settings for the given set of input bodies. Default settings are described in
 detail `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/default_env_models.html>`_ .
 Note that if a body is provided as input for which default settings do not exist, an exception is thrown. In addition
-to settings for each separate body, this function returns an object that defines the global frame origin and orientation,
+to settings for each separate body, this function returns an object that defines the global frame origin and orientation.
+
+.. note::
+
+    Before using this function, make sure to have the appropriate set of SPICE kernels loaded.
+    Typically, this is done through the :func:`~tudatpy.interface.spice.load_standard_kernels` function.
 
 
 Parameters

--- a/tudatpy/kernel/expose_numerical_simulation/expose_propagation_setup/expose_acceleration_setup.cpp
+++ b/tudatpy/kernel/expose_numerical_simulation/expose_propagation_setup/expose_acceleration_setup.cpp
@@ -738,7 +738,7 @@ Parameters
 ----------
 use_schwarzschild : bool, default=False
     Boolean defining whether or not to use the Schwarzschild contribution to the acceleration correction
-use_lense_thirring : bool
+use_lense_thirring : bool, default=False
     Boolean defining whether or not to use the Lense-Thirring contribution to the acceleration correction
 use_de_sitter : bool, default=False
     Boolean defining whether or not to use the de Sitter contribution to the acceleration correction

--- a/tudatpy/kernel/expose_numerical_simulation/expose_propagation_setup/expose_integrator_setup.cpp
+++ b/tudatpy/kernel/expose_numerical_simulation/expose_propagation_setup/expose_integrator_setup.cpp
@@ -837,7 +837,7 @@ embedded propagators of the RKF7(8) method are created, with a time-step of 120 
            py::arg( "assess_termination_on_minor_steps" ) = false,
            R"doc(
 
-Creates the settings for the Runge-Kutta fixed step size integrator.
+Creates the settings for the Runge-Kutta variable step size integrator.
 
 Function to create settings for the Runge-Kutta variable step size integrator.
 Different coefficient sets (Butcher's tableau) can be used (see the :class:`CoefficientSets` enum).
@@ -875,7 +875,7 @@ IntegratorSettings
 
 Examples
 --------
-In this example, settings for the varianle step RK4(5) integrator are created, with the same tolerances (:math:`10^{-10}`)
+In this example, settings for the variable step RK4(5) integrator are created, with the same tolerances (:math:`10^{-10}`)
 applied element-wise on the propagated state. The minimum and maximum time steps are set to 0.001 and 1000 seconds,
 and the initial step is set to 30 seconds. All other inputs are left on their defaults
 

--- a/tudatpy/kernel/expose_numerical_simulation/expose_propagation_setup/expose_propagator_setup.cpp
+++ b/tudatpy/kernel/expose_numerical_simulation/expose_propagation_setup/expose_propagator_setup.cpp
@@ -550,17 +550,23 @@ Propagation of Unified state model using exponential map (state vector size 7, l
             .value( "quaternions",
                     tp::RotationalPropagatorType::quaternions,
                     R"doc(
-Entries 1-4: The quaternion defining the rotation from inertial to body-fixed frame (see `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/frames_in_environment.html#definition-of-rotational-state>`_) Entries 5-7: The body's angular velocity vector, expressed in its body-fixed frame.
+Entries 1-4: The quaternion defining the rotation from inertial to body-fixed frame (see `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/frames_in_environment.html#definition-of-rotational-state>`_)
+
+Entries 5-7: The body's angular velocity vector, expressed in its body-fixed frame.
      )doc" )
             .value( "modified_rodrigues_parameters",
                     tp::RotationalPropagatorType::modified_rodrigues_parameters,
                     R"doc(
-Entries 1-4: The modified Rodrigues parameters defining the rotation from inertial to body-fixed frame (with entry four the shadow parameter) Entries 5-7: The body's angular velocity vector, expressed in its body-fixed frame.
+Entries 1-4: The modified Rodrigues parameters defining the rotation from inertial to body-fixed frame (with entry four the shadow parameter)
+
+Entries 5-7: The body's angular velocity vector, expressed in its body-fixed frame.
      )doc" )
             .value( "exponential_map",
                     tp::RotationalPropagatorType::exponential_map,
                     R"doc(
-Entries 1-4: The exponential map defining the rotation from inertial to body-fixed frame (with entry four the shadow parameter) Entries 5-7: The body's angular velocity vector, expressed in its body-fixed frame.
+Entries 1-4: The exponential map defining the rotation from inertial to body-fixed frame (with entry four the shadow parameter)
+
+Entries 5-7: The body's angular velocity vector, expressed in its body-fixed frame.
      )doc" )
             .export_values( );
 
@@ -924,7 +930,7 @@ The propagated state vector is defined by the integrated bodies, which defines t
 differential equation defining the evolution of the rotational state between an
 inertial and body-fixed frame are to be solved. The propagator input defines the
 formulation in which the differential equations are set up. The dynamical models are
-defined by an ``TorqueModelMap``, as created by ``create_torque_models`` function.
+defined by a ``TorqueModelMap``, as created by :func:`~tudatpy.numerical_simulation.propagation_setup.create_torque_models` function.
 Details on the usage of this function are discussed in more detail in the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/rotational.html>`_
 
 
@@ -1008,7 +1014,7 @@ Parameters
 ----------
 bodies_with_mass_to_propagate : list[str]
     List of bodies whose mass should be numerically propagated.
-mass_rate_settings : SelectedMassRateModelMap
+mass_rate_models : SelectedMassRateModelMap
     Mass rates associated to each body, provided as a mass rate settings object.
 initial_body_masses : numpy.ndarray
     Initial masses of the bodies to integrate (one initial mass for each body), provided in the same order as the bodies to integrate.
@@ -1355,7 +1361,7 @@ very minor deviations from the specified final condition can occur.
 
 Examples
 --------
-In this example, we set the termination time of the propagation equal to one day (86400 $s$).
+In this example, we set the termination time of the propagation equal to one day (86400 s).
 
 .. code-block:: python
 
@@ -1435,7 +1441,7 @@ use_as_lower_limit : bool, default=False
     Denotes whether the limit value should be used as lower or upper limit.
 terminate_exactly_on_final_condition : bool, default=False
     Denotes whether the propagation is to terminate exactly on the final condition, or whether it is to terminate on the first step where it is violated.
-termination_root_finder_settings : bool, default=None
+termination_root_finder_settings : RootFinderSettings, default=None
     Settings object to create root finder used to converge on exact final condition.
 Returns
 -------
@@ -1545,7 +1551,7 @@ stop the propagation. Each termination condition should be created according to 
 and then added to a list of termination conditions.
 
 Note that, when using this option, the :attr:`~tudatpy.numerical_simulation.propagation.SingleArcSimulationResults.termination_details` of
-the simulation results object (obtained from here after a propagation: `:attr:`~tudatpy.numerical_simulation.SingleArcSimulator.propagation_results`)
+the simulation results object (obtained from here after a propagation: :attr:`~tudatpy.numerical_simulation.SingleArcSimulator.propagation_results`)
 is of derived type :class:`~tudatpy.numerical_simulation.propagation.PropagationTerminationDetailsFromHybridCondition`, which
 contains additional details on the hybrid termination (such as the specific conditions that were met).
 

--- a/tudatpy/kernel/expose_numerical_simulation_estimator.cpp
+++ b/tudatpy/kernel/expose_numerical_simulation_estimator.cpp
@@ -223,7 +223,7 @@ void expose_numerical_simulation_estimator( py::module &m )
         equations of motion and variational equations/dynamics in the Estimator object.
 
 
-        :type: :class:`~tudatpy.numerical_simulation.SingleArcVariationalSolver`
+        :type: :class:`~tudatpy.numerical_simulation.SingleArcVariationalSimulator`
      )doc" );
 };
 

--- a/tudatpy/kernel/expose_numerical_simulation_variational.cpp
+++ b/tudatpy/kernel/expose_numerical_simulation_variational.cpp
@@ -186,7 +186,7 @@ Returns
         Returns
         -------
         None
-            Creates / modifies the `state_history` property of the :class:`~tudatpy.numerical_simulation.SingleArcVariationalSolver` object.
+            Creates / modifies the `state_history` property of the :class:`~tudatpy.numerical_simulation.SingleArcVariationalSimulator` object.
 
 
 


### PR DESCRIPTION
- Move enums and classes to beginning of `time_conversion` module so they can be resolved in function definitions
- Remove duplicate exposure of `keplerian_to_cartesian`
- Add note to `spice.get_body_gravitational_parameter` as distinction to default models
- Fix docstring and argument type of first derivative data in interpolators