### PR TITLE
Remove default nullptr argument to avoid segfault

### DIFF
--- a/tudatpy/kernel/expose_numerical_simulation/expose_environment_setup/expose_vehicle_systems_setup.cpp
+++ b/tudatpy/kernel/expose_numerical_simulation/expose_environment_setup/expose_vehicle_systems_setup.cpp
@@ -178,7 +178,7 @@ BodyPanelGeometrySettings
     m.def( "body_panel_settings",
            &tss::bodyPanelSettings,
            py::arg( "panel_geometry" ),
-           py::arg( "panel_reflection_law" ) = nullptr,
+           py::arg( "panel_reflection_law" ),
            py::arg( "panel_type_id" ) = "",
            R"doc(
 
@@ -194,8 +194,8 @@ Parameters
 ----------
 panel_geometry : BodyPanelGeometrySettings
     Geometric properties of the panel (size and orientation, at least)
-panel_reflection_law : BodyPanelReflectionLawSettings, default = None
-    Reflection law settings of the panel (default none)
+panel_reflection_law : BodyPanelReflectionLawSettings
+    Reflection law settings of the panel
 panel_type_id : str, default = ""
     Optional identifier for panel type
 Returns


### PR DESCRIPTION
At the moment the default nullptr argument for the `panel_reflection_law` argument in the `body_panel_settings` function causes a segfault, unless explicitly overwritten. The default argument has been removed and should now throw an error (see https://github.com/tudat-team/tudat/pull/307 for corresponding tudat PR).

<details><summary>Segfault-throwing code for reference (should be resolved once PRs are merged)</summary>
<p>
 
```python
import matplotlib
# Load standard modules
import numpy as np
from matplotlib import pyplot as plt
from tudatpy import constants, numerical_simulation
from tudatpy.astro.time_conversion import DateTime
# Load tudatpy modules
from tudatpy.interface import spice
from tudatpy.numerical_simulation import (environment, environment_setup,
                                          propagation_setup)

# Load spice kernels
spice.load_standard_kernels()

# Define string names for bodies to be created from default.
bodies_to_create = ["Sun", "Earth"]

# Use "Earth"/"J2000" as global frame origin and orientation.
global_frame_origin = "Earth"
global_frame_orientation = "J2000"

# Create default body settings
body_settings = environment_setup.get_default_body_settings(
    bodies_to_create, global_frame_origin, global_frame_orientation
)

# Create empty body settings for the satellite
body_settings.add_empty_settings("Delfi-C3")

np_target_settings = environment_setup.radiation_pressure.panelled_radiation_target(
    {"Sun": ["Earth"]}
)

# Add the radiation pressure interface to the body settings
body_settings.get("Delfi-C3").radiation_pressure_target_settings = np_target_settings

rotation_model_settings = (
    environment_setup.rotation_model.orbital_state_direction_based(
        "Earth", True, False, "J2000", "DelfiBF"
    )
)

body_settings.get("Delfi-C3").rotation_model_settings = rotation_model_settings

#! Undefined for demonstration
# reflection_law_settings = (
#     environment_setup.radiation_pressure.specular_diffuse_body_panel_reflection(
#         0.5, 0.5, True
#     )
# )

L = 0.3
W = 0.1
H = 0.1

solar_panel_geometry = environment_setup.vehicle_systems.body_tracking_panel_geometry(
    "Sun", True, L * W * 2
)


#! No reflection law settings for demonstration
panel_settings = [
    environment_setup.vehicle_systems.body_panel_settings(solar_panel_geometry)
]

vehicle_system_settings = environment_setup.vehicle_systems.full_panelled_body_settings(
    panel_settings
)

# Add the radiation pressure interface to the body settings
body_settings.get("Delfi-C3").radiation_pressure_target_settings = np_target_settings
body_settings.get("Delfi-C3").vehicle_shape_settings = vehicle_system_settings
body_settings.get("Delfi-C3").rotation_model_settings = rotation_model_settings

# Finally, the system of bodies is created using the settings. This system of bodies is stored into the variable `bodies`.

bodies = environment_setup.create_system_of_bodies(body_settings)
bodies.get("Delfi-C3").mass = 2.2  # kg

# Define bodies that are propagated
bodies_to_propagate = ["Delfi-C3"]

# Define central bodies of propagation
central_bodies = ["Earth"]

# Define accelerations acting on Delfi-C3 by Sun and Earth.
accelerations_settings_delfi_c3 = dict(
    Sun=[
        propagation_setup.acceleration.radiation_pressure(),
    ],
    Earth=[
        propagation_setup.acceleration.point_mass_gravity(),
    ],
)

# Create global accelerations settings dictionary.
acceleration_settings = {
    "Delfi-C3": accelerations_settings_delfi_c3,
}

# Create acceleration models.
acceleration_models = propagation_setup.create_acceleration_models(
    bodies, acceleration_settings, bodies_to_propagate, central_bodies
)

# Set simulation start and end epochs
simulation_start_epoch = DateTime(2008, 4, 28).epoch()
simulation_end_epoch = DateTime(2008, 4, 29).epoch()

# Retrieve the initial state of Delfi-C3 using Two-Line-Elements (TLEs)
delfi_tle = environment.Tle(
    "1 32789U 07021G   08119.60740078 -.00000054  00000-0  00000+0 0  9999",
    "2 32789 098.0082 179.6267 0015321 307.2977 051.0656 14.81417433    68",
)
delfi_ephemeris = environment.TleEphemeris("Earth", "J2000", delfi_tle, False)
initial_state = delfi_ephemeris.cartesian_state(simulation_start_epoch)

# Create termination settings
termination_condition = propagation_setup.propagator.time_termination(
    simulation_end_epoch
)

# Create numerical integrator settings
fixed_step_size = 10.0
integrator_settings = propagation_setup.integrator.runge_kutta_fixed_step(
    fixed_step_size, coefficient_set=propagation_setup.integrator.CoefficientSets.rk_4
)

# Create propagation settings
propagator_settings = propagation_setup.propagator.translational(
    central_bodies,
    acceleration_models,
    bodies_to_propagate,
    initial_state,
    simulation_start_epoch,
    integrator_settings,
    termination_condition,
    # output_variables=dependent_variables_to_save,
)

dynamics_simulator = numerical_simulation.create_dynamics_simulator(
    bodies, propagator_settings
)

```

</p>
</details>