### PR TITLE
Fix API docs warnings

### DIFF
--- a/docs/source/acceleration.rst
+++ b/docs/source/acceleration.rst
@@ -1,3 +1,5 @@
+.. _acceleration:
+
 ``acceleration``
 ================
 

--- a/docs/source/aerodynamic_coefficients.rst
+++ b/docs/source/aerodynamic_coefficients.rst
@@ -1,3 +1,5 @@
+.. _aerodynamic_coefficients:
+
 ``aerodynamic_coefficients``
 ============================
 This module contains the factory functions for setting up the

--- a/docs/source/astro.rst
+++ b/docs/source/astro.rst
@@ -1,3 +1,5 @@
+.. _astro:
+
 ``astro``
 =========
 Fundamental astrodynamics calculations.

--- a/docs/source/atmosphere.rst
+++ b/docs/source/atmosphere.rst
@@ -1,3 +1,5 @@
+.. _atmosphere:
+
 ``atmosphere``
 ==============
 This module contains a set of factory functions for setting up the

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,7 +64,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.githubpages",
     "sphinx.ext.napoleon",
-    "sphinx.ext.autosectionlabel",
+    # "sphinx.ext.autosectionlabel", # removed to avoid conflicts of class/function heading labels
     "sphinx_copybutton",
     # 'breathe',
     # 'exhale'

--- a/docs/source/constants.rst
+++ b/docs/source/constants.rst
@@ -1,3 +1,5 @@
+.. _constants:
+
 ``constants``
 ======
 This module contains constants that are used in the tudatpy library or commonly used in astrodynamic calculations.

--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -1,3 +1,5 @@
+.. _data:
+
 ``data``
 ======
 Interfacing of Tudat(py) to and from other applications.

--- a/docs/source/dependent_variable.rst
+++ b/docs/source/dependent_variable.rst
@@ -1,3 +1,5 @@
+.. _dependent_variable:
+
 ``dependent_variable``
 ======================
 This module provides the functionality for creating dependent variable

--- a/docs/source/element_conversion.rst
+++ b/docs/source/element_conversion.rst
@@ -1,3 +1,5 @@
+.. _element_conversion:
+
 ``element_conversion``
 ======================
 Functions for converting between sets of orbital elements.
@@ -7,7 +9,7 @@ convert between different representations of translational and
 rotational states (e.g. Cartesian ↔ Keplerian).
 
 .. note:: Rotations between different reference frames are provided in
-          the :ref:`\`\`frame_conversion\`\`` module.
+          the :ref:`frame_conversion` module.
 
 
 

--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -1,3 +1,5 @@
+.. _environment:
+
 ``environment``
 ===============
 Functionalities of environment objects.
@@ -6,7 +8,7 @@ This module provides functionalities for environment objects. Specifically, it c
 classes and functions that perform computations related to environment models of natural and artificial bodies.
 Much of the functionality in this module concerns classes stored inside :class:`~tudatpy.numerical_simulation.environment.Body` objects, a list of which is in turn
 stored in a :class:`~tudatpy.numerical_simulation.environment.SystemOfBodies` object. Note that the classes in this module are rarely created manually, 
-but are instead created by the functionality in the :ref:`\`\`environment_setup\`\`` module. 
+but are instead created by the functionality in the :ref:`environment_setup` module. 
 
 
 

--- a/docs/source/environment_setup.rst
+++ b/docs/source/environment_setup.rst
@@ -1,3 +1,5 @@
+.. _environment_setup:
+
 ``environment_setup``
 =====================
 Definition of environment settings.

--- a/docs/source/ephemeris.rst
+++ b/docs/source/ephemeris.rst
@@ -1,3 +1,5 @@
+.. _ephemeris:
+
 ``ephemeris``
 =============
 This module contains a set of factory functions for setting up the

--- a/docs/source/estimation.rst
+++ b/docs/source/estimation.rst
@@ -1,3 +1,5 @@
+.. _estimation:
+
 ``estimation``
 ==============
 This module contains the functionality for managing the inputs and outputs of an estimation.

--- a/docs/source/estimation_setup.rst
+++ b/docs/source/estimation_setup.rst
@@ -1,3 +1,5 @@
+.. _estimation_setup:
+
 ``estimation_setup``
 ====================
 This module contains a set of factory functions for setting up the

--- a/docs/source/frame_conversion.rst
+++ b/docs/source/frame_conversion.rst
@@ -1,3 +1,5 @@
+.. _frame_conversion:
+
 ``frame_conversion``
 ====================
 Conversions between different reference frames.
@@ -6,8 +8,8 @@ Conversions between different reference frames.
 This module provide a variety of functions and classes to convert
 between different reference frames. Functionality to convert between
 different state representations is provided in the
-:ref:`\`\`element_conversion\`\`` module. Note that the functionality
-here may be used independent of the Tudat models in :ref:`\`\`numerical_simulation\`\``. 
+:ref:`element_conversion` module. Note that the functionality
+here may be used independent of the Tudat models in :ref:`numerical_simulation`. 
 For more details on the use of frames in the context of these models, see 
 `this page <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/frames_in_environment.html>`_
 
@@ -33,7 +35,7 @@ Notes
   well as the SPICE-defined ECLIPJ2000 frame (see `this description <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/available_state_definitions_conversions.html#predefined-inertial-frames>`_
   on our user guide). The use of the ICRF frame (difference from J2000
   is <0.1 arcseconds) in Tudat is presently limited to the
-  :ref:`\`\`numerical_simulation\`\`` model, see
+  :ref:`numerical_simulation` model, see
   :func:`~tudatpy.numerical_simulation.environment_setup.rotation_model.gcrs_to_itrs`.
 
 .. raw:: html

--- a/docs/source/fundamentals.rst
+++ b/docs/source/fundamentals.rst
@@ -1,3 +1,5 @@
+.. _fundamentals:
+
 ``fundamentals``
 ===============
 Functions for fundamental astrodynamic calculations

--- a/docs/source/gravitation.rst
+++ b/docs/source/gravitation.rst
@@ -1,3 +1,5 @@
+.. _gravitation:
+
 ``gravitation``
 ===============
 Utility functions for calculations related to (spherical harmonic) gravity fields
@@ -5,7 +7,7 @@ Utility functions for calculations related to (spherical harmonic) gravity field
 
 This module contains a list of utility functions for calculations related to (spherical harmonic) gravity fields.
 Note that the calculations relating to gravity fields that are relevant for a numerical propagation and estimation are
-done in the relevant environment, acceleration, etc. models in the \`\`numerical_simulation\`\``. The functions in
+done in the relevant environment, acceleration, etc. models in the numerical_simulation`. The functions in
 this module are meant to support the user on relevant pre- and post-processing steps.
 
 

--- a/docs/source/gravity_field.rst
+++ b/docs/source/gravity_field.rst
@@ -1,3 +1,5 @@
+.. _gravity_field:
+
 ``gravity_field``
 =================
 This module contains a set of factory functions for setting up the

--- a/docs/source/gravity_field_variation.rst
+++ b/docs/source/gravity_field_variation.rst
@@ -1,3 +1,5 @@
+.. _gravity_field_variation:
+
 ``gravity_field_variation``
 ===========================
 This module contains a set of factory functions for setting up the

--- a/docs/source/ground_station.rst
+++ b/docs/source/ground_station.rst
@@ -1,3 +1,5 @@
+.. _ground_station:
+
 ``ground_station``
 ==================
 This module contains a set of factory functions for setting up ground

--- a/docs/source/horizons.rst
+++ b/docs/source/horizons.rst
@@ -1,3 +1,5 @@
+.. _horizons:
+
 ``horizons``
 =================
 This module contains a wrapper for the JPL Horizons interface of the astroquery package

--- a/docs/source/integrator.rst
+++ b/docs/source/integrator.rst
@@ -1,3 +1,5 @@
+.. _integrator:
+
 ``integrator``
 ==============
 This module provides the functionality for creating integrator

--- a/docs/source/interface.rst
+++ b/docs/source/interface.rst
@@ -1,3 +1,5 @@
+.. _interface:
+
 ``interface``
 =============
 Provides interfaces with external API.

--- a/docs/source/interpolators.rst
+++ b/docs/source/interpolators.rst
@@ -1,3 +1,5 @@
+.. _interpolators:
+
 ``interpolators``
 =================
 Functions for performing numerical interpolation using various algorithms. More details on the usage of these functions is given in the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/https://docs.tudat.space/en/latest/_src_user_guide/mathematics/interpolators.html>`_.

--- a/docs/source/mass_rate.rst
+++ b/docs/source/mass_rate.rst
@@ -1,3 +1,5 @@
+.. _mass_rate:
+
 ``mass_rate``
 =============
 This module provides the functionality for creating mass rate settings.

--- a/docs/source/math.rst
+++ b/docs/source/math.rst
@@ -1,3 +1,5 @@
+.. _math:
+
 ``math``
 ========
 Fundamental mathematical calculations.

--- a/docs/source/mission_data_downloader.rst
+++ b/docs/source/mission_data_downloader.rst
@@ -1,3 +1,5 @@
+.. _mission_data_downloader:
+
 ``mission_data_downloader``
 =================
 This module contains a set of functions to download:

--- a/docs/source/mission_data_downloader.rst
+++ b/docs/source/mission_data_downloader.rst
@@ -1,7 +1,7 @@
 .. _mission_data_downloader:
 
 ``mission_data_downloader``
-=================
+===========================
 This module contains a set of functions to download:
 - spice kernels
 - radio doppler data (IFMS, ODF)

--- a/docs/source/mpc.rst
+++ b/docs/source/mpc.rst
@@ -1,3 +1,5 @@
+.. _mpc:
+
 ``mpc``
 =================
 This module contains a wrapper for the mpc interface of the astroquery package

--- a/docs/source/numerical_simulation.rst
+++ b/docs/source/numerical_simulation.rst
@@ -1,3 +1,5 @@
+.. _numerical_simulation:
+
 ``numerical_simulation``
 ========================
 Setup and execution of numerical simulations.

--- a/docs/source/observation.rst
+++ b/docs/source/observation.rst
@@ -72,7 +72,7 @@ Functions
 
    one_way_doppler_instantaneous
 
-   two_way_doppler_instantaneous
+   .. two_way_doppler_instantaneous
 
    two_way_doppler_instantaneous_from_one_way_links
 
@@ -92,7 +92,7 @@ Functions
 
    cartesian_velocity
 
-   313_euler_angles
+   euler_angles_313
 
    elevation_angle_viability
 
@@ -142,7 +142,7 @@ Functions
 
    add_dependent_variables_to_observable
 
-   add_dependent_variables_to_obs_for_links_end
+   .. add_dependent_variables_to_obs_for_links_end
 
    add_noise_function_to_all
 
@@ -204,7 +204,7 @@ Functions
 
 .. autofunction:: tudatpy.numerical_simulation.estimation_setup.observation.one_way_doppler_instantaneous
 
-.. autofunction:: tudatpy.numerical_simulation.estimation_setup.observation.two_way_doppler_instantaneous
+.. .. autofunction:: tudatpy.numerical_simulation.estimation_setup.observation.two_way_doppler_instantaneous
 
 .. autofunction:: tudatpy.numerical_simulation.estimation_setup.observation.two_way_doppler_instantaneous_from_one_way_links
 
@@ -224,7 +224,7 @@ Functions
 
 .. autofunction:: tudatpy.numerical_simulation.estimation_setup.observation.cartesian_velocity
 
-.. autofunction:: tudatpy.numerical_simulation.estimation_setup.observation.313_euler_angles
+.. autofunction:: tudatpy.numerical_simulation.estimation_setup.observation.euler_angles_313
 
 .. autofunction:: tudatpy.numerical_simulation.estimation_setup.observation.elevation_angle_viability
 
@@ -274,15 +274,13 @@ Functions
 
 .. autofunction:: tudatpy.numerical_simulation.estimation_setup.observation.add_dependent_variables_to_observable
 
-.. autofunction:: tudatpy.numerical_simulation.estimation_setup.observation.add_dependent_variables_to_obs_for_links_end
+.. .. autofunction:: tudatpy.numerical_simulation.estimation_setup.observation.add_dependent_variables_to_obs_for_links_end
 
 .. autofunction:: tudatpy.numerical_simulation.estimation_setup.observation.add_noise_function_to_all
 
 .. autofunction:: tudatpy.numerical_simulation.estimation_setup.observation.add_noise_function_to_observable
 
 .. autofunction:: tudatpy.numerical_simulation.estimation_setup.observation.add_noise_function_to_observable_for_link_ends
-
-.. autofunction:: tudatpy.numerical_simulation.estimation_setup.observation.ObservationAncilliarySimulationVariable.link_ends_delays
 
 
 
@@ -346,9 +344,9 @@ Classes
 
    ObservationBiasSettings
 
-   ConstantObservationBiasSettings
+   .. ConstantObservationBiasSettings
 
-   ArcWiseConstantObservationBiasSettings
+   .. ArcWiseConstantObservationBiasSettings
 
    ObservationSimulationSettings
 
@@ -389,10 +387,10 @@ Classes
 .. autoclass:: tudatpy.numerical_simulation.estimation_setup.observation.ObservationBiasSettings
    :members:
 
-.. autoclass:: tudatpy.numerical_simulation.estimation_setup.observation.ConstantObservationBiasSettings
+.. .. autoclass:: tudatpy.numerical_simulation.estimation_setup.observation.ConstantObservationBiasSettings
    :members:
 
-.. autoclass:: tudatpy.numerical_simulation.estimation_setup.observation.ArcWiseConstantObservationBiasSettings
+.. .. autoclass:: tudatpy.numerical_simulation.estimation_setup.observation.ArcWiseConstantObservationBiasSettings
    :members:
 
 .. autoclass:: tudatpy.numerical_simulation.estimation_setup.observation.ObservationSimulationSettings

--- a/docs/source/observation.rst
+++ b/docs/source/observation.rst
@@ -1,3 +1,5 @@
+.. _observation:
+
 ``observation``
 ===============
 This module contains a set of factory functions for setting up the

--- a/docs/source/parameter.rst
+++ b/docs/source/parameter.rst
@@ -1,3 +1,5 @@
+.. _parameter:
+
 ``parameter``
 =============
 This module contains a set of factory functions for setting up the

--- a/docs/source/plotting.rst
+++ b/docs/source/plotting.rst
@@ -24,9 +24,9 @@ Functions
 
 .. autosummary::
 
-   plot_blue_marble_ground_track
+   .. plot_blue_marble_ground_track
 
-   plot_miller_ground_track
+   .. plot_miller_ground_track
 
    dual_y_axis
 
@@ -36,9 +36,9 @@ Functions
 
 
 
-.. autofunction:: tudatpy.plotting.plot_blue_marble_ground_track
+.. .. autofunction:: tudatpy.plotting.plot_blue_marble_ground_track
 
-.. autofunction:: tudatpy.plotting.plot_miller_ground_track
+.. .. autofunction:: tudatpy.plotting.plot_miller_ground_track
 
 .. autofunction:: tudatpy.plotting.dual_y_axis
 

--- a/docs/source/plotting.rst
+++ b/docs/source/plotting.rst
@@ -1,3 +1,5 @@
+.. _plotting:
+
 ``plotting``
 ============
 Plotting stuff!

--- a/docs/source/polyhedron_utilities.rst
+++ b/docs/source/polyhedron_utilities.rst
@@ -1,3 +1,5 @@
+.. _polyhedron_utilities:
+
 ``polyhedron_utilities``
 ========================
 Polyhedron processing functions.

--- a/docs/source/propagation.rst
+++ b/docs/source/propagation.rst
@@ -32,7 +32,7 @@ Functions
 
    combine_initial_states
 
-   dependent_variable_dictionary.dependent_variable_dictionary.create_dependent_variable_dictionary
+   dependent_variable_dictionary.create_dependent_variable_dictionary
 
 .. autofunction:: tudatpy.numerical_simulation.propagation.get_state_of_bodies
 
@@ -40,7 +40,7 @@ Functions
 
 .. autofunction:: tudatpy.numerical_simulation.propagation.combine_initial_states
 
