### PR TITLE
Small fixes to API docs

### DIFF
--- a/docs/source/spice.rst
+++ b/docs/source/spice.rst
@@ -4,7 +4,9 @@ Interface to the SPICE package.
 
 This module provides an interface to NAIF's ``SPICE`` package.
 
+.. note::
 
+   All functions return values in SI units (meter, seconds, kilogram, radian) and therefore require no conversion when used in combination with other tudatpy functions.
 
 
 

--- a/tudatpy/kernel/expose_astro/expose_time_conversion.cpp
+++ b/tudatpy/kernel/expose_astro/expose_time_conversion.cpp
@@ -361,14 +361,41 @@ Returns
 DateTime
     DateTime object defined in Tudat
 
-    m.def("year_and_days_in_year_to_calendar_date",
-          &tba::convertYearAndDaysInYearToTudatDate,
-          py::arg("year"),
-          py::arg("days_in_year"),
-          get_docstring("year_and_days_in_year_to_calendar_date").c_str()
-    );
+    )doc" );
+
+    m.def( "year_and_days_in_year_to_calendar_date",
+           &tba::convertYearAndDaysInYearToTudatDate,
+           py::arg( "year" ),
+           py::arg( "days_in_year" ),
+           R"doc(
+        
+Create the calendar date from the year and the number of days in the year.
+
+Parameters
+----------
+year : int
+    Calendar year.
+days_in_year : int
+    Number of days that have passed in the year.
+Returns
+-------
+DateTime
+    Corresponding calendar date as a :class:`DateTime` object. Note: the hours, minutes and seconds in the object are set to 0 when calling this function.
 
 
+
+
+
+Examples
+--------
+In this example, the calendar date corresponding to when 122 days have passed in 2020 is computed.
+
+.. code-block:: python
+
+  # Compute the calendar date when 122 days have passed in 2020
+  currentDate = time_conversion.year_and_days_in_year_to_calendar_date(2020, 122)
+  # Print the converted output
+  print(currentDate)  # prints (2020, 5, 2, 0, 0)
 
 
     )doc" );

--- a/tudatpy/kernel/expose_numerical_simulation/expose_environment_setup.cpp
+++ b/tudatpy/kernel/expose_numerical_simulation/expose_environment_setup.cpp
@@ -726,14 +726,14 @@ coefficient_settings : AerodynamicCoefficientSettings
            py::arg( "radiation_pressure_target_settings" ),
            R"doc(
 
-Function that creates an radiation pressure interface from settings, and adds it to an existing body.
+Function that creates a radiation pressure target model from settings, and adds it to an existing body.
 
-This function can be used to add an radiation pressure interface to an existing body. It requires
-settings for the radiation pressure interface, created using one of the functions from the :ref:`\`\`radiation_pressure\`\`` module.
-This function creates the actual coefficient interface from these settings, and assigns it to the
+This function can be used to add a radiation pressure target model to an existing body. It requires
+settings for the radiation pressure target model, created using one of the functions from the :ref:`\`\`radiation_pressure\`\`` module.
+This function creates the actual target model from these settings, and assigns it to the
 selected body. In addition to the identifier for the body to which it is assigned, this function
 requires the full :class:`~tudatpy.numerical_simulation.environment.SystemOfBodies` as input, to facilitate
-inter-body dependencies in the radiation pressure interface
+inter-body dependencies in the radiation pressure interface.
 
 
 Parameters
@@ -742,8 +742,8 @@ bodies : SystemOfBodies
     Object defining the physical environment, with all properties of artificial and natural bodies.
 body_name : str
     Name of the body to which the radiation pressure interface is to be assigned
-radiation_pressure_settings : RadiationPressureInterfaceSettings
-    Settings defining the radiation pressure interface that is to be created.
+radiation_pressure_target_settings : RadiationPressureTargetModelSettings
+    Settings defining the radiation pressure target model that is to be created.
 
 
 

--- a/tudatpy/kernel/expose_numerical_simulation/expose_estimation_setup.cpp
+++ b/tudatpy/kernel/expose_numerical_simulation/expose_estimation_setup.cpp
@@ -99,7 +99,7 @@ Examples
     initial_state = np.zeros(6)  # Use a real initial state if needed
 
     # Integrator settings