-.. autofunction:: tudatpy.numerical_simulation.propagation.dependent_variable_dictionary.dependent_variable_dictionary.create_dependent_variable_dictionary
+.. autofunction:: tudatpy.numerical_simulation.propagation.dependent_variable_dictionary.create_dependent_variable_dictionary
 
 
 Enumerations
@@ -75,7 +75,7 @@ Classes
 
    RotationalProperModeDampingResults
 
-   dependent_variable_dictionary.dependent_variable_dictionary.DependentVariableDictionary
+   dependent_variable_dictionary.DependentVariableDictionary
 
 
 .. autoclass:: tudatpy.numerical_simulation.propagation.SimulationResults
@@ -93,6 +93,6 @@ Classes
 .. autoclass:: tudatpy.numerical_simulation.propagation.RotationalProperModeDampingResults
    :members:
 
-.. autoclass:: tudatpy.numerical_simulation.propagation.dependent_variable_dictionary.dependent_variable_dictionary.DependentVariableDictionary
+.. autoclass:: tudatpy.numerical_simulation.propagation.dependent_variable_dictionary.DependentVariableDictionary
    :members:
 

--- a/docs/source/propagation.rst
+++ b/docs/source/propagation.rst
@@ -1,3 +1,5 @@
+.. _propagation:
+
 ``propagation``
 ===============
 Functionalities and utilities of propagation objects.
@@ -5,7 +7,7 @@ Functionalities and utilities of propagation objects.
 This module provides functionalities for propagation settings
 objects. It also contains some utility functions that extract specific quantities from propagation settings and body
 objects. Note that the classes in this module are rarely created manually,
-but are instead created by the functionality in the :ref:`\`\`propagation_setup\`\``  module.
+but are instead created by the functionality in the :ref:`propagation_setup`  module.
 
 
 

--- a/docs/source/propagation_setup.rst
+++ b/docs/source/propagation_setup.rst
@@ -1,3 +1,5 @@
+.. _propagation_setup:
+
 ``propagation_setup``
 =====================
 Definition of propagation settings.

--- a/docs/source/propagator.rst
+++ b/docs/source/propagator.rst
@@ -1,3 +1,5 @@
+.. _propagator:
+
 ``propagator``
 ==============
 This module provides the functionality for creating propagator settings.

--- a/docs/source/radiation_pressure.rst
+++ b/docs/source/radiation_pressure.rst
@@ -124,14 +124,14 @@ Enumerations
 
    KnockeTypeSurfacePropertyDistributionModel
 
-   SphericalHarmonicSurfacePropertyDistribution
+   SphericalHarmonicsSurfacePropertyDistributionModel
 
 
 
 .. autoclass:: tudatpy.numerical_simulation.environment_setup.radiation_pressure.KnockeTypeSurfacePropertyDistributionModel
    :members:
 
-.. autoclass:: tudatpy.numerical_simulation.environment_setup.radiation_pressure.SphericalHarmonicSurfacePropertyDistribution
+.. autoclass:: tudatpy.numerical_simulation.environment_setup.radiation_pressure.SphericalHarmonicsSurfacePropertyDistributionModel
    :members:
 
 

--- a/docs/source/radiation_pressure.rst
+++ b/docs/source/radiation_pressure.rst
@@ -1,3 +1,5 @@
+.. _radiation_pressure:
+
 ``radiation_pressure``
 ======================
 This module contains a set of factory functions for setting up the

--- a/docs/source/rigid_body.rst
+++ b/docs/source/rigid_body.rst
@@ -1,3 +1,5 @@
+.. _rigid_body:
+
 ``rigid_body``
 ==============
 This module contains a set of factory functions for setting up the

--- a/docs/source/root_finders.rst
+++ b/docs/source/root_finders.rst
@@ -1,3 +1,5 @@
+.. _root_finders:
+
 ``root_finders``
 ================
 Functions for root-finding of algebraic univariate functions using various algorithms. 

--- a/docs/source/rotation_model.rst
+++ b/docs/source/rotation_model.rst
@@ -1,3 +1,5 @@
+.. _rotation_model:
+
 ``rotation_model``
 ==================
 This module contains a set of factory functions for setting up the

--- a/docs/source/sbdb.rst
+++ b/docs/source/sbdb.rst
@@ -1,3 +1,5 @@
+.. _sbdb:
+
 ``sbdb``
 =================
 This module contains a wrapper for the SBDB (small-body database) interface of the astroquery package

--- a/docs/source/shape.rst
+++ b/docs/source/shape.rst
@@ -1,3 +1,5 @@
+.. _shape:
+
 ``shape``
 =========
 This module contains a set of factory functions for setting up the

--- a/docs/source/shape_based_thrust.rst
+++ b/docs/source/shape_based_thrust.rst
@@ -1,3 +1,5 @@
+.. _shape_based_thrust:
+
 ``shape_based_thrust``
 ======================
 Functionalities for shape-based low-thrust trajectory design.

--- a/docs/source/shape_based_thrust.rst
+++ b/docs/source/shape_based_thrust.rst
@@ -6,7 +6,8 @@ Functionalities for shape-based low-thrust trajectory design.
 
 This module provides the functionality for creating shape-based low-thrust trajectory design legs.
 Without using any numerical propagation, this generates a preliminary low-thrust trajectory using
-relatively simple (semi-)analytical methods
+relatively simple (semi-)analytical methods.
+For background information on the methods, see [1]_.
 
 
 

--- a/docs/source/shape_deformation.rst
+++ b/docs/source/shape_deformation.rst
@@ -1,3 +1,5 @@
+.. _shape_deformation:
+
 ``shape_deformation``
 =====================
 This module contains a set of factory functions for setting up the

--- a/docs/source/spice.rst
+++ b/docs/source/spice.rst
@@ -102,23 +102,3 @@ Functions
 
 
 
-
-
-Classes
--------
-.. currentmodule:: tudatpy.interface.spice
-
-.. autosummary::
-
-   SpiceEphemeris
-
-
-
-.. autoclass:: tudatpy.interface.spice.SpiceEphemeris
-   :members:
-   :special-members: __init__
-
-
-
-
-

--- a/docs/source/spice.rst
+++ b/docs/source/spice.rst
@@ -1,3 +1,5 @@
+.. _spice:
+
 ``spice``
 =========
 Interface to the SPICE package.

--- a/docs/source/thrust.rst
+++ b/docs/source/thrust.rst
@@ -1,3 +1,5 @@
+.. _thrust:
+
 ``thrust``
 ==========
 This module provides the functionality for creating thrust 

--- a/docs/source/time_conversion.rst
+++ b/docs/source/time_conversion.rst
@@ -1,3 +1,5 @@
+.. _time_conversion:
+
 ``time_conversion``
 ===================
 Conversions and computation on date and time.

--- a/docs/source/time_conversion.rst
+++ b/docs/source/time_conversion.rst
@@ -67,7 +67,7 @@ Functions
 
    modified_julian_day_to_julian_day
 
-   calendar_date_to_day_of_year
+   .. calendar_date_to_day_of_year
 
    year_and_days_in_year_to_calendar_date
 
@@ -132,7 +132,7 @@ Functions
 
 .. autofunction:: tudatpy.astro.time_conversion.modified_julian_day_to_julian_day
 
-.. autofunction:: tudatpy.astro.time_conversion.calendar_date_to_day_of_year
+.. .. autofunction:: tudatpy.astro.time_conversion.calendar_date_to_day_of_year
 
 .. autofunction:: tudatpy.astro.time_conversion.year_and_days_in_year_to_calendar_date
 

--- a/docs/source/torque.rst
+++ b/docs/source/torque.rst
@@ -1,3 +1,5 @@
+.. _torque:
+
 ``torque``
 ==========
 This module provides the functionality for creating torque settings.

--- a/docs/source/trajectory_design.rst
+++ b/docs/source/trajectory_design.rst
@@ -1,3 +1,5 @@
+.. _trajectory_design:
+
 ``trajectory_design``
 =====================
 Functionalities for trajectory design.

--- a/docs/source/transfer_trajectory.rst
+++ b/docs/source/transfer_trajectory.rst
@@ -1,3 +1,5 @@
+.. _transfer_trajectory:
+
 ``transfer_trajectory``
 =======================
 Functionalities for multiple-leg interplanetary transfer trajectories.

--- a/docs/source/two_body_dynamics.rst
+++ b/docs/source/two_body_dynamics.rst
@@ -1,3 +1,5 @@
+.. _two_body_dynamics:
+
 ``two_body_dynamics``
 =====================
 Functions for (semi-)analytical calculations in a simple two-body point-mass system.

--- a/docs/source/util.rst
+++ b/docs/source/util.rst
@@ -1,3 +1,5 @@
+.. _util:
+
 ``util``
 ========
 Miscellaneous utilities.

--- a/docs/source/vehicle_systems.rst
+++ b/docs/source/vehicle_systems.rst
@@ -1,3 +1,5 @@
+.. _vehicle_systems:
+
 ``vehicle_systems``
 ===================
 This module contains a set of factory functions for setting up physical and system properties of a vehicle.

--- a/src/tudatpy/astro/element_conversion/expose_element_conversion.cpp
+++ b/src/tudatpy/astro/element_conversion/expose_element_conversion.cpp
@@ -1305,7 +1305,7 @@ void expose_element_conversion( py::module& m )
            &tsi::getRotationFromJ2000ToEclipJ2000,
            R"doc(
 
- Provides the (constant) rotation matrix from the J2000 to the ECLIPJ2000 frame, as defined in the SPICE library (see :ref:`\`\`spice\`\`` for more details on our interface with this library).
+ Provides the (constant) rotation matrix from the J2000 to the ECLIPJ2000 frame, as defined in the SPICE library (see :ref:`spice` for more details on our interface with this library).
 
  Returns
  -------
@@ -1319,7 +1319,7 @@ void expose_element_conversion( py::module& m )
            &tsi::getRotationFromEclipJ2000ToJ2000,
            R"doc(
 
- Provides the (constant) rotation matrix from the ECLIPJ2000 to the J2000 frame, as defined in the SPICE library (see :ref:`\`\`spice\`\`` for more details on our interface with this library).
+ Provides the (constant) rotation matrix from the ECLIPJ2000 to the J2000 frame, as defined in the SPICE library (see :ref:`spice` for more details on our interface with this library).
 
  Returns
  -------

--- a/src/tudatpy/astro/time_conversion/expose_time_conversion.cpp
+++ b/src/tudatpy/astro/time_conversion/expose_time_conversion.cpp
@@ -665,6 +665,7 @@ In this example, the calendar date corresponding to when 122 days have passed in
  In this example, an amount of seconds since J2000 (January 1st 2000) is converted to the Julian date (in days since January 1st 4713 BC).
 
  .. code-block:: python
+ 
    # Define the amount of seconds since January 1st 2000
    seconds_since_J2000 = 706413165.1200145
    # Convert the amount of seconds since J2000 to the Julian date

--- a/src/tudatpy/astro/two_body_dynamics/expose_two_body_dynamics.cpp
+++ b/src/tudatpy/astro/two_body_dynamics/expose_two_body_dynamics.cpp
@@ -318,7 +318,7 @@ void expose_two_body_dynamics( py::module &m )
  Parameters
  ----------
  initial_kepler_elements : numpy.ndarray
-     Keplerian elements that are to be propagated (see :ref:`\`\`element_conversion\`\`` for order)
+     Keplerian elements that are to be propagated (see :ref:`element_conversion` for order)
  propagation_time : float
      Time for which the elements are to be propagated w.r.t. the initial elements
  gravitational_parameter : float

--- a/src/tudatpy/astro/two_body_dynamics/expose_two_body_dynamics.cpp
+++ b/src/tudatpy/astro/two_body_dynamics/expose_two_body_dynamics.cpp
@@ -324,7 +324,7 @@ void expose_two_body_dynamics( py::module &m )
  gravitational_parameter : float
      Gravitational parameter of central body used for propagation
  root_finder : RootFinder, default = None
-     Root finder used to solve Kepler's equation when converting mean to eccentric anomaly. When no root finder is specified, the default option of the mean to eccentric anomaly function is used (see :func:`~mean_to_eccentric_anomaly').
+     Root finder used to solve Kepler's equation when converting mean to eccentric anomaly. When no root finder is specified, the default option of the mean to eccentric anomaly function is used (see :func:`~tudatpy.astro.element_conversion.mean_to_eccentric_anomaly`).
  Returns
  -------
  numpy.ndarray

--- a/src/tudatpy/interface/spice/expose_spice.cpp
+++ b/src/tudatpy/interface/spice/expose_spice.cpp
@@ -586,17 +586,17 @@ void expose_spice( py::module &m )
 
  Loads the default spice kernels shopped with tudat. The kernels that are loaded are (in order):
 
- - pck00010.tpc - Orientation and size/shape data for natural bodies, based mainly on  IAU Working Group on Cartographic Coordinates and Rotational Elements, obtained from `here <https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/>`_
- - inpop19a_TDB_m100_p100_spice.tpc - Masses of solar system planets and large asteroids, as determined in INPOP19a ephemerides, obtained from `here <https://www.imcce.fr/recherche/equipes/asd/inpop/download19a>`_
- - NOE-4-2020.tpc - Mars and Martian moon masses; Mars rotation model, as determined/used in NOE Martian satellite ephemerides, obtained from `here <ftp://ftp.imcce.fr/pub/ephem/satel/NOE/MARS/2020/>`_
- - NOE-5-2021.tpc - Jupiter and selected Jovian moon (Io, Europa, Ganymede, Callisto, Amalthea) masses; Jupiter rotation model, as determined/used in NOE Jovian satellite ephemerides, obtained from `here <ftp://ftp.imcce.fr/pub/ephem/satel/NOE/JUPITER/2021/>`_
- - NOE-6-2018-MAIN-v2.tpc - Saturn and selected Saturnian moon (Mimas, Enceladus, Tethys, Dione, Rhea, Titan, Hyperion, Iapetus) masses; Saturn rotation model, as determined/used in NOE Saturnian satellite ephemerides, obtained from `here <ftp://ftp.imcce.fr/pub/ephem/satel/NOE/SATURNE/2018/>`_
- - codes_300ast_20100725.bsp - Ephemerides of 300 of of the largest asteroids, obtained from `here <https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/asteroids/>`_
- - inpop19a_TDB_m100_p100_spice.bsp - Ephemerides of Solar system planetary system barycenters, Sun, Moon, Earth and Pluto, as determined in INPOP19a ephemerides, obtained from `here <https://www.imcce.fr/recherche/equipes/asd/inpop/download19a>`_
- - NOE-4-2020.bsp - Mars, Phobos and Deimos ephemerides (w.r.t. Martian system barycenter), as determined/used in NOE Martian satellite ephemerides, obtained from  `here <ftp://ftp.imcce.fr/pub/ephem/satel/NOE/MARS/2020/>`_
- - NOE-5-2021.bsp - Jupiter, Io, Europa, Ganymede, Callisto, Amalthea ephemerides (w.r.t. Jovian system barycenter), as determined/used in NOE Jovian satellite ephemerides, obtained from  `here <ftp://ftp.imcce.fr/pub/ephem/satel/NOE/JUPITER/2021/>`_
- - NOE-6-2018-MAIN-v2.bsp - Saturn, Mimas, Enceladus, Tethys, Dione, Rhea, Titan, Hyperion, Iapetus ephemerides (w.r.t. Saturnian system barycenter), as determined/used in NOE Saturnian satellite ephemerides, obtained from  `here <ftp://ftp.imcce.fr/pub/ephem/satel/NOE/SATURNE/2018/>`_
- - naif0012.tls - Leap second kernel, obtained from `here <https://naif.jpl.nasa.gov/pub/naif/generic_kernels/lsk/>`_
+ - pck00010.tpc - Orientation and size/shape data for natural bodies, based mainly on  IAU Working Group on Cartographic Coordinates and Rotational Elements, obtained from `here <https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/>`__
+ - inpop19a_TDB_m100_p100_spice.tpc - Masses of solar system planets and large asteroids, as determined in INPOP19a ephemerides, obtained from `here <https://www.imcce.fr/recherche/equipes/asd/inpop/download19a>`__
+ - NOE-4-2020.tpc - Mars and Martian moon masses; Mars rotation model, as determined/used in NOE Martian satellite ephemerides, obtained from `here <ftp://ftp.imcce.fr/pub/ephem/satel/NOE/MARS/2020/>`__
+ - NOE-5-2021.tpc - Jupiter and selected Jovian moon (Io, Europa, Ganymede, Callisto, Amalthea) masses; Jupiter rotation model, as determined/used in NOE Jovian satellite ephemerides, obtained from `here <ftp://ftp.imcce.fr/pub/ephem/satel/NOE/JUPITER/2021/>`__
+ - NOE-6-2018-MAIN-v2.tpc - Saturn and selected Saturnian moon (Mimas, Enceladus, Tethys, Dione, Rhea, Titan, Hyperion, Iapetus) masses; Saturn rotation model, as determined/used in NOE Saturnian satellite ephemerides, obtained from `here <ftp://ftp.imcce.fr/pub/ephem/satel/NOE/SATURNE/2018/>`__
+ - codes_300ast_20100725.bsp - Ephemerides of 300 of of the largest asteroids, obtained from `here <https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/asteroids/>`__
+ - inpop19a_TDB_m100_p100_spice.bsp - Ephemerides of Solar system planetary system barycenters, Sun, Moon, Earth and Pluto, as determined in INPOP19a ephemerides, obtained from `here <https://www.imcce.fr/recherche/equipes/asd/inpop/download19a>`__
+ - NOE-4-2020.bsp - Mars, Phobos and Deimos ephemerides (w.r.t. Martian system barycenter), as determined/used in NOE Martian satellite ephemerides, obtained from  `here <ftp://ftp.imcce.fr/pub/ephem/satel/NOE/MARS/2020/>`__
+ - NOE-5-2021.bsp - Jupiter, Io, Europa, Ganymede, Callisto, Amalthea ephemerides (w.r.t. Jovian system barycenter), as determined/used in NOE Jovian satellite ephemerides, obtained from  `here <ftp://ftp.imcce.fr/pub/ephem/satel/NOE/JUPITER/2021/>`__
+ - NOE-6-2018-MAIN-v2.bsp - Saturn, Mimas, Enceladus, Tethys, Dione, Rhea, Titan, Hyperion, Iapetus ephemerides (w.r.t. Saturnian system barycenter), as determined/used in NOE Saturnian satellite ephemerides, obtained from  `here <ftp://ftp.imcce.fr/pub/ephem/satel/NOE/SATURNE/2018/>`__
+ - naif0012.tls - Leap second kernel, obtained from `here <https://naif.jpl.nasa.gov/pub/naif/generic_kernels/lsk/>`__
 
 
  Parameters

--- a/src/tudatpy/math/root_finders/expose_root_finders.cpp
+++ b/src/tudatpy/math/root_finders/expose_root_finders.cpp
@@ -45,7 +45,7 @@ void expose_root_finders( py::module &m )
                                                 "MaximumIterationHandling",
                                                 R"doc(
 
-         Enumeration of types of behaviour to be used when the convergence criterion on maximum number of iterations is reached.
+Enumeration of types of behaviour to be used when the convergence criterion on maximum number of iterations is reached.
 
 
 
@@ -55,17 +55,17 @@ void expose_root_finders( py::module &m )
             .value( "accept_result",
                     trf::MaximumIterationHandling::accept_result,
                     R"doc(
- The program will accept the root at the final iteration, without any additional output
+The program will accept the root at the final iteration, without any additional output
       )doc" )
             .value( "accept_result_with_warning",
                     trf::MaximumIterationHandling::accept_result_with_warning,
                     R"doc(
- The program will accept the root at the final iteration, but will print a warning to the terminal that the root finder may not have converged
+The program will accept the root at the final iteration, but will print a warning to the terminal that the root finder may not have converged
       )doc" )
             .value( "throw_exception",
                     trf::MaximumIterationHandling::throw_exception,
                     R"doc(
- The program will not accept the root at the final iteration, and will throw an exception
+The program will not accept the root at the final iteration, and will throw an exception
       )doc" )
             .export_values( );
 

--- a/src/tudatpy/numerical_simulation/environment/expose_environment.cpp
+++ b/src/tudatpy/numerical_simulation/environment/expose_environment.cpp
@@ -3027,14 +3027,14 @@ void expose_environment( py::module &m )
                   &tss::SystemOfBodies::getFrameOrientation,
                   R"doc(
 
-         Common global frame orientation for all bodies in this SystemOfBodies, described in more detail `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/frames_in_environment.html#frame-orientation>`_.
+         Common global frame orientation for all bodies in this SystemOfBodies, described in more detail `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/frames_in_environment.html#frame-orientation>`__.
 
      )doc" )
             .def( "global_frame_origin",
                   &tss::SystemOfBodies::getFrameOrigin,
                   R"doc(
 
-         Common global frame origin for all bodies in this SystemOfBodies, described in more detail `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/frames_in_environment.html#global-origin>`_.
+         Common global frame origin for all bodies in this SystemOfBodies, described in more detail `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/frames_in_environment.html#global-origin>`__.
 
      )doc" );
 

--- a/src/tudatpy/numerical_simulation/environment/expose_environment.cpp
+++ b/src/tudatpy/numerical_simulation/environment/expose_environment.cpp
@@ -444,7 +444,7 @@ void expose_environment( py::module &m )
 
 
          Base class for computing the current aerodynamic coefficients of the body. The implementation of the computation
-         depends on the choice of aerodynamic coefficient model (see :ref:`\`\`aerodynamic_coefficients\`\`` for available options).
+         depends on the choice of aerodynamic coefficient model (see :ref:`aerodynamic_coefficients` for available options).
          During the propagation, this object is automatically updated to the current state by the :class:`~AtmosphericFlightConditions` object.
          The user may override the current aerodynamic coefficients when using, for instance, a custom aerodynamic guidance model
          (see `here <https://docs.tudat.space/en/latest/_src_getting_started/_src_examples/notebooks/propagation/reentry_trajectory.html>`_ for an example).
@@ -1747,7 +1747,7 @@ void expose_environment( py::module &m )
 
          Function to get rotation matrix from body-fixed (target) frame to inertial (base) frame over time.
          The calculation of this rotation matrix depends on the specific rotation model that has been defined,
-         either from an a priori definition (see :ref:`\`\`rotation_model\`\`` submodule) or from processing
+         either from an a priori definition (see :ref:`rotation_model` submodule) or from processing
          the results of propagation of the rotational equations of motion.
 
 
@@ -1851,7 +1851,7 @@ void expose_environment( py::module &m )
 
          Function to get the body's angular velocity vector :math:`\boldsymbol{\omega}^{(B)}`, expressed in the body-fixed frame :math:`B`.
          The calculation of the angular velocity depends on the specific rotation model that has been defined,
-         either from an a priori definition (see :ref:`\`\`rotation_model\`\`` submodule) or from processing
+         either from an a priori definition (see :ref:`rotation_model` submodule) or from processing
          the results of propagation of the rotational equations of motion.
          Note that when numerically propagating rotational dynamics, this angular velocity vector is typically directly defined
          in the last three entries of the state vector.

--- a/src/tudatpy/numerical_simulation/environment_setup/ephemeris/expose_ephemeris.cpp
+++ b/src/tudatpy/numerical_simulation/environment_setup/ephemeris/expose_ephemeris.cpp
@@ -423,7 +423,7 @@ void expose_ephemeris_setup( py::module& m )
 
  Function for settings object, defining ephemeris model which represents an ideal Kepler orbit from the given Kepler elements.
  These are taken as the elements at the ``initial_state_epoch`` and propagated to any other time using the provided ``central_body_gravitational_parameter``.
- See `Element Types <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/available_state_definitions_conversions.html#element-types>`_ and the :ref:`\`\`astro\`\`` module for more details on orbital elements in tudat.
+ See `Element Types <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/available_state_definitions_conversions.html#element-types>`_ and the :ref:`astro` module for more details on orbital elements in tudat.
 
 
  Parameters
@@ -499,7 +499,7 @@ void expose_ephemeris_setup( py::module& m )
 
  Function for settings object, defining ephemeris model which represents an ideal Kepler orbit from an initial state from Spice.
  The Kepler elements inferred from the initial state are propagated to any other time using the provided ``central_body_gravitational_parameter``.
- See `Element Types <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/available_state_definitions_conversions.html#element-types>`_ and the :ref:`\`\`astro\`\`` module for more details on orbital elements in tudat.
+ See `Element Types <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/available_state_definitions_conversions.html#element-types>`_ and the :ref:`astro` module for more details on orbital elements in tudat.
 
 
  Parameters

--- a/src/tudatpy/numerical_simulation/environment_setup/expose_environment_setup.cpp
+++ b/src/tudatpy/numerical_simulation/environment_setup/expose_environment_setup.cpp
@@ -81,7 +81,7 @@ void expose_environment_setup( py::module &m )
 
          Object that defines the settings of the atmosphere model that is to be created. Note that wind model settings
          may be defined inside this object. A variable of this type is typically assigned by using a function from the
-         :ref:`\`\`atmosphere\`\`` module.
+         :ref:`atmosphere` module.
 
 
          :type: AtmosphereSettings
@@ -89,7 +89,7 @@ void expose_environment_setup( py::module &m )
             .def_readwrite( "ephemeris_settings", &tss::BodySettings::ephemerisSettings, R"doc(
 
          Object that defines the settings of the ephemeris model that is to be created. A variable of this type is typically
-         assigned by using a function from the :ref:`\`\`ephemeris\`\`` module.
+         assigned by using a function from the :ref:`ephemeris` module.
 
 
          :type: EphemerisSettings
@@ -99,7 +99,7 @@ void expose_environment_setup( py::module &m )
                             R"doc(
 
          Object that defines the settings of the gravity field model that is to be created. A variable of this type is typically
-         assigned by using a function from the :ref:`\`\`gravity_field\`\`` module.
+         assigned by using a function from the :ref:`gravity_field` module.
 
 
          :type: GravityFieldSettings
@@ -109,7 +109,7 @@ void expose_environment_setup( py::module &m )
                             R"doc(
 
          Object that defines the settings of the rotation model that is to be created. A variable of this type is typically
-         assigned by using a function from the :ref:`\`\`rotation_model\`\`` module.
+         assigned by using a function from the :ref:`rotation_model` module.
 
 
          :type: RotationModelSettings
@@ -119,7 +119,7 @@ void expose_environment_setup( py::module &m )
                             R"doc(
 
          Object that defines the settings of the shape model that is to be created. A variable of this type is typically
-         assigned by using a function from the :ref:`\`\`shape\`\`` module.
+         assigned by using a function from the :ref:`shape` module.
 
 
          :type: BodyShapeSettings
@@ -129,7 +129,7 @@ void expose_environment_setup( py::module &m )
                             R"doc(
 
          Object that defines the settings of the aerodynamic coefficient model that is to be created. A variable of this type is typically
-         assigned by using a function from the :ref:`\`\`aerodynamic_coefficients\`\`` module.
+         assigned by using a function from the :ref:`aerodynamic_coefficients` module.
 
 
          :type: AerodynamicCoefficientSettings
@@ -139,7 +139,7 @@ void expose_environment_setup( py::module &m )
                             R"doc(
 
          List of objects that define the settings of time variations of the gravity field variation models that are to be created. Variables in this list are typically
-         assigned by using a function from the :ref:`\`\`gravity_field_variations\`\`` module.
+         assigned by using a function from the :ref:`gravity_field_variations` module.
 
 
          :type: list[GravityFieldVariationSettings]
@@ -149,7 +149,7 @@ void expose_environment_setup( py::module &m )
                             R"doc(
 
          List of objects that define the settings of time variations of the exterior shape of natural bodies are to be created. Variables in this list are typically
-         assigned by using a function from the :ref:`\`\`shape_deformation\`\`` module.
+         assigned by using a function from the :ref:`shape_deformation` module.
 
 
          :type: list[BodyDeformationSettings]
@@ -162,7 +162,7 @@ void expose_environment_setup( py::module &m )
                             R"doc(
 
          Object that defines the settings of the body rigid body (mass, center of mass, inertia) properties that are to be created. A variable of this type is typically
-         assigned by using a function from the :ref:`\`\`rigid_body\`\`` module. Note that this setting does *not* define
+         assigned by using a function from the :ref:`rigid_body` module. Note that this setting does *not* define
          the gravity field, but rather only the mass, center of mass and inertia tensor.
 
 
@@ -173,7 +173,7 @@ void expose_environment_setup( py::module &m )
                             R"doc(
 
          Object that defines the settings of the radiation pressure target model that is to be created. A variable of this type is typically
-         assigned by using a function from the :ref:`\`\`radiation_pressure\`\`` module.
+         assigned by using a function from the :ref:`radiation_pressure` module.
 
 
          :type: RadiationPressureTargetModelSettings
@@ -183,7 +183,7 @@ void expose_environment_setup( py::module &m )
                             R"doc(
 
          Object that defines the settings of the radiation source model that is to be created. A variable of this type is typically
-         assigned by using a function from the :ref:`\`\`radiation_pressure\`\`` module.
+         assigned by using a function from the :ref:`radiation_pressure` module.
 
 
          :type: RadiationSourceModelSettings
@@ -192,7 +192,7 @@ void expose_environment_setup( py::module &m )
                     "vehicle_shape_settings", &tss::BodySettings::bodyExteriorPanelSettings_, R"doc(
 
          Object that defines the settings of an exterior panelled vehicle shape that is to be created. A variable of this type is typically
-         assigned by using a function from the :ref:`\`\`vehicle_systems\`\`` module.
+         assigned by using a function from the :ref:`vehicle_systems` module.
 
 
          :type: FullPanelledBodySettings
@@ -753,7 +753,7 @@ void expose_environment_setup( py::module &m )
  Function that creates a radiation pressure target model from settings, and adds it to an existing body.
 
  This function can be used to add a radiation pressure target model to an existing body. It requires
- settings for the radiation pressure target model, created using one of the functions from the :ref:`\`\`radiation_pressure\`\`` module.
+ settings for the radiation pressure target model, created using one of the functions from the :ref:`radiation_pressure` module.
  This function creates the actual target model from these settings, and assigns it to the
  selected body. In addition to the identifier for the body to which it is assigned, this function
  requires the full :class:`~tudatpy.numerical_simulation.environment.SystemOfBodies` as input, to facilitate
@@ -872,7 +872,7 @@ void expose_environment_setup( py::module &m )
  assigned to this engine model are:
 
  * The (constant) direction in body-fixed frame in which the engine is pointing (e.g. the body-fixed thrust direction when the engine is on)
- * Settings for computing the thrust magnitude (as a function of time and/or other parameters), using a suitable function from the :ref:`\`\`thrust\`\`` submodule
+ * Settings for computing the thrust magnitude (as a function of time and/or other parameters), using a suitable function from the :ref:`thrust` submodule
 
 
  Parameters

--- a/src/tudatpy/numerical_simulation/environment_setup/expose_environment_setup.cpp
+++ b/src/tudatpy/numerical_simulation/environment_setup/expose_environment_setup.cpp
@@ -139,7 +139,7 @@ void expose_environment_setup( py::module &m )
                             R"doc(
 
          List of objects that define the settings of time variations of the gravity field variation models that are to be created. Variables in this list are typically
-         assigned by using a function from the :ref:`gravity_field_variations` module.
+         assigned by using a function from the :ref:`gravity_field_variation` module.
 
 
          :type: list[GravityFieldVariationSettings]

--- a/src/tudatpy/numerical_simulation/environment_setup/gravity_field/expose_gravity_field.cpp
+++ b/src/tudatpy/numerical_simulation/environment_setup/gravity_field/expose_gravity_field.cpp
@@ -139,7 +139,7 @@ void expose_gravity_field_setup( py::module& m )
          Enumeration of predefined spherical harmonics models.
 
          Enumeration of predefined spherical harmonics models supported by tudat, for which thee coefficient files are automatically available (downloaded from
-         `here <https://github.com/tudat-team/tudat-resources/tree/master/resource/gravity_models>`_). The directory where these files are stored can be
+         `here <https://github.com/tudat-team/tudat-resources/tree/master/resource/gravity_models>`__). The directory where these files are stored can be
          extracted using the :func:`~tudatpy.data.get_gravity_models_path` function.
 
 