-    integrator_settings = propagation_setup.integrator.runge_kutta_fixed_step_size(60.0,
+    integrator_settings = propagation_setup.integrator.runge_kutta_fixed_step(60.0,
                                                                                    coefficient_set=propagation_setup.integrator.CoefficientSets.rkdp_87)
 
     # Create propagator

--- a/tudatpy/kernel/expose_numerical_simulation/expose_propagation_setup.cpp
+++ b/tudatpy/kernel/expose_numerical_simulation/expose_propagation_setup.cpp
@@ -94,8 +94,8 @@ central_bodies : list
     List of central bodies, each referred to each propagated body in the same order.
 Returns
 -------
-AccelerationMap
-    Set of accelerations acting on the bodies to propagate, provided as dual key-value container, similar to the acceleration settings input, but now with ``AccelerationModel`` lists as inner value
+AccelerationMap : dict[str, list[AccelerationModel]]
+    Set of accelerations acting on the bodies to propagate, provided as dual key-value container (dictionary), similar to the acceleration settings input, but now with ``AccelerationModel`` lists as inner value
 
 
 
@@ -218,7 +218,7 @@ body_system : SystemOfBodies
     System of bodies to be used in the propagation.
 selected_mass_rates_per_body : Dict[str, List[MassRateModelSettings]]
     Key-value container, with key denoting the body with changing mass, and the value containing a list of mass rate settings (in most cases, this list will have only a single entry)
-acceleration_models : AccelerationMap
+acceleration_models : dict[str, list[AccelerationModel]]
     Sorted list of acceleration models, as created by :func:`create_acceleration_models`
 Returns
 -------

--- a/tudatpy/kernel/expose_numerical_simulation/expose_propagation_setup/expose_integrator_setup.cpp
+++ b/tudatpy/kernel/expose_numerical_simulation/expose_propagation_setup/expose_integrator_setup.cpp
@@ -559,7 +559,10 @@ that :math:`\epsilon_{i}\rightarrow||\boldsymbol{\epsilon_{[i,k],[j,l]}}||`. Whe
 start column :math:`j`, number of rows :math:`k` and number of columns :math:`l`. over
 which the state error norm is to be taken. For a single Cartesian state vector, the norm is taken on blocks :math:`[0,3],[0,1]` and :math:`[3,3],[0,1]`
 
+.. note::
 
+    If you would like to create block indices that group the position and velocity elements, take a look at the :func:`~tudatpy.numerical_simulation.propagation_setup.integrator.standard_cartesian_state_element_blocks` function.
+    The function will create a list of blocks that can be used as input to the `block_indices` argument of this function.
 
 Parameters
 ----------
@@ -581,8 +584,94 @@ IntegratorStepSizeControlSettings
     Object containing settings for per-element step-size control.
 
 
+Examples
+--------
+In this example, step size control settings are created for a Cartesian state vector, which group the position and velocity elements for the step size validation. Note, these block indices can also be conveniently created using the :func:`~tudatpy.numerical_simulation.propagation_setup.integrator.standard_cartesian_state_element_blocks` function.
+Here we will create them manually for demonstration purposes.
+
+We would like to create integrator settings with the following settings:
+
+- Relative error tolerance of 1e-12
+- Absolute error tolerance of 1e-12
+- Relative and absolute error tolerances are applied to the position and velocity blocks of a single Cartesian state vector
+
+.. code-block:: python
+
+    from tudatpy.numerical_simulation import propagation_setup
+
+    ...
+
+    # Define integrator step settings
+    initial_time_step = 10.0
+    minimum_step_size = 1.0e-12
+    maximum_step_size = 60.0
+
+    relative_tolerance = 1.0e-12
+    absolute_tolerance = 1.0e-12
+
+    """
+    Our Cartesian state y is a 2D vector, with dimensions [6, 1].
+
+    # column-index
+           0
+    y = [[ x ], # row-index 0
+         [ y ], # row-index 1
+         [ z ], # row-index 2
+         [ vx ], # row-index 3
+         [ vy ], # row-index 4
+         [ vz ]] # row-index 5
+
+    The block indices are denoted as i, j, k, l, where:
+    - i: start row index of the block
+    - j: start column index of the block
+    - k: number of rows in the block
+    - l: number of columns in the block
+
+    The corresponding block indices for the position block are therefore
+    - i = 0 (start the block at row-index 0)
+    - j = 0 (start the block at column-index 0)
+    - k = 3 (the block has 3 rows: x, y, z)
+    - l = 1 (the block has 1 column)
+    which gives us the block indices (i=0, j=0, k=3, l=1).
 
 
+    For the velocity block, the indices are:
+    - i = 3 (start the block at row-index 3)
+    - j = 0 (start the block at column-index 0)
+    - k = 3 (the block has 3 rows: vx, vy, vz)
+    - l = 1 (the block has 1 column)
+    which gives us the block indices (i=3, j=0, k=3, l=1).
+
+    """
+
+    # Manually define block indices for position and velocity,
+    # which is equivalent to the standard block indices using:
+    # block_indices = propagation_setup.integrator.standard_cartesian_state_element_blocks(6, 1)
+    block_indices = [(0, 0, 3, 1), (3, 0, 3, 1)]
+
+    step_size_control_settings = (
+        propagation_setup.integrator.step_size_control_blockwise_scalar_tolerance(
+            block_indices, relative_tolerance, absolute_tolerance
+        )
+    )
+
+    step_size_validation_settings = propagation_setup.integrator.step_size_validation(
+        minimum_step=minimum_step_size, maximum_step=maximum_step_size
+    )
+
+    # Retrieve coefficient set
+    coefficient_set = propagation_setup.integrator.rkf_78
+
+    variable_step_integrator_settings = (
+        propagation_setup.integrator.runge_kutta_variable_step(
+            initial_time_step,
+            coefficient_set,
+            step_size_control_settings,
+            step_size_validation_settings,
+        )
+    )
+
+    ...
 
 
     )doc" );
@@ -606,7 +695,10 @@ different tolerances can be provided for each state block.
 
 If the size of the tolerances used as input differ from one another, or differ from the number of blocks, an exception is thrown
 
+.. note::
 
+    If you would like to create block indices that group the position and velocity elements, take a look at the :func:`~tudatpy.numerical_simulation.propagation_setup.integrator.standard_cartesian_state_element_blocks` function.
+    The function will create a list of blocks that can be used as input to the `block_indices` argument of this function.
 
 Parameters
 ----------
@@ -628,7 +720,102 @@ IntegratorStepSizeControlSettings
     Object containing settings for per-element step-size control.
 
 
+Examples
+--------
+In this example, step size control settings are created for a Cartesian state vector, which group the position and velocity elements for the step size validation. Note, these block indices can also be conveniently created using the :func:`~tudatpy.numerical_simulation.propagation_setup.integrator.standard_cartesian_state_element_blocks` function.
+Here we will create them manually for demonstration purposes.
 
+We would like to create integrator settings with the following settings:
+
+- Relative error tolerance of 1e-12 for position and velocity blocks
+- Absolute error tolerance of 1e-9 for position and 1e-12 for velocity blocks
+
+.. code-block:: python
+
+    import numpy as np
+
+    from tudatpy.numerical_simulation import propagation_setup
+
+    ...
+
+    # Define integrator step settings
+    initial_time_step = 10.0
+    minimum_step_size = 1.0e-12
+    maximum_step_size = 60.0
+
+    relative_tolerance_pos = 1.0e-12
+    relative_tolerance_vel = 1.0e-12
+    absolute_tolerance_pos = 1.0e-9
+    absolute_tolerance_vel = 1.0e-12
+
+    """
+    Our Cartesian state y is a 2D vector, with dimensions [6, 1].
+
+    # column-index
+        0
+    y = [[ x ], # row-index 0
+        [ y ], # row-index 1
+        [ z ], # row-index 2
+        [ vx ], # row-index 3
+        [ vy ], # row-index 4
+        [ vz ]] # row-index 5
+
+    The block indices are denoted as i, j, k, l, where:
+    - i: start row index of the block
+    - j: start column index of the block
+    - k: number of rows in the block
+    - l: number of columns in the block
+
+    The corresponding block indices for the position block are therefore
+    - i = 0 (start the block at row-index 0)
+    - j = 0 (start the block at column-index 0)
+    - k = 3 (the block has 3 rows: x, y, z)
+    - l = 1 (the block has 1 column)
+    which gives us the block indices (i=0, j=0, k=3, l=1).
+
+
+    For the velocity block, the indices are:
+    - i = 3 (start the block at row-index 3)
+    - j = 0 (start the block at column-index 0)
+    - k = 3 (the block has 3 rows: vx, vy, vz)
+    - l = 1 (the block has 1 column)
+    which gives us the block indices (i=3, j=0, k=3, l=1).
+
+    """
+
+    # Manually define block indices for position and velocity,
+    # which is equivalent to the standard block indices using:
+    # block_indices = propagation_setup.integrator.standard_cartesian_state_element_blocks(6, 1)
+    block_indices = [(0, 0, 3, 1), (3, 0, 3, 1)]
+
+    # Different from the scalar tolerance, the matrix tolerance is defined as
+    # the relative and absolute tolerances for each block.
+    relative_tolerances = np.array([[relative_tolerance_pos], [relative_tolerance_vel]])
+    absolute_tolerances = np.array([[absolute_tolerance_pos], [absolute_tolerance_vel]])
+
+    step_size_control_settings = (
+        propagation_setup.integrator.step_size_control_blockwise_matrix_tolerance(
+            block_indices, relative_tolerances, absolute_tolerances
+        )
+    )
+
+    step_size_validation_settings = propagation_setup.integrator.step_size_validation(
+        minimum_step=minimum_step_size, maximum_step=maximum_step_size
+    )
+
+    # Retrieve coefficient set
+    coefficient_set = propagation_setup.integrator.rkf_78
+
+    variable_step_integrator_settings = (
+        propagation_setup.integrator.runge_kutta_variable_step(
+            initial_time_step,
+            coefficient_set,
+            step_size_control_settings,
+            step_size_validation_settings,
+        )
+    )
+
+    ...
 
 
 