@@ -150,42 +150,42 @@ void expose_gravity_field_setup( py::module& m )
             .value( "egm96",
                     tss::SphericalHarmonicsModel::egm96,
                     R"doc(
- Coefficients for EGM96 Earth gravity field up to degree and order 200, (see `link <https://cddis.gsfc.nasa.gov/926/egm96/egm96.html>`_ )
+ Coefficients for EGM96 Earth gravity field up to degree and order 200, (see `link <https://cddis.gsfc.nasa.gov/926/egm96/egm96.html>`__ )
       )doc" )
             .value( "ggm02c",
                     tss::SphericalHarmonicsModel::ggm02c,
                     R"doc(
- Coefficients for the combined GGM02 Earth gravity field up to degree and order 200, (see `link <https://www2.csr.utexas.edu/grace/gravity/ggm02/>`_ )
+ Coefficients for the combined GGM02 Earth gravity field up to degree and order 200, (see `link <https://www2.csr.utexas.edu/grace/gravity/ggm02/>`__ )
       )doc" )
             .value( "ggm02s",
                     tss::SphericalHarmonicsModel::ggm02s,
                     R"doc(
- Coefficients for the GRACE-only GGM02 Earth gravity field up to degree and order 160, (see `link <https://www2.csr.utexas.edu/grace/gravity/ggm02/>`_ )
+ Coefficients for the GRACE-only GGM02 Earth gravity field up to degree and order 160, (see `link <https://www2.csr.utexas.edu/grace/gravity/ggm02/>`__ )
       )doc" )
             .value( "goco05c",
                     tss::SphericalHarmonicsModel::goco05c,
                     R"doc(
- Coefficients for the GOCO05c combined Earth gravity field up to degree and order 719, (see `link <https://www2.csr.utexas.edu/grace/gravity/ggm02/>`_ )
+ Coefficients for the GOCO05c combined Earth gravity field up to degree and order 719, (see `link <https://www2.csr.utexas.edu/grace/gravity/ggm02/>`__ )
       )doc" )
             .value( "glgm3150", tss::SphericalHarmonicsModel::glgm3150, R"doc(
- Coefficients for the GLGM3150 Moon gravity field up to degree and order 150, (see `link <https://pds.nasa.gov/ds-view/pds/viewProfile.jsp?dsid=LP-L-RSS-5-GLGM3/GRAVITY-V1.0>`_ )
+ Coefficients for the GLGM3150 Moon gravity field up to degree and order 150, (see `link <https://pds.nasa.gov/ds-view/pds/viewProfile.jsp?dsid=LP-L-RSS-5-GLGM3/GRAVITY-V1.0>`__ )
       )doc" )
             .value( "lpe200",
                     tss::SphericalHarmonicsModel::lpe200,
                     R"doc(
- Coefficients for the LPE200 Moon gravity field up to degree and order 200, (see `link <https://pds.nasa.gov/ds-view/pds/viewProfile.jsp?dsid=LP-L-RSS-5-GLGM3/GRAVITY-V1.0>`_ )
+ Coefficients for the LPE200 Moon gravity field up to degree and order 200, (see `link <https://pds.nasa.gov/ds-view/pds/viewProfile.jsp?dsid=LP-L-RSS-5-GLGM3/GRAVITY-V1.0>`__ )
       )doc" )
             .value( "gggrx1200", tss::SphericalHarmonicsModel::gggrx1200, R"doc(
- Coefficients for the GRGM1200A Moon gravity field up to degree and order 1199, (see `link <https://pgda.gsfc.nasa.gov/products/50>`_ )
+ Coefficients for the GRGM1200A Moon gravity field up to degree and order 1199, (see `link <https://pgda.gsfc.nasa.gov/products/50>`__ )
       )doc" )
             .value( "jgmro120d", tss::SphericalHarmonicsModel::jgmro120d, R"doc(
- Coefficients for the MRO120D Moon gravity field up to degree and order 120, (see `link <https://pds-geosciences.wustl.edu/mro/mro-m-rss-5-sdp-v1/mrors_1xxx/data/shadr/>`_ )
+ Coefficients for the MRO120D Moon gravity field up to degree and order 120, (see `link <https://pds-geosciences.wustl.edu/mro/mro-m-rss-5-sdp-v1/mrors_1xxx/data/shadr/>`__ )
       )doc" )
             .value( "jgmess160a", tss::SphericalHarmonicsModel::jgmess160a, R"doc(
- Coefficients for the MESS160A Moon gravity field up to degree and order 160, (see `link <https://pds-geosciences.wustl.edu/messenger/mess-h-rss_mla-5-sdp-v1/messrs_1001/data/shadr/jgmess_160a_sha.lbl>`_ )
+ Coefficients for the MESS160A Moon gravity field up to degree and order 160, (see `link <https://pds-geosciences.wustl.edu/messenger/mess-h-rss_mla-5-sdp-v1/messrs_1001/data/shadr/jgmess_160a_sha.lbl>`__ )
       )doc" )
             .value( "shgj180u", tss::SphericalHarmonicsModel::shgj180u, R"doc(
- Coefficients for the SHGJ180U Moon gravity field up to degree and order 180, (see `link <https://pds-geosciences.wustl.edu/mgn/mgn-v-rss-5-gravity-l2-v1/mg_5201/gravity/shgj120u.lbl>`_ )
+ Coefficients for the SHGJ180U Moon gravity field up to degree and order 180, (see `link <https://pds-geosciences.wustl.edu/mgn/mgn-v-rss-5-gravity-l2-v1/mg_5201/gravity/shgj120u.lbl>`__ )
       )doc" )
             .export_values( );
 
@@ -599,7 +599,7 @@ void expose_gravity_field_setup( py::module& m )
 
  Function to load a custom spherical harmonics gravity field settings from a file. The file should contain **fully normalized** spherical harmonic coefficients.
  The associated gravitational parameter and reference radius should be given in m^3/s^2 and m, respectively. The file format should be the same as that used for the files
- in the directories `here <https://github.com/tudat-team/tudat-resources/tree/master/resource/gravity_models>`_. Specifically, the file should contain
+ in the directories `here <https://github.com/tudat-team/tudat-resources/tree/master/resource/gravity_models>`__. Specifically, the file should contain
 
  - The first line should be a series of text blocks (typically numerical data). Two of these blocks (by default the first and second one) should be the gravitational parameter and reference radius, respectively. The text block should be separated by spaces, tabs and/or commas
  - Each subsequent line should contain a set of spherical harmonic coefficients (first ordered in ascending order by degree, then in ascending order by order), where the first, second, third and fourth value of the line should be: degree :math:`l`, order :math:`m`, normalized cosine coefficient :math:`\bar{C}_{lm}`, normalized sine coefficient :math:`\bar{S}_{lm}`. Additional entries (for instance with coefficient uncertainties) are ignored.
@@ -705,8 +705,8 @@ void expose_gravity_field_setup( py::module& m )
  This function uses the gravitational parameter to define the gravity field. To instead use the density
  constant see :func:`~tudatpy.astro.gravitation.polyhedron_from_density`. Since both models tend to be computationally intensive,
  it is recommended to use polyhedra with the lowest number of facets that allows meeting the desired accuracy. The number of facets of a polyhedron
- model can be reduced using any mesh processing software, for example `PyMeshLab <https://pymeshlab.readthedocs.io/en/latest/>`_.
- Additionally, different functions to process a polyhedron are available in `Polyhedron utilities <https://py.api.tudat.space/en/latest/polyhedron_utilities.html>`_.
+ model can be reduced using any mesh processing software, for example `PyMeshLab <https://pymeshlab.readthedocs.io/en/latest/>`__.
+ Additionally, different functions to process a polyhedron are available in `Polyhedron utilities <https://py.api.tudat.space/en/latest/polyhedron_utilities.html>`__.
 
 
  Parameters

--- a/src/tudatpy/numerical_simulation/environment_setup/gravity_field/expose_gravity_field.cpp
+++ b/src/tudatpy/numerical_simulation/environment_setup/gravity_field/expose_gravity_field.cpp
@@ -614,7 +614,7 @@ void expose_gravity_field_setup( py::module& m )
  maximum_order : int
      Maximum order of the coefficients that are to be loaded
  associated_reference_frame : str, default = ""
-     Name of the body-fixed reference frame to which the gravity field is to be fixed. If left empty, this reference frame will automatically be set to the body-fixed frame defined by this body's rotation (see :ref:`\`\`rotation_model\`\`` for specifying rotation models).
+     Name of the body-fixed reference frame to which the gravity field is to be fixed. If left empty, this reference frame will automatically be set to the body-fixed frame defined by this body's rotation (see :ref:`rotation_model` for specifying rotation models).
  gravitational_parameter_index : int, default = 0
      Index of the values in the file header (first line of file) that contains the gravitational parameter
  reference_radius_index : int, default = 1

--- a/src/tudatpy/numerical_simulation/environment_setup/ground_station/expose_ground_station.cpp
+++ b/src/tudatpy/numerical_simulation/environment_setup/ground_station/expose_ground_station.cpp
@@ -180,7 +180,7 @@ void expose_ground_station_setup( py::module &m )
  Function for creating settings for all DSN stations
 
  Function for creating settings for all DSN stations, defined by nominal positions and linear velocities, as defined
- by Cartesian elements in *DSN No. 810-005, 301, Rev. K*,  see `this link <https://deepspace.jpl.nasa.gov/dsndocs/810-005/301/301K.pdf>`_.
+ by Cartesian elements in *DSN No. 810-005, 301, Rev. K*,  see `this link <https://deepspace.jpl.nasa.gov/dsndocs/810-005/301/301K.pdf>`__.
  Note that calling these settings will use the Cartesian elements provided in this document (in ITRF93) and apply them to the Earth-fixed
  station positions, regardless of the selected Earth rotation model.
 
@@ -197,7 +197,7 @@ void expose_ground_station_setup( py::module &m )
 
  Function for creating settings for all EVN stations.
 
- Function for creating settings for all EVN stations. EVN stations are defined by nominal positions and linear velocities, as defined by the glo.sit station file, see `this link <https://gitlab.com/gofrito/pysctrack/-/blob/master/cats/glo.sit?ref_type=heads>`_.
+ Function for creating settings for all EVN stations. EVN stations are defined by nominal positions and linear velocities, as defined by the glo.sit station file, see `this link <https://gitlab.com/gofrito/pysctrack/-/blob/master/cats/glo.sit?ref_type=heads>`__.
  Note that calling these settings will use the Cartesian elements provided by these documents and apply them to the Earth-fixed station positions, regardless of the selected Earth rotation model.
 
  Returns
@@ -214,8 +214,8 @@ void expose_ground_station_setup( py::module &m )
  Function for creating settings for all DSN and EVN stations.
 
  Function for creating settings for all DSN and EVN stations.
- DSN stations are defined by nominal positions and linear velocities, as defined by Cartesian elements in DSN No. 810-005, 301, Rev. K., see `this link <https://deepspace.jpl.nasa.gov/dsndocs/810-005/301/301K.pdf>`_.
- EVN stations are defined by nominal positions and linear velocities, as defined by the glo.sit station file, see `this link <https://gitlab.com/gofrito/pysctrack/-/blob/master/cats/glo.sit?ref_type=heads>`_.
+ DSN stations are defined by nominal positions and linear velocities, as defined by Cartesian elements in DSN No. 810-005, 301, Rev. K., see `this link <https://deepspace.jpl.nasa.gov/dsndocs/810-005/301/301K.pdf>`__.
+ EVN stations are defined by nominal positions and linear velocities, as defined by the glo.sit station file, see `this link <https://gitlab.com/gofrito/pysctrack/-/blob/master/cats/glo.sit?ref_type=heads>`__.
  Note that calling these settings will use the Cartesian elements provided by these documents and apply them to the Earth-fixed station positions, regardless of the selected Earth rotation model.
 
  Returns

--- a/src/tudatpy/numerical_simulation/environment_setup/rotation_model/expose_rotation_model.cpp
+++ b/src/tudatpy/numerical_simulation/environment_setup/rotation_model/expose_rotation_model.cpp
@@ -744,7 +744,7 @@ void expose_rotation_model_setup( py::module &m )
 
  Function for creating a high-accuracy Mars rotation model, using the default parameters of `Konopliv et al. (2016) <https://www.sciencedirect.com/science/article/abs/pii/S0019103516001305>`_
  and the mathematical model of `Konopliv et al. (2006) <https://www.sciencedirect.com/science/article/pii/S0019103506000297>`_ . The rotation matrix formulation is given in Eq. (13)-(19) of that paper.
- Note that, at the moment, all parameters in this rotation model are hard coded, and cannot be adapted by the user (except by estimating a number of its constituent parameters, see :ref:`\`\`parameter\`\`` module )
+ Note that, at the moment, all parameters in this rotation model are hard coded, and cannot be adapted by the user (except by estimating a number of its constituent parameters, see :ref:`parameter` module )
  As such, this model is at present applicable to Mars rotation only. If you require more fine-grained control of the parameters, please contact the Tudat support team
 
 

--- a/src/tudatpy/numerical_simulation/estimation_setup/expose_estimation_setup.cpp
+++ b/src/tudatpy/numerical_simulation/estimation_setup/expose_estimation_setup.cpp
@@ -138,7 +138,7 @@ void expose_estimation_setup( py::module& m )
  Parameters
  ----------
  parameter_settings : list( :class:`~tudatpy.numerical_simulation.estimation_setup.parameter.EstimatableParameterSettings` )
-     List of objects that define the settings for the parameters that are to be created. Each entry in this list is typically created by a call to a function in the :ref:`\`\`parameter\`\`` module
+     List of objects that define the settings for the parameters that are to be created. Each entry in this list is typically created by a call to a function in the :ref:`parameter` module
 
  bodies : :class:`~tudatpy.numerical_simulation.environment.SystemOfBodies`
      Object consolidating all bodies and environment models, including ground station models, that constitute the physical environment.

--- a/src/tudatpy/numerical_simulation/estimation_setup/observation/expose_observation.cpp
+++ b/src/tudatpy/numerical_simulation/estimation_setup/observation/expose_observation.cpp
@@ -2163,6 +2163,7 @@ void expose_observation_setup( py::module& m )
          Examples
          --------
          .. code-block:: python
+        
              # Code snippet to show the creation of an ObservationBiasSettings object
              # using absolute and relative bias settings
              from tudatpy.numerical_simulation.estimation_setup import observation
@@ -2780,6 +2781,7 @@ void expose_observation_setup( py::module& m )
 
  Examples
  --------
+ 
  .. code-block:: python
 
      # Code snippet to print all available Observation Ancillary Variable Types