--- a/tudatpy/kernel/expose_numerical_simulation/expose_propagation_setup/expose_propagator_setup.cpp
+++ b/tudatpy/kernel/expose_numerical_simulation/expose_propagation_setup/expose_propagator_setup.cpp
@@ -40,7 +40,6 @@ namespace propagation_setup
 namespace propagator
 {
 
-
 std::shared_ptr< tudat::propagators::MultiArcPropagatorProcessingSettings > multiArcProcessingSettings( )
 {
     return std::make_shared< tudat::propagators::MultiArcPropagatorProcessingSettings >( );
@@ -857,7 +856,7 @@ Function to create translational state propagator settings for N bodies.
 The propagated state vector is defined by the combination of integrated bodies, and their central body, the combination
 of which define the relative translational states for which a differential equation is to be solved. The propagator
 input defines the formulation in which the differential equations are set up
-The dynamical models are defined by an ``AccelerationMap``, as created by :func:`~tudatpy.numerical_simulation.propagation_setup.create_acceleration_models` function.
+The dynamical models are defined by an ``AccelerationMap`` (dict[str, list[AccelerationModel]]), as created by :func:`~tudatpy.numerical_simulation.propagation_setup.create_acceleration_models` function.
 Details on the usage of this function are discussed in more detail in the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/translational.html>`_.
 
 
@@ -865,7 +864,7 @@ Parameters
 ----------
 central_bodies : list[str]
     List of central bodies with respect to which the bodies to be integrated are propagated.
-acceleration_models : AccelerationMap
+acceleration_models : dict[str, list[AccelerationModel]]
     Set of accelerations acting on the bodies to propagate, provided as acceleration models.
 bodies_to_integrate : list[str]
     List of bodies to be numerically propagated, whose order reflects the order of the central bodies.
@@ -1158,8 +1157,7 @@ MultiTypePropagatorSettings
 
     )doc" );
 
-    m.def( "multi_arc_processing_settings",
-           &multiArcProcessingSettings );
+    m.def( "multi_arc_processing_settings", &multiArcProcessingSettings );
 
     m.def( "multi_arc",
            &tp::multiArcPropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE >,

--- a/tudatpy/kernel/expose_numerical_simulation_estimator.cpp
+++ b/tudatpy/kernel/expose_numerical_simulation_estimator.cpp
@@ -222,7 +222,7 @@ void expose_numerical_simulation_estimator( py::module &m )
         Variational equations solver, which is used to manage and execute the numerical integration of
         equations of motion and variational equations/dynamics in the Estimator object.
 
-        :type: :class:`~tudatpy.numerical_simulation.VariationalSimulator`
+        :type: :class:`~tudatpy.numerical_simulation.SingleArcVariationalSimulator`
      )doc" );
 };
 


### PR DESCRIPTION
Small fixes from the collection issue, including:
- Fix `year_and_days_in_year_to_calendar_date` exposure
- Update integrator settings #259
- Add references to step size control functions for `standard_cartesian_state_element_blocks` #260 
- Add code snippet with explanation how to create block indices for `step_size_control_blockwise_scalar_tolerance` and `step_size_control_blockwise_matrix_tolerance`