--- a/src/tudatpy/numerical_simulation/estimation_setup/observation/expose_observation.cpp
+++ b/src/tudatpy/numerical_simulation/estimation_setup/observation/expose_observation.cpp
@@ -219,22 +219,22 @@ void expose_observation_setup( py::module& m )
 
     py::enum_< tom::LinkEndType >( m, "LinkEndType", R"doc(
 
-         Enumeration of available link end types.
+Enumeration of available link end types.
 
- Examples
- --------
- .. code-block:: python
+Examples
+--------
+.. code-block:: python
 
-     # Code snippet to print all available Link End Types
-     from tudatpy.numerical_simulation import estimation_setup
+    # Code snippet to print all available Link End Types
+    from tudatpy.numerical_simulation import estimation_setup
 
-     # Check how many Link End Types are available in Tudatpy
-     num_link_end_types = len(estimation_setup.observation.LinkEndType.__members__)
-     print(f'The length of all available Tudatpy Link End Types is: {num_link_end_types}')
+    # Check how many Link End Types are available in Tudatpy
+    num_link_end_types = len(estimation_setup.observation.LinkEndType.__members__)
+    print(f'The length of all available Tudatpy Link End Types is: {num_link_end_types}')
 
-     # Print all available Link End Types using the "name" property
-     for i in range(num_link_end_types):
-         print(i, estimation_setup.observation.LinkEndType(i).name)
+    # Print all available Link End Types using the "name" property
+    for i in range(num_link_end_types):
+        print(i, estimation_setup.observation.LinkEndType(i).name)
 
 
 
@@ -701,21 +701,21 @@ void expose_observation_setup( py::module& m )
 
     py::enum_< tom::ObservableType >( m, "ObservableType", R"doc(
 
-         Enumeration of available observable types.
+Enumeration of available observable types.
 
- Examples
- --------
- .. code-block:: python
+Examples
+--------
+.. code-block:: python
 
-     # Code snippet to print all available Observable Types
-     from tudatpy.numerical_simulation import estimation_setup
+    # Code snippet to print all available Observable Types
+    from tudatpy.numerical_simulation import estimation_setup
 
-     num_observable_types = len(estimation_setup.observation.ObservableType.__members__)
-     print(f'The length of all available Tudatpy Observable Types is: {num_observable_types}')
+    num_observable_types = len(estimation_setup.observation.ObservableType.__members__)
+    print(f'The length of all available Tudatpy Observable Types is: {num_observable_types}')
 
-     # Print all available Observable Types using the "name" property
-     for i in range(num_observable_types):
-         print(i, estimation_setup.observation.ObservableType(i).name)
+    # Print all available Observable Types using the "name" property
+    for i in range(num_observable_types):
+        print(i, estimation_setup.observation.ObservableType(i).name)
 
 
 
@@ -881,21 +881,21 @@ void expose_observation_setup( py::module& m )
 
     py::enum_< tom::LightTimeFailureHandling >( m, "LightTimeFailureHandling", R"doc(
 
-         Enumeration of behaviour when failing to converge light-time with required settings.
+Enumeration of behaviour when failing to converge light-time with required settings.
 
- Examples
- --------
- .. code-block:: python
+Examples
+--------
+.. code-block:: python
 
-     # Code snippet to print all available Light Time Failure Handling Types
-     from tudatpy.numerical_simulation import estimation_setup
+    # Code snippet to print all available Light Time Failure Handling Types
+    from tudatpy.numerical_simulation import estimation_setup
 
-     num_LightTimeFailureHandling_types = len(estimation_setup.observation.LightTimeFailureHandling.__members__)
-     print(f'The length of all available Tudatpy Light Time Failure Handling Types is: {num_LightTimeFailureHandling_types}')
+    num_LightTimeFailureHandling_types = len(estimation_setup.observation.LightTimeFailureHandling.__members__)
+    print(f'The length of all available Tudatpy Light Time Failure Handling Types is: {num_LightTimeFailureHandling_types}')
 
-     # Print all available Observation Viability Types using the "name" property
-     for i in range(num_LightTimeFailureHandling_types):
-         print(i, estimation_setup.observation.LightTimeFailureHandling(i).name)
+    # Print all available Observation Viability Types using the "name" property
+    for i in range(num_LightTimeFailureHandling_types):
+        print(i, estimation_setup.observation.LightTimeFailureHandling(i).name)
 
 
 
@@ -2041,53 +2041,50 @@ void expose_observation_setup( py::module& m )
            py::arg( "perturbing_bodies" ),
            R"doc(
 
- Function for creating settings for first-order relativistic light-time corrections.
+Function for creating settings for first-order relativistic light-time corrections.
 
- Function for creating settings for first-order relativistic light-time corrections:  These corrections account for the delay in light travel time caused by stationary point masses, calculated up to
- :math:`c^{-2}` according to general relativity (e.g., Moyer, 2000). A key consideration in the model is the time at which the states of the perturbing bodies are evaluated. This depends on their involvement in the observation link ends:
+Function for creating settings for first-order relativistic light-time corrections:  These corrections account for the delay in light travel time caused by stationary point masses, calculated up to
+:math:`c^{-2}` according to general relativity (e.g., Moyer, 2000). A key consideration in the model is the time at which the states of the perturbing bodies are evaluated. This depends on their involvement in the observation link ends:
 
- * 1. **Perturbing Body as a Link End:**
- If the perturbing body (e.g., Earth) is directly involved in the observation (e.g., as the location of a transmitter or receiver):
+* 1. **Perturbing Body as a Link End:** If the perturbing body (e.g., Earth) is directly involved in the observation (e.g., as the location of a transmitter or receiver):
 
-     - The body's state is evaluated at the **transmission time** if it acts as the **transmitter**.
+    - The body's state is evaluated at the **transmission time** if it acts as the **transmitter**.
+    - The body's state is evaluated at the **reception time** if it acts as the **receiver**.
 
-     - The body's state is evaluated at the **reception time** if it acts as the **receiver**.
+* 2. **Perturbing Body Not as a Link End:** If the perturbing body is not part of the observation link ends, its state is evaluated at the **midpoint time** between the transmission and reception events.
 
- * 2. **Perturbing Body Not as a Link End:**
- If the perturbing body is not part of the observation link ends, its state is evaluated at the **midpoint time** between the transmission and reception events.
+Parameters
+----------
+perturbing_bodies : List[str]
+    A list containing the names of the bodies due to which the light-time correction is to be taken into account.
 
- Parameters
- ----------
- perturbing_bodies : List[str]
-     A list containing the names of the bodies due to which the light-time correction is to be taken into account.
+Returns
+-------
+:class:`~tudatpy.numerical_simulation.estimation_setup.observation.LightTimeCorrectionSettings`
+    Instance of the :class:`~tudatpy.numerical_simulation.estimation_setup.observation.LightTimeCorrectionSettings` configured to include
+    first-order relativistic light-time corrections.
 
- Returns
- -------
- :class:`~tudatpy.numerical_simulation.estimation_setup.observation.LightTimeCorrectionSettings`
-     Instance of the :class:`~tudatpy.numerical_simulation.estimation_setup.observation.LightTimeCorrectionSettings` configured to include
-     first-order relativistic light-time corrections.
+Examples
+--------
+.. code-block:: python
 
- Examples
- --------
- .. code-block:: python
+    # Code Snippet to showcase the use of the first_order_relativistic_light_time_correction function
+    from tudatpy.numerical_simulation.estimation_setup import observation
 
-     # Code Snippet to showcase the use of the first_order_relativistic_light_time_correction function
-     from tudatpy.numerical_simulation.estimation_setup import observation
+    # Create Link Ends dictionary
+    link_ends = dict()
+    link_ends[observation.receiver] = observation.body_origin_link_end_id("Earth")
+    link_ends[observation.transmitter] = observation.body_origin_link_end_id("Delfi-C3")
 
-     # Create Link Ends dictionary
-     link_ends = dict()
-     link_ends[observation.receiver] = observation.body_origin_link_end_id("Earth")
-     link_ends[observation.transmitter] = observation.body_origin_link_end_id("Delfi-C3")
+    # Create a Link Definition Object from link_ends dictionary
+    Link_Definition_Object = observation.LinkDefinition(link_ends)
 
-     # Create a Link Definition Object from link_ends dictionary
-     Link_Definition_Object = observation.LinkDefinition(link_ends)
+    # The function first_order_relativistic_light_time_correction() requires a list of strings (perturbing body/bodies) as input
+    perturbing_body = ['Earth']
+    doppler_observation_settings = observation.first_order_relativistic_light_time_correction(perturbing_body)
 
-     # The function first_order_relativistic_light_time_correction() requires a list of strings (perturbing body/bodies) as input
-     perturbing_body = ['Earth']
-     doppler_observation_settings = observation.first_order_relativistic_light_time_correction(perturbing_body)
-
-     # Show that it returns a LightTimeCorrectionSettings object.
-     print(doppler_observation_settings)
+    # Show that it returns a LightTimeCorrectionSettings object.
+    print(doppler_observation_settings)
 
      )doc" );
 
@@ -2696,7 +2693,7 @@ void expose_observation_setup( py::module& m )
 
  Parameters
  ----------
- bias_list : List[:class:`~tudatpy.numerical_simulation.estimation_setup.observation.ObservationBiasSettings]
+ bias_list : List[:class:`~tudatpy.numerical_simulation.estimation_setup.observation.ObservationBiasSettings`]
      A list containing the bias settings that are to be applied to the observable.
 
  Returns
@@ -2746,21 +2743,21 @@ void expose_observation_setup( py::module& m )
 
     py::enum_< tom::ObservationViabilityType >( m, "ObservationViabilityType", R"doc(
 
-         Enumeration of observation viability criterion types.
+Enumeration of observation viability criterion types.
 
- Examples
- --------
- .. code-block:: python
+Examples
+--------
+.. code-block:: python
 
-     # Code snippet to print all available Observation Viability Types
-     from tudatpy.numerical_simulation import estimation_setup
+    # Code snippet to print all available Observation Viability Types
+    from tudatpy.numerical_simulation import estimation_setup
 
-     num_observation_viability_types = len(estimation_setup.observation.ObservationViabilityType.__members__)
-     print(f'The length of all available Tudatpy Observation Viability Types is: {num_observation_viability_types}')
+    num_observation_viability_types = len(estimation_setup.observation.ObservationViabilityType.__members__)
+    print(f'The length of all available Tudatpy Observation Viability Types is: {num_observation_viability_types}')
 
-     # Print all available Observation Viability Types using the "name" property
-     for i in range(num_observation_viability_types):
-         print(i, estimation_setup.observation.ObservationViabilityType(i).name)
+    # Print all available Observation Viability Types using the "name" property
+    for i in range(num_observation_viability_types):
+        print(i, estimation_setup.observation.ObservationViabilityType(i).name)
 
 
 
@@ -2777,22 +2774,22 @@ void expose_observation_setup( py::module& m )
             "ObservationAncilliarySimulationVariable",
             R"doc(
 
-         Enumeration of observation ancillary variable types.
+Enumeration of observation ancillary variable types.
 
- Examples
- --------
- 
- .. code-block:: python
+Examples
+--------
 
-     # Code snippet to print all available Observation Ancillary Variable Types
-     from tudatpy.numerical_simulation import estimation_setup
+.. code-block:: python
 
-     num_observation_ancillary_variable_types = len(estimation_setup.observation.ObservationAncilliarySimulationVariable.__members__)
-     print(f'The length of all available Tudatpy  Observation Ancillary Variable Types is: {num_observation_ancillary_variable_types}')
+    # Code snippet to print all available Observation Ancillary Variable Types
+    from tudatpy.numerical_simulation import estimation_setup
 
-     # Print all Observation Ancillary Variable Types using the "name" property
-     for i in range(num_observation_ancillary_variable_types):
-         print(i, estimation_setup.observation.ObservationAncilliarySimulationVariable(i).name)
+    num_observation_ancillary_variable_types = len(estimation_setup.observation.ObservationAncilliarySimulationVariable.__members__)
+    print(f'The length of all available Tudatpy  Observation Ancillary Variable Types is: {num_observation_ancillary_variable_types}')
+
+    # Print all Observation Ancillary Variable Types using the "name" property
+    for i in range(num_observation_ancillary_variable_types):
+        print(i, estimation_setup.observation.ObservationAncilliarySimulationVariable(i).name)
 
 
 

--- a/src/tudatpy/numerical_simulation/estimation_setup/parameter/expose_parameter.cpp
+++ b/src/tudatpy/numerical_simulation/estimation_setup/parameter/expose_parameter.cpp
@@ -642,7 +642,7 @@ void expose_estimated_parameter_setup( py::module& m )
  Function for creating a (linear sensitivity) parameter settings object for the gravitational parameter of massive bodies.
  Using the gravitational parameter as estimatable parameter requires:
 
- * The body specified by the ``body`` parameter to be endowed with a gravity field (see :ref:`\`\`gravity_field\`\`` module for options)
+ * The body specified by the ``body`` parameter to be endowed with a gravity field (see :ref:`gravity_field` module for options)
  * Any dynamical or observational model to depend on the gravitational parameter of the body specified by the ``body`` parameter
 
 

--- a/src/tudatpy/numerical_simulation/expose_numerical_simulation_simulator.cpp
+++ b/src/tudatpy/numerical_simulation/expose_numerical_simulation_simulator.cpp
@@ -347,7 +347,7 @@ void expose_numerical_simulation_simulator( py::module &m )
     Function to create object that propagates the dynamics.
 
     Function to create object that propagates the dynamics, as specified by propagator settings, and the physical environment.
-    Depending on the specific input type (e.g. which function from the :ref:`\`\`propagator\`\`` module was used),
+    Depending on the specific input type (e.g. which function from the :ref:`propagator` module was used),
     a single-, multi- or hybrid-arc simulator is created. The environment is typically created by the :func:`~tudatpy.numerical_simulation.environment_setup.create_system_of_bodies`
     function.
 

--- a/src/tudatpy/numerical_simulation/expose_numerical_simulation_variational.cpp
+++ b/src/tudatpy/numerical_simulation/expose_numerical_simulation_variational.cpp
@@ -287,7 +287,7 @@ void expose_numerical_simulation_variational( py::module &m )
  Function to create object that propagates the dynamics and variational equations.
 
  Function to create object that propagates the dynamics and variational equations, as specified by propagator settings, the physical environment, and a set of parameters for which to compute the partials.
- Depending on the specific input type (e.g. which function from the :ref:`\`\`propagator\`\`` module was used to define the propagator settings),
+ Depending on the specific input type (e.g. which function from the :ref:`propagator` module was used to define the propagator settings),
  a single-, multi- or hybrid-arc variational solver is created. The environment is typically created by the :func:`~tudatpy.numerical_simulation.environment_setup.create_system_of_bodies`
  function. When using default settings, calling this function will automatically propagate the dynamics.
 

--- a/src/tudatpy/numerical_simulation/propagation/dependent_variable_dictionary.py
+++ b/src/tudatpy/numerical_simulation/propagation/dependent_variable_dictionary.py
@@ -33,11 +33,11 @@ class DependentVariableDictionary(dict):
     The goal of this class is to make dependent variable time history retrieval semantic and
     straight-forward:
 
-    ```
-    total_acceleration_history = dep_vars_dict[
-        propagation_setup.dependent_variable.total_acceleration("Delfi-C3")
-    ]
-    ```
+    .. code-block:: python
+
+        total_acceleration_history = dep_vars_dict[
+            propagation_setup.dependent_variable.total_acceleration("Delfi-C3")
+        ]
 
     Example usage:
     --------------
@@ -45,41 +45,38 @@ class DependentVariableDictionary(dict):
     See the example below. As you can see, we can use as keys either the
 
     * Original dependent variable settings object (`dependent_variables_to_save[0]`),
-
     * Or a newly created dependent variable settings object (`propagation_setup.dependent_variable.total_acceleration("Delfi-C3")`)
 
-    ```
-    # Create simulation object and propagate the dynamics
-    dynamics_simulator = numerical_simulation.create_dynamics_simulator(
-        bodies, propagator_settings
-    )
+    .. code-block:: python
 
-    # Create DependentVariableDictionary
-    dep_vars_dict = result2dict(dynamics_simulator)
+        # Create simulation object and propagate the dynamics
+        dynamics_simulator = numerical_simulation.create_dynamics_simulator(
+            bodies, propagator_settings
+        )
 
-    # Retrieve the time history (in `dict[epoch: value]` form) of the total acceleration experienced by Delft-C3
-    total_acceleration_history = dep_vars_dict[
-        # This can be done using either the `SingleAccelerationDependentVariableSaveSettings`
-        # corresponding to this dependent variable
-        dependent_variables_to_save[0]
-    ]
-    total_acceleration_history = dep_vars_dict[
-        # Or a newly created one
-        propagation_setup.dependent_variable.total_acceleration("Delfi-C3")
-    ]
-    ```
+        # Create DependentVariableDictionary
+        dep_vars_dict = result2dict(dynamics_simulator)
+
+        # Retrieve the time history (in `dict[epoch: value]` form) of the total acceleration experienced by Delft-C3
+        total_acceleration_history = dep_vars_dict[
+            # This can be done using either the `SingleAccelerationDependentVariableSaveSettings`
+            # corresponding to this dependent variable
+            dependent_variables_to_save[0]
+        ]
+        total_acceleration_history = dep_vars_dict[
+            # Or a newly created one
+            propagation_setup.dependent_variable.total_acceleration("Delfi-C3")
+        ]
 
     How are time histories saved in a `DependentVariableDictionary`?
-    -----------------------------------------------------------
+    ----------------------------------------------------------------
 
     A `DependentVariableDictionary` maps which maps dependent variables, identified by either their
     corresponding dependent variable settings object (an instance of a `VariableSettings`-derived
     class) or its string ID, to their time histories.
 
     The time history of each dependent variable is a Python `dict` which maps epochs (`float`) to
-    NumPy arrays (`np.ndarray`) of shape `(A, B)`:
-
-        dict[epoch: np.ndarray[A, B]]
+    NumPy arrays (`np.ndarray`) of shape `(A, B)`: dict[epoch: np.ndarray[A, B]].
 
     **Important**: in `(A, B)`, we remove singleton/trivial dimensions (dimensions, `A` or `B`, of size 1).
     In the case of scalar dependent variables, the value associated to each epoch is a `np.ndarray` of shape `(1,)`.
@@ -92,10 +89,14 @@ class DependentVariableDictionary(dict):
     | Data Type | Shape       |
     +===========+=============+
     | Scalar    | `(1,)`      |
+    +-----------+-------------+
     | Vectorial | `(3,)`      |
+    +-----------+-------------+
     | Matrix    | `(A, B)`    |
+    +-----------+-------------+
     | Tensor    | `(A, B, C)` |
-    +===========+=============+
+    +-----------+-------------+
+
     """
 
     def __read_key(self, key: VariableSettings):
@@ -178,9 +179,9 @@ class DependentVariableDictionary(dict):
 
         Output
         ------
+            Time history of the dependent variable, returned as a `dict` mapping epochs (`float`)
+            to `np.ndarray`s containing the value of the dependent variable at each given epoch.
 
-        * Time history of the dependent variable, returned as a `dict` mapping epochs (`float`)
-          to `np.ndarray`s containing the value of the dependent variable at each given epoch.
         """
         try:
             return super().__getitem__(self.__read_key(__key))
@@ -235,11 +236,13 @@ class DependentVariableDictionary(dict):
 
         Arguments
         ---------
-        - key: dependent variable settings object or string ID of the dependent variable
+        key : VariableSettings
+            dependent variable settings object or string ID of the dependent variable
 
-        Output
+        Returns
         ------
-        - time_history: time history of the dependent variable, returned as a NumPy array
+        time_history : np.ndarray
+            time history of the dependent variable, returned as a NumPy array
         """
         return np.array(list(self[key].values()))
 
@@ -254,11 +257,13 @@ def create_dependent_variable_dictionary(
 
     Arguments
     ---------
-    - dynamics_simulator: `SingleArcSimulator` object containing the results of the numerical propagation
+    dynamics_simulator : SingleArcSimulator
+        `SingleArcSimulator` object containing the results of the numerical propagation
 
-    Output
+    Returns
     ------
-    - dependent_variable_dictionary: `DependentVariableDictionary` of propagation
+    dependent_variable_dictionary : DependentVariableDictionary
+        `DependentVariableDictionary` of propagation
     """
 
     # --------------------------------------------------------------------

--- a/src/tudatpy/numerical_simulation/propagation_setup/acceleration/expose_acceleration.cpp
+++ b/src/tudatpy/numerical_simulation/propagation_setup/acceleration/expose_acceleration.cpp
@@ -395,7 +395,7 @@ void expose_acceleration_setup( py::module &m )
 
  with :math:`\mathbf{r}` the position vector measured from the center of mass of the body exerting the acceleration.
 
- The body exerting the acceleration needs to have a gravity field model (:ref:`\`\`gravity_field\`\`` module) defined to use this acceleration.
+ The body exerting the acceleration needs to have a gravity field model (:ref:`gravity_field` module) defined to use this acceleration.
 
  Depending on the body undergoing the acceleration :math:`A`, the body exerting the acceleration :math:`B`, and the central body of propagation :math:`C`, choosing this option may create a direct point-mass attraction (:math:`\mu=\mu_{B}`), a central point-mass attraction (:math:`\mu=\mu_{B}+\mu_{A}`) or a third-body point-mass attraction (see `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/translational/third_body_acceleration.html>`_ for more details).
 
@@ -437,7 +437,7 @@ void expose_acceleration_setup( py::module &m )
 
  with :math:`\mathbf{R}^{(I/\text{Aero})}` the rotation matrix from the aerodynamic frame of the body undergoing acceleration to the inertial frame (computed from the body's current state, and the rotation of the body exerting the acceleration), :math:`\rho` the local freestream atmospheric density, :math:`v_{\text{air}}` the airspeed,  :math:`C_{D,S,L}` the drag, side and lift coefficients (which may depend on any number of properties of the body/environment) with reference area :math:`S_{ref}`, and :math:`m` the mass of the body undergoing acceleration
  The body exerting the acceleration needs to have an
- atmosphere (:ref:`\`\`atmosphere\`\`` module), shape (:ref:`\`\`shape\`\`` module) and rotation model (:ref:`\`\`rotation_model\`\`` module) defined. The body undergoing the acceleration needs to have aerodynamic coefficients (:ref:`\`\`aerodynamic_coefficients\`\`` module) defined.
+ atmosphere (:ref:`atmosphere` module), shape (:ref:`shape` module) and rotation model (:ref:`rotation_model` module) defined. The body undergoing the acceleration needs to have aerodynamic coefficients (:ref:`aerodynamic_coefficients` module) defined.
 
  Returns
  -------
@@ -544,7 +544,7 @@ void expose_acceleration_setup( py::module &m )
 
  with :math:`\mathbf{r}` the position vector measured from the center of mass of the body exerting the acceleration, :math:`\mathbf{R}^{(I/B)}` the rotation matrix from body-fixed to inertial frame, and :math:`\nabla^{(B)}` the gradient operator in a body-fixed frame, and :math:`U` the spherical harmonic gravitational potential, expanded up to the provided ``maximum_degree`` and ``maximum_order``.
 
- The body exerting the acceleration needs to have a spherical harmonic gravity field model (see :class:`~tudatpy.numerical_simulation.environment_setup.gravity_field.spherical_harmonic`) and a rotation model (:ref:`\`\`rotation_model\`\`` module) defined.
+ The body exerting the acceleration needs to have a spherical harmonic gravity field model (see :class:`~tudatpy.numerical_simulation.environment_setup.gravity_field.spherical_harmonic`) and a rotation model (:ref:`rotation_model` module) defined.
 
  Depending on the body undergoing the acceleration :math:`A`, the body exerting the acceleration :math:`B`, and the central body of propagation :math:`C`, choosing this option may create a direct spherical harmonic attraction (:math:`\mu=\mu_{B}`), a central spherical harmonic attraction (:math:`\mu=\mu_{B}+\mu_{A}`) or a third-body spherical harmonic attraction (see `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/translational/third_body_acceleration.html>`_ for more details).
 

--- a/src/tudatpy/numerical_simulation/propagation_setup/propagator/expose_propagator.cpp
+++ b/src/tudatpy/numerical_simulation/propagation_setup/propagator/expose_propagator.cpp
@@ -99,7 +99,7 @@ void expose_propagator_setup( py::module &m )
          entries of the processed state vector are to be printed to
          the console (after the propagation). The distinction between the
          propagated and processed (or conventional) state representation is described in
-         detail `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/processed_propagated_elements.html>`_.
+         detail `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/processed_propagated_elements.html>`__.
          Summarizing: the processed state is the 'typical' formulation of the state (for translational dynamics: Cartesian states).
 
          .. note:: The same information can be retrieved from the
@@ -271,7 +271,7 @@ void expose_propagator_setup( py::module &m )
          variable is set to True, the properties of the propagated
          :class:`~tudatpy.numerical_simulation.environment.Body`
          object will be updated as per the numerical results
-         (see `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/printing_processing_results.html#automatic-processing>`_ for details).
+         (see `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/printing_processing_results.html#automatic-processing>`__ for details).
 
 
          :type: bool
@@ -567,7 +567,7 @@ Enumeration of available rotational propagator types.
             .value( "quaternions",
                     tp::RotationalPropagatorType::quaternions,
                     R"doc(
-Entries 1-4: The quaternion defining the rotation from inertial to body-fixed frame (see `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/frames_in_environment.html#definition-of-rotational-state>`_)
+Entries 1-4: The quaternion defining the rotation from inertial to body-fixed frame (see `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/frames_in_environment.html#definition-of-rotational-state>`__)
 
 Entries 5-7: The body's angular velocity vector, expressed in its body-fixed frame.
       )doc" )
@@ -900,7 +900,7 @@ The propagated state vector is defined by the combination of integrated bodies, 
 of which define the relative translational states for which a differential equation is to be solved. The propagator
 input defines the formulation in which the differential equations are set up
 The dynamical models are defined by an ``AccelerationMap`` (dict[str, list[AccelerationModel]]), as created by :func:`~tudatpy.numerical_simulation.propagation_setup.create_acceleration_models` function.
-Details on the usage of this function are discussed in more detail in the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/translational.html>`_.
+Details on the usage of this function are discussed in more detail in the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/translational.html>`__.
 
 Parameters
 ----------
@@ -926,7 +926,7 @@ propagator : TranslationalPropagatorType, default=cowell
 output_variables : list[SingleDependentVariableSaveSettings], default=[]
     Object to define settings on how the numerical results are to be used, both during the propagation (printing to console) and after propagation (resetting environment)
 processing_settings: SingleArcPropagatorProcessingSettings, default=[]
-    Object to define how the numerical results are to be processed after the propagation terminates, and which information to print to the console during the propagation. See `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/printing_processing_results.html>`_ for details on all options.
+    Object to define how the numerical results are to be processed after the propagation terminates, and which information to print to the console during the propagation. See `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/printing_processing_results.html>`__ for details on all options.
     If this object is left empty default settings of the :class:`~SingleArcPropagatorProcessingSettings` class are used.
 
 Returns
@@ -984,7 +984,7 @@ differential equation defining the evolution of the rotational state between an
 inertial and body-fixed frame are to be solved. The propagator input defines the
 formulation in which the differential equations are set up. The dynamical models are
 defined by a ``TorqueModelMap``, as created by :func:`~tudatpy.numerical_simulation.propagation_setup.create_torque_models` function.
-Details on the usage of this function are discussed in more detail in the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/rotational.html>`_
+Details on the usage of this function are discussed in more detail in the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/rotational.html>`__
 
 
 Parameters
@@ -996,7 +996,7 @@ bodies_to_integrate : list[str]
 initial_states : numpy.ndarray
     Initial rotational states of the bodies to integrate (one initial state for each body), provided in the same order as the bodies to integrate.
     Regardless of the propagator that is selected, the initial rotational state is always defined as four quaternion entries, and the angular velocity of the body,
-    as defined in more detail `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/frames_in_environment.html#definition-of-rotational-state>`_.
+    as defined in more detail `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/frames_in_environment.html#definition-of-rotational-state>`__.
 initial_time : float
     Initial epoch of the numerical propagation
 integrator_settings : IntegratorSettings
@@ -1013,7 +1013,7 @@ propagator : RotationalPropagatorType, default=quaternions
 output_variables : list[SingleDependentVariableSaveSettings], default=[]
     Object to define settings on how the numerical results are to be used, both during the propagation (printing to console) and after propagation (resetting environment)
 processing_settings: SingleArcPropagatorProcessingSettings, default=[]
-    Object to define how the numerical results are to be processed after the propagation terminates, and which information to print to the console during the propagation. See `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/printing_processing_results.html>`_ for details on all options.
+    Object to define how the numerical results are to be processed after the propagation terminates, and which information to print to the console during the propagation. See `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/printing_processing_results.html>`__ for details on all options.
     If this object is left empty default settings of the :class:`~SingleArcPropagatorProcessingSettings` class are used.
 
 Returns
@@ -1067,7 +1067,7 @@ It works by providing a key-value mass rate container, containing the list of ma
 each body. In this function, the dependent variables to save are provided
 as a list of SingleDependentVariableSaveSettings objects. In this function, the termination conditions are set
 through the termination settings object provided.
-Details on the usage of this function are discussed in more detail in the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/mass.html>`_
+Details on the usage of this function are discussed in more detail in the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/mass.html>`__
 
 
 Parameters
@@ -1090,7 +1090,7 @@ termination_settings : PropagationTerminationSettings
 output_variables : list[SingleDependentVariableSaveSettings], default=[]
     Object to define settings on how the numerical results are to be used, both during the propagation (printing to console) and after propagation (resetting environment)
 processing_settings: SingleArcPropagatorProcessingSettings, default=[]
-    Object to define how the numerical results are to be processed after the propagation terminates, and which information to print to the console during the propagation. See `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/printing_processing_results.html>`_ for details on all options.
+    Object to define how the numerical results are to be processed after the propagation terminates, and which information to print to the console during the propagation. See `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/printing_processing_results.html>`__ for details on all options.
     If this object is left empty default settings of the :class:`~SingleArcPropagatorProcessingSettings` class are used.
 
 Returns
@@ -1126,7 +1126,7 @@ defined by accelerations (as is the case for translational state) or torques (as
 additional flexibility to define their own model by adding (for instance) the integration of co-states to the propagation without having to
 implement the governing dynamics into Tudat. This propagator requires a function of the form :math:`\frac{d\mathbf{x}}{dt}=\mathbf{f}(t,\mathbf{x})`,
 with :math:`t` the current time, :math:`\mathbf{x}` the current state, and :math:`\mathbf{f}` the state derivative function. This function can
-depend on any quantities of the user's choosing, for details on how to link the properties of the environment to this function, see `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/custom_models.html>`_.
+depend on any quantities of the user's choosing, for details on how to link the properties of the environment to this function, see `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/custom_models.html>`__.
 
 Parameters
 ----------
@@ -1146,7 +1146,7 @@ termination_settings : PropagationTerminationSettings
 output_variables : list[SingleDependentVariableSaveSettings], default=[]
     Object to define settings on how the numerical results are to be used, both during the propagation (printing to console) and after propagation (resetting environment)
 processing_settings: SingleArcPropagatorProcessingSettings, default=[]
-    Object to define how the numerical results are to be processed after the propagation terminates, and which information to print to the console during the propagation. See `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/printing_processing_results.html>`_ for details on all options.
+    Object to define how the numerical results are to be processed after the propagation terminates, and which information to print to the console during the propagation. See `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/printing_processing_results.html>`__ for details on all options.
     If this object is left empty default settings of the :class:`~SingleArcPropagatorProcessingSettings` class are used.
 
 Returns
@@ -1187,7 +1187,7 @@ Function to create multitype propagator settings.
 It works by providing a list of SingleArcPropagatorSettings objects. When using this function,
 only the termination and output settings provided here are used, any such settings in the
 constituent propagator settings are ignored
-Details on the usage of this function are discussed in more detail in the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/multi_type.html>`_
+Details on the usage of this function are discussed in more detail in the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/multi_type.html>`__
 
 .. note:: The propagated state contains the state types in the following order: Translational ( **C** ), Rotational ( **R** ), Mass ( **M** ), and Custom ( **C** ).
         When propagating two bodies, an example of what the output state would look like is for instance:
@@ -1210,7 +1210,7 @@ termination_settings : PropagationTerminationSettings
 output_variables : list[SingleDependentVariableSaveSettings], default=[]
     Object to define settings on how the numerical results are to be used, both during the propagation (printing to console) and after propagation (resetting environment)
 processing_settings: SingleArcPropagatorProcessingSettings, default=[]
-    Object to define how the numerical results are to be processed after the propagation terminates, and which information to print to the console during the propagation. See `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/printing_processing_results.html>`_ for details on all options.
+    Object to define how the numerical results are to be processed after the propagation terminates, and which information to print to the console during the propagation. See `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/printing_processing_results.html>`__ for details on all options.
     If this object is left empty default settings of the :class:`~SingleArcPropagatorProcessingSettings` class are used.
 
 Returns

--- a/src/tudatpy/numerical_simulation/propagation_setup/propagator/expose_propagator.cpp
+++ b/src/tudatpy/numerical_simulation/propagation_setup/propagator/expose_propagator.cpp
@@ -500,7 +500,7 @@ void expose_propagator_setup( py::module &m )
                                                   "TranslationalPropagatorType",
                                                   R"doc(
 
-         Enumeration of available translational propagator types.
+Enumeration of available translational propagator types.
 
 
 
@@ -514,38 +514,38 @@ void expose_propagator_setup( py::module &m )
             .value( "cowell",
                     tp::TranslationalPropagatorType::cowell,
                     R"doc(
- Propagation of Cartesian elements (state vector size 6), without any transformations
+Propagation of Cartesian elements (state vector size 6), without any transformations
       )doc" )
             .value( "encke",
                     tp::TranslationalPropagatorType::encke,
                     R"doc(
- Propagation of the difference in Cartesian elements of the orbit w.r.t. an unperturbed reference orbit. The reference orbit is generated from the initial state/central body, and not updated during the propagation (see Wakker, 2015 [2]_)
+Propagation of the difference in Cartesian elements of the orbit w.r.t. an unperturbed reference orbit. The reference orbit is generated from the initial state/central body, and not updated during the propagation (see Wakker, 2015 [2]_)
       )doc" )
             .value( "gauss_keplerian",
                     tp::TranslationalPropagatorType::gauss_keplerian,
                     R"doc(
- Propagation of Keplerian elements (state vector size 6), with true anomaly as the 'fast' element  (see Vallado, 2001 [4]_)
+Propagation of Keplerian elements (state vector size 6), with true anomaly as the 'fast' element  (see Vallado, 2001 [4]_)
       )doc" )
             .value( "gauss_modified_equinoctial",
                     tp::TranslationalPropagatorType::gauss_modified_equinoctial,
                     R"doc(
- Propagation of Modified equinoctial elements (state vector size 6), with the element :math:`I` defining the location of the singularity based on the initial condition (see Hintz, 2008 [3]_)
+Propagation of Modified equinoctial elements (state vector size 6), with the element :math:`I` defining the location of the singularity based on the initial condition (see Hintz, 2008 [3]_)
       )doc" )
             .value( "unified_state_model_quaternions",
                     tp::TranslationalPropagatorType::unified_state_model_quaternions,
                     R"doc(
- Propagation of Unified state model using quaternions (state vector size 7, see Vittaldev et al., 2012 [1]_)
+Propagation of Unified state model using quaternions (state vector size 7, see Vittaldev et al., 2012 [1]_)
       )doc" )
             .value( "unified_state_model_modified_rodrigues_parameters",
                     tp::TranslationalPropagatorType::
                             unified_state_model_modified_rodrigues_parameters,
                     R"doc(
- Propagation of Unified state model using modified Rodrigues parameters (state vector size 7, last element represents shadow parameter, see Vittaldev et al., 2012 [1]_)
+Propagation of Unified state model using modified Rodrigues parameters (state vector size 7, last element represents shadow parameter, see Vittaldev et al., 2012 [1]_)
       )doc" )
             .value( "unified_state_model_exponential_map",
                     tp::unified_state_model_exponential_map,
                     R"doc(
- Propagation of Unified state model using exponential map (state vector size 7, last element represents shadow parameter, see Vittaldev et al., 2012 [1]_)
+Propagation of Unified state model using exponential map (state vector size 7, last element represents shadow parameter, see Vittaldev et al., 2012 [1]_)
       )doc" )
             .export_values( );
 
@@ -553,7 +553,7 @@ void expose_propagator_setup( py::module &m )
                                                "RotationalPropagatorType",
                                                R"doc(
 
-         Enumeration of available rotational propagator types.
+Enumeration of available rotational propagator types.
 
 
 
@@ -567,23 +567,23 @@ void expose_propagator_setup( py::module &m )
             .value( "quaternions",
                     tp::RotationalPropagatorType::quaternions,
                     R"doc(
- Entries 1-4: The quaternion defining the rotation from inertial to body-fixed frame (see `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/frames_in_environment.html#definition-of-rotational-state>`_)
+Entries 1-4: The quaternion defining the rotation from inertial to body-fixed frame (see `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/frames_in_environment.html#definition-of-rotational-state>`_)
 
- Entries 5-7: The body's angular velocity vector, expressed in its body-fixed frame.
+Entries 5-7: The body's angular velocity vector, expressed in its body-fixed frame.
       )doc" )
             .value( "modified_rodrigues_parameters",
                     tp::RotationalPropagatorType::modified_rodrigues_parameters,
                     R"doc(
- Entries 1-4: The modified Rodrigues parameters defining the rotation from inertial to body-fixed frame (with entry four the shadow parameter)
+Entries 1-4: The modified Rodrigues parameters defining the rotation from inertial to body-fixed frame (with entry four the shadow parameter)
 
- Entries 5-7: The body's angular velocity vector, expressed in its body-fixed frame.
+Entries 5-7: The body's angular velocity vector, expressed in its body-fixed frame.
       )doc" )
             .value( "exponential_map",
                     tp::RotationalPropagatorType::exponential_map,
                     R"doc(
- Entries 1-4: The exponential map defining the rotation from inertial to body-fixed frame (with entry four the shadow parameter)
+Entries 1-4: The exponential map defining the rotation from inertial to body-fixed frame (with entry four the shadow parameter)
 
- Entries 5-7: The body's angular velocity vector, expressed in its body-fixed frame.
+Entries 5-7: The body's angular velocity vector, expressed in its body-fixed frame.
       )doc" )
             .export_values( );
 
@@ -591,7 +591,7 @@ void expose_propagator_setup( py::module &m )
                                                   "PropagationTerminationTypes",
                                                   R"doc(
 
-         Enumeration of possible propagation termination types
+Enumeration of possible propagation termination types
 
 
 
@@ -893,47 +893,46 @@ void expose_propagator_setup( py::module &m )
                    std::make_shared< tp::SingleArcPropagatorProcessingSettings >( ),
            R"doc(
 
- Function to create translational state propagator settings with stopping condition at given final time.
+Function to create translational state propagator settings with stopping condition at given final time.
 
- Function to create translational state propagator settings for N bodies.
- The propagated state vector is defined by the combination of integrated bodies, and their central body, the combination
- of which define the relative translational states for which a differential equation is to be solved. The propagator
- input defines the formulation in which the differential equations are set up
- The dynamical models are defined by an ``AccelerationMap`` (dict[str, list[AccelerationModel]]), as created by :func:`~tudatpy.numerical_simulation.propagation_setup.create_acceleration_models` function.
- Details on the usage of this function are discussed in more detail in the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/translational.html>`_.
+Function to create translational state propagator settings for N bodies.
+The propagated state vector is defined by the combination of integrated bodies, and their central body, the combination
+of which define the relative translational states for which a differential equation is to be solved. The propagator
+input defines the formulation in which the differential equations are set up
+The dynamical models are defined by an ``AccelerationMap`` (dict[str, list[AccelerationModel]]), as created by :func:`~tudatpy.numerical_simulation.propagation_setup.create_acceleration_models` function.
+Details on the usage of this function are discussed in more detail in the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/translational.html>`_.
 
+Parameters
+----------
+central_bodies : list[str]
+    List of central bodies with respect to which the bodies to be integrated are propagated.
+acceleration_models : dict[str, list[AccelerationModel]]
+    Set of accelerations acting on the bodies to propagate, provided as acceleration models.
+bodies_to_integrate : list[str]
+    List of bodies to be numerically propagated, whose order reflects the order of the central bodies.
+initial_states : numpy.ndarray
+    Initial states of the bodies to integrate (one initial state for each body, concatenated into a single array), provided in the same order as the bodies to integrate. The initial states must be expressed in Cartesian elements, w.r.t. the central body of each integrated body. The states must be defined with the same frame orientation as the global frame orientation of the environment (specified when creating a system of bodies, see for instance :func:`~tudatpy.numerical_simulation.environment_setup.get_default_body_settings` and :func:`~tudatpy.numerical_simulation.environment_setup.create_system_of_bodies`). Consequently, for N integrated bodies, this input is a vector with size size 6N.
+initial_time : float
+    Initial epoch of the numerical propagation
+integrator_settings : IntegratorSettings
+    Settings defining the numerical integrator that is to be used for the propagation
 
- Parameters
- ----------
- central_bodies : list[str]
-     List of central bodies with respect to which the bodies to be integrated are propagated.
- acceleration_models : dict[str, list[AccelerationModel]]
-     Set of accelerations acting on the bodies to propagate, provided as acceleration models.
- bodies_to_integrate : list[str]
-     List of bodies to be numerically propagated, whose order reflects the order of the central bodies.
- initial_states : numpy.ndarray
-     Initial states of the bodies to integrate (one initial state for each body, concatenated into a single array), provided in the same order as the bodies to integrate. The initial states must be expressed in Cartesian elements, w.r.t. the central body of each integrated body. The states must be defined with the same frame orientation as the global frame orientation of the environment (specified when creating a system of bodies, see for instance :func:`~tudatpy.numerical_simulation.environment_setup.get_default_body_settings` and :func:`~tudatpy.numerical_simulation.environment_setup.create_system_of_bodies`). Consequently, for N integrated bodies, this input is a vector with size size 6N.
- initial_time : float
-     Initial epoch of the numerical propagation
- integrator_settings : IntegratorSettings
-     Settings defining the numerical integrator that is to be used for the propagation
+    .. note:: The sign of the initial time step in the integrator settings defines whether the propagation will be forward or backward in time
 
-     .. note:: The sign of the initial time step in the integrator settings defines whether the propagation will be forward or backward in time
+termination_settings : PropagationTerminationSettings
+    Generic termination settings object to check whether the propagation should be ended.
+propagator : TranslationalPropagatorType, default=cowell
+    Type of translational propagator to be used (see `TranslationalPropagatorType` enum).
+output_variables : list[SingleDependentVariableSaveSettings], default=[]
+    Object to define settings on how the numerical results are to be used, both during the propagation (printing to console) and after propagation (resetting environment)
+processing_settings: SingleArcPropagatorProcessingSettings, default=[]
+    Object to define how the numerical results are to be processed after the propagation terminates, and which information to print to the console during the propagation. See `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/printing_processing_results.html>`_ for details on all options.
+    If this object is left empty default settings of the :class:`~SingleArcPropagatorProcessingSettings` class are used.
 
- termination_settings : PropagationTerminationSettings
-     Generic termination settings object to check whether the propagation should be ended.
- propagator : TranslationalPropagatorType, default=cowell
-     Type of translational propagator to be used (see `TranslationalPropagatorType` enum).
- output_variables : list[SingleDependentVariableSaveSettings], default=[]
-     Object to define settings on how the numerical results are to be used, both during the propagation (printing to console) and after propagation (resetting environment)
- processing_settings: SingleArcPropagatorProcessingSettings, default=[]
-     Object to define how the numerical results are to be processed after the propagation terminates, and which information to print to the console during the propagation. See `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/printing_processing_results.html>`_ for details on all options.
-     If this object is left empty default settings of the :class:`~SingleArcPropagatorProcessingSettings` class are used.
-
- Returns
- -------
- TranslationalStatePropagatorSettings
-     Translational state propagator settings object.
+Returns
+-------
+TranslationalStatePropagatorSettings
+    Translational state propagator settings object.
 
 
 
@@ -977,49 +976,50 @@ void expose_propagator_setup( py::module &m )
                    std::make_shared< tp::SingleArcPropagatorProcessingSettings >( ),
            R"doc(
 
- Function to create rotational state propagator settings.
+Function to create rotational state propagator settings.
 
- Function to create rotational state propagator settings for N bodies.
- The propagated state vector is defined by the integrated bodies, which defines the bodies for which the
- differential equation defining the evolution of the rotational state between an
- inertial and body-fixed frame are to be solved. The propagator input defines the
- formulation in which the differential equations are set up. The dynamical models are
- defined by a ``TorqueModelMap``, as created by :func:`~tudatpy.numerical_simulation.propagation_setup.create_torque_models` function.
- Details on the usage of this function are discussed in more detail in the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/rotational.html>`_
+Function to create rotational state propagator settings for N bodies.
+The propagated state vector is defined by the integrated bodies, which defines the bodies for which the
+differential equation defining the evolution of the rotational state between an
+inertial and body-fixed frame are to be solved. The propagator input defines the
+formulation in which the differential equations are set up. The dynamical models are
+defined by a ``TorqueModelMap``, as created by :func:`~tudatpy.numerical_simulation.propagation_setup.create_torque_models` function.
+Details on the usage of this function are discussed in more detail in the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/rotational.html>`_
 
 
- Parameters
- ----------
- torque_models : TorqueModelMap
-     Set of torques acting on the bodies to propagate, provided as torque models.
- bodies_to_integrate : list[str]
-     List of bodies to be numerically propagated, whose order reflects the order of the central bodies.
- initial_states : numpy.ndarray
-     Initial rotational states of the bodies to integrate (one initial state for each body), provided in the same order as the bodies to integrate.
-     Regardless of the propagator that is selected, the initial rotational state is always defined as four quaternion entries, and the angular velocity of the body,
-     as defined in more detail `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/frames_in_environment.html#definition-of-rotational-state>`_.
+Parameters
+----------
+torque_models : TorqueModelMap
+    Set of torques acting on the bodies to propagate, provided as torque models.
+bodies_to_integrate : list[str]
+    List of bodies to be numerically propagated, whose order reflects the order of the central bodies.
+initial_states : numpy.ndarray
+    Initial rotational states of the bodies to integrate (one initial state for each body), provided in the same order as the bodies to integrate.
+    Regardless of the propagator that is selected, the initial rotational state is always defined as four quaternion entries, and the angular velocity of the body,
+    as defined in more detail `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/frames_in_environment.html#definition-of-rotational-state>`_.
+initial_time : float
+    Initial epoch of the numerical propagation
+integrator_settings : IntegratorSettings
+    Settings defining the numerical integrator that is to be used for the propagation
 
- initial_time : float
-     Initial epoch of the numerical propagation
- integrator_settings : IntegratorSettings
-     Settings defining the numerical integrator that is to be used for the propagation
+    .. note:: 
+    
+        The sign of the initial time step in the integrator settings defines whether the propagation will be forward or backward in time
+    
+termination_settings : PropagationTerminationSettings
+    Generic termination settings object to check whether the propagation should be ended.
+propagator : RotationalPropagatorType, default=quaternions
+    Type of rotational propagator to be used (see `RotationalPropagatorType` enum).
+output_variables : list[SingleDependentVariableSaveSettings], default=[]
+    Object to define settings on how the numerical results are to be used, both during the propagation (printing to console) and after propagation (resetting environment)
+processing_settings: SingleArcPropagatorProcessingSettings, default=[]
+    Object to define how the numerical results are to be processed after the propagation terminates, and which information to print to the console during the propagation. See `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/printing_processing_results.html>`_ for details on all options.
+    If this object is left empty default settings of the :class:`~SingleArcPropagatorProcessingSettings` class are used.
 
-     .. note:: The sign of the initial time step in the integrator settings defines whether the propagation will be forward or backward in time
-
- termination_settings : PropagationTerminationSettings
-     Generic termination settings object to check whether the propagation should be ended.
- propagator : RotationalPropagatorType, default=quaternions
-     Type of rotational propagator to be used (see `RotationalPropagatorType` enum).
- output_variables : list[SingleDependentVariableSaveSettings], default=[]
-     Object to define settings on how the numerical results are to be used, both during the propagation (printing to console) and after propagation (resetting environment)
- processing_settings: SingleArcPropagatorProcessingSettings, default=[]
-     Object to define how the numerical results are to be processed after the propagation terminates, and which information to print to the console during the propagation. See `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/printing_processing_results.html>`_ for details on all options.
-     If this object is left empty default settings of the :class:`~SingleArcPropagatorProcessingSettings` class are used.
-
- Returns
- -------
- RotationalStatePropagatorSettings
-     Rotational state propagator settings object.
+Returns
+-------
+RotationalStatePropagatorSettings
+    Rotational state propagator settings object.
 
 
 
@@ -1060,43 +1060,43 @@ void expose_propagator_setup( py::module &m )
                    std::make_shared< tp::SingleArcPropagatorProcessingSettings >( ),
            R"doc(
 
- Function to create mass propagator settings
+Function to create mass propagator settings
 
- Function to create mass propagator settings
- It works by providing a key-value mass rate container, containing the list of mass rate settings objects associated to
- each body. In this function, the dependent variables to save are provided
- as a list of SingleDependentVariableSaveSettings objects. In this function, the termination conditions are set
- through the termination settings object provided.
- Details on the usage of this function are discussed in more detail in the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/mass.html>`_
+Function to create mass propagator settings
+It works by providing a key-value mass rate container, containing the list of mass rate settings objects associated to
+each body. In this function, the dependent variables to save are provided
+as a list of SingleDependentVariableSaveSettings objects. In this function, the termination conditions are set
+through the termination settings object provided.
+Details on the usage of this function are discussed in more detail in the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/mass.html>`_
 
 
- Parameters
- ----------
- bodies_with_mass_to_propagate : list[str]
-     List of bodies whose mass should be numerically propagated.
- mass_rate_models : SelectedMassRateModelMap
-     Mass rates associated to each body, provided as a mass rate settings object.
- initial_body_masses : numpy.ndarray
-     Initial masses of the bodies to integrate (one initial mass for each body), provided in the same order as the bodies to integrate.
- initial_time : float
-     Initial epoch of the numerical propagation
- integrator_settings : IntegratorSettings
-     Settings defining the numerical integrator that is to be used for the propagation
+Parameters
+----------
+bodies_with_mass_to_propagate : list[str]
+    List of bodies whose mass should be numerically propagated.
+mass_rate_models : SelectedMassRateModelMap
+    Mass rates associated to each body, provided as a mass rate settings object.
+initial_body_masses : numpy.ndarray
+    Initial masses of the bodies to integrate (one initial mass for each body), provided in the same order as the bodies to integrate.
+initial_time : float
+    Initial epoch of the numerical propagation
+integrator_settings : IntegratorSettings
+    Settings defining the numerical integrator that is to be used for the propagation
 
-     .. note:: The sign of the initial time step in the integrator settings defines whether the propagation will be forward or backward in time
+    .. note:: The sign of the initial time step in the integrator settings defines whether the propagation will be forward or backward in time
 
- termination_settings : PropagationTerminationSettings
-     Generic termination settings object to check whether the propagation should be ended.
- output_variables : list[SingleDependentVariableSaveSettings], default=[]
-     Object to define settings on how the numerical results are to be used, both during the propagation (printing to console) and after propagation (resetting environment)
- processing_settings: SingleArcPropagatorProcessingSettings, default=[]
-     Object to define how the numerical results are to be processed after the propagation terminates, and which information to print to the console during the propagation. See `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/printing_processing_results.html>`_ for details on all options.
-     If this object is left empty default settings of the :class:`~SingleArcPropagatorProcessingSettings` class are used.
+termination_settings : PropagationTerminationSettings
+    Generic termination settings object to check whether the propagation should be ended.
+output_variables : list[SingleDependentVariableSaveSettings], default=[]
+    Object to define settings on how the numerical results are to be used, both during the propagation (printing to console) and after propagation (resetting environment)
+processing_settings: SingleArcPropagatorProcessingSettings, default=[]
+    Object to define how the numerical results are to be processed after the propagation terminates, and which information to print to the console during the propagation. See `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/printing_processing_results.html>`_ for details on all options.
+    If this object is left empty default settings of the :class:`~SingleArcPropagatorProcessingSettings` class are used.
 
- Returns
- -------
- SingleArcPropagatorSettings
-     Mass propagator settings object.
+Returns
+-------
+SingleArcPropagatorSettings
+    Mass propagator settings object.
 
 
 
@@ -1118,41 +1118,41 @@ void expose_propagator_setup( py::module &m )
                    std::make_shared< tp::SingleArcPropagatorProcessingSettings >( ),
            R"doc(
 
- Function to create custom propagator settings.
+Function to create custom propagator settings.
 
- Function to create custom propagator settings.
- By using this propagator, the user can define their own differential equation to be solved, rather than have the differential equation be
- defined by accelerations (as is the case for translational state) or torques (as is the case for rotational state). This permits the user
- additional flexibility to define their own model by adding (for instance) the integration of co-states to the propagation without having to
- implement the governing dynamics into Tudat. This propagator requires a function of the form :math:`\frac{d\mathbf{x}}{dt}=\mathbf{f}(t,\mathbf{x})`,
- with :math:`t` the current time, :math:`\mathbf{x}` the current state, and :math:`\mathbf{f}` the state derivative function. This function can
- depend on any quantities of the user's choosing, for details on how to link the properties of the environment to this function, see `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/custom_models.html>`_.
+Function to create custom propagator settings.
+By using this propagator, the user can define their own differential equation to be solved, rather than have the differential equation be
+defined by accelerations (as is the case for translational state) or torques (as is the case for rotational state). This permits the user
+additional flexibility to define their own model by adding (for instance) the integration of co-states to the propagation without having to
+implement the governing dynamics into Tudat. This propagator requires a function of the form :math:`\frac{d\mathbf{x}}{dt}=\mathbf{f}(t,\mathbf{x})`,
+with :math:`t` the current time, :math:`\mathbf{x}` the current state, and :math:`\mathbf{f}` the state derivative function. This function can
+depend on any quantities of the user's choosing, for details on how to link the properties of the environment to this function, see `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/custom_models.html>`_.
 
- Parameters
- ----------
- state_derivative_function : callable[[float, numpy.ndarray[numpy.float64[m, 1]]], numpy.ndarray[numpy.float64[m, 1]]])
-     Function :math:`\mathbf{f}` (ser above) to compute the derivative of the current custom state
- initial_state : numpy.ndarray
-     Initial value of the propagated custom state
- initial_time : float
-     Initial epoch of the numerical propagation
- integrator_settings : IntegratorSettings
-     Settings defining the numerical integrator that is to be used for the propagation
+Parameters
+----------
+state_derivative_function : callable[[float, numpy.ndarray[numpy.float64[m, 1]]], numpy.ndarray[numpy.float64[m, 1]]])
+    Function :math:`\mathbf{f}` (ser above) to compute the derivative of the current custom state
+initial_state : numpy.ndarray
+    Initial value of the propagated custom state
+initial_time : float
+    Initial epoch of the numerical propagation
+integrator_settings : IntegratorSettings
+    Settings defining the numerical integrator that is to be used for the propagation
 
-     .. note:: The sign of the initial time step in the integrator settings defines whether the propagation will be forward or backward in time
+    .. note:: The sign of the initial time step in the integrator settings defines whether the propagation will be forward or backward in time
 
- termination_settings : PropagationTerminationSettings
-     Generic termination settings object to check whether the propagation should be ended.
- output_variables : list[SingleDependentVariableSaveSettings], default=[]
-     Object to define settings on how the numerical results are to be used, both during the propagation (printing to console) and after propagation (resetting environment)
- processing_settings: SingleArcPropagatorProcessingSettings, default=[]
-     Object to define how the numerical results are to be processed after the propagation terminates, and which information to print to the console during the propagation. See `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/printing_processing_results.html>`_ for details on all options.
-     If this object is left empty default settings of the :class:`~SingleArcPropagatorProcessingSettings` class are used.
+termination_settings : PropagationTerminationSettings
+    Generic termination settings object to check whether the propagation should be ended.
+output_variables : list[SingleDependentVariableSaveSettings], default=[]
+    Object to define settings on how the numerical results are to be used, both during the propagation (printing to console) and after propagation (resetting environment)
+processing_settings: SingleArcPropagatorProcessingSettings, default=[]
+    Object to define how the numerical results are to be processed after the propagation terminates, and which information to print to the console during the propagation. See `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/printing_processing_results.html>`_ for details on all options.
+    If this object is left empty default settings of the :class:`~SingleArcPropagatorProcessingSettings` class are used.
 
- Returns
- -------
- SingleArcPropagatorSettings
-     Custom propagator settings object.
+Returns
+-------
+SingleArcPropagatorSettings
+    Custom propagator settings object.
      )doc" );
 
     m.def( "multitype",
@@ -1181,42 +1181,42 @@ void expose_propagator_setup( py::module &m )
                    std::make_shared< tp::SingleArcPropagatorProcessingSettings >( ),
            R"doc(
 
- Function to create multitype propagator settings.
+Function to create multitype propagator settings.
 
- Function to create multitype propagator settings.
- It works by providing a list of SingleArcPropagatorSettings objects. When using this function,
- only the termination and output settings provided here are used, any such settings in the
- constituent propagator settings are ignored
- Details on the usage of this function are discussed in more detail in the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/multi_type.html>`_
+Function to create multitype propagator settings.
+It works by providing a list of SingleArcPropagatorSettings objects. When using this function,
+only the termination and output settings provided here are used, any such settings in the
+constituent propagator settings are ignored
+Details on the usage of this function are discussed in more detail in the `user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/multi_type.html>`_
 
- .. note:: The propagated state contains the state types in the following order: Translational ( **C** ), Rotational ( **R** ), Mass ( **M** ), and Custom ( **C** ).
-           When propagating two bodies, an example of what the output state would look like is for instance:
-           [ **T** Body 1, **T** Body 2, **R** Body 1, **R** Body 2, **M** Body 1, **M** Body 2 ]
+.. note:: The propagated state contains the state types in the following order: Translational ( **C** ), Rotational ( **R** ), Mass ( **M** ), and Custom ( **C** ).
+        When propagating two bodies, an example of what the output state would look like is for instance:
+        [ **T** Body 1, **T** Body 2, **R** Body 1, **R** Body 2, **M** Body 1, **M** Body 2 ]
 
 
- Parameters
- ----------
- propagator_settings_list : list[SingleArcPropagatorSettings]
-     List of SingleArcPropagatorSettings objects to use.
- integrator_settings : IntegratorSettings
-     Settings defining the numerical integrator that is to be used for the propagation
+Parameters
+----------
+propagator_settings_list : list[SingleArcPropagatorSettings]
+    List of SingleArcPropagatorSettings objects to use.
+integrator_settings : IntegratorSettings
+    Settings defining the numerical integrator that is to be used for the propagation
 
-     .. note:: The sign of the initial time step in the integrator settings defines whether the propagation will be forward or backward in time
+    .. note:: The sign of the initial time step in the integrator settings defines whether the propagation will be forward or backward in time
 
- initial_time : float
-     Initial epoch of the numerical propagation
- termination_settings : PropagationTerminationSettings
-     Generic termination settings object to check whether the propagation should be ended.
- output_variables : list[SingleDependentVariableSaveSettings], default=[]
-     Object to define settings on how the numerical results are to be used, both during the propagation (printing to console) and after propagation (resetting environment)
- processing_settings: SingleArcPropagatorProcessingSettings, default=[]
-     Object to define how the numerical results are to be processed after the propagation terminates, and which information to print to the console during the propagation. See `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/printing_processing_results.html>`_ for details on all options.
-     If this object is left empty default settings of the :class:`~SingleArcPropagatorProcessingSettings` class are used.
+initial_time : float
+    Initial epoch of the numerical propagation
+termination_settings : PropagationTerminationSettings
+    Generic termination settings object to check whether the propagation should be ended.
+output_variables : list[SingleDependentVariableSaveSettings], default=[]
+    Object to define settings on how the numerical results are to be used, both during the propagation (printing to console) and after propagation (resetting environment)
+processing_settings: SingleArcPropagatorProcessingSettings, default=[]
+    Object to define how the numerical results are to be processed after the propagation terminates, and which information to print to the console during the propagation. See `our user guide <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/printing_processing_results.html>`_ for details on all options.
+    If this object is left empty default settings of the :class:`~SingleArcPropagatorProcessingSettings` class are used.
 
- Returns
- -------
- MultiTypePropagatorSettings
-     Multi-type propagator settings object.
+Returns
+-------
+MultiTypePropagatorSettings
+    Multi-type propagator settings object.
 
      )doc" );
 
@@ -1229,22 +1229,22 @@ void expose_propagator_setup( py::module &m )
            py::arg( "processing_settings" ) = multiArcProcessingSettings( ),
            R"doc(
 
- Function to create multi-arc propagator settings.
+Function to create multi-arc propagator settings.
 
- Function to create multi-arc propagator settings. It works by providing separate settings for
- each arc in a list.
+Function to create multi-arc propagator settings. It works by providing separate settings for
+each arc in a list.
 
 
- Parameters
- ----------
- single_arc_settings : list[SingleArcPropagatorSettings]
-     List of SingleArcPropagatorSettings objects to use, one for each arc.
- transfer_state_to_next_arc : bool, default=False
-     Object to define settings on how the numerical results are to be used, both during the propagation (printing to console) and after propagation (resetting environment)
- Returns
- -------
- MultiArcPropagatorSettings
-     Multi-arc propagator settings object.
+Parameters
+----------
+single_arc_settings : list[SingleArcPropagatorSettings]
+    List of SingleArcPropagatorSettings objects to use, one for each arc.
+transfer_state_to_next_arc : bool, default=False
+    Object to define settings on how the numerical results are to be used, both during the propagation (printing to console) and after propagation (resetting environment)
+Returns
+-------
+MultiArcPropagatorSettings
+    Multi-arc propagator settings object.
 
 
 
@@ -1261,21 +1261,21 @@ void expose_propagator_setup( py::module &m )
                    std::make_shared< tp::HybridArcPropagatorProcessingSettings >( ),
            R"doc(
 
- Function to create hybrid-arc propagator settings.
+Function to create hybrid-arc propagator settings.
 
- Function to create hybrid-arc propagator settings (i.e., a combination of single- and multi-arc dynamics).
+Function to create hybrid-arc propagator settings (i.e., a combination of single- and multi-arc dynamics).
 
 
- Parameters
- ----------
- single_arc_settings : SingleArcPropagatorSettings
-     SingleArcPropagatorSettings object to use for the propagation.
- multi_arc_settings : MultiArcPropagatorSettings
-     Object to define settings on how the numerical results are to be used, both during the propagation (printing to console) and after propagation (resetting environment)
- Returns
- -------
- HybridArcPropagatorSettings
-     Hybrid-arc propagator settings object.
+Parameters
+----------
+single_arc_settings : SingleArcPropagatorSettings
+    SingleArcPropagatorSettings object to use for the propagation.
+multi_arc_settings : MultiArcPropagatorSettings
+    Object to define settings on how the numerical results are to be used, both during the propagation (printing to console) and after propagation (resetting environment)
+Returns
+-------
+HybridArcPropagatorSettings
+    Hybrid-arc propagator settings object.
 
 
 

--- a/src/tudatpy/numerical_simulation/propagation_setup/thrust/expose_thrust.cpp
+++ b/src/tudatpy/numerical_simulation/propagation_setup/thrust/expose_thrust.cpp
@@ -96,8 +96,6 @@ void expose_thrust_setup( py::module &m )
              Value of the constant thrust magnitude.
          specific_impulse : float
              Value of the constant specific impulse.
-         specific_impulse : numpy.ndarray
-             Thrust direction vector expressed in the body-fixed reference frame.
 
 
 


### PR DESCRIPTION
PR that addresses the numerous warnings when building the API docs. To keep the review (somewhat) manageable, this is the first PR with ~half the warnings fixed.

Main changes:
- Do not use `sphinx.ext.autosectionlabel` to avoid duplicate unnecessary labels for all the "Classes" and "Functions" headers. Add manual labels to the module headings, which are the ones that are actually referenced.
- Comment out functions/classes that have yet to be exposed. These have been added to #211 for future reference
- Use anonymous URL link names to avoid duplicate target labels
- Make indentation consistent where this was causing problems
- Other minor typos etc