### PR TITLE
Fix API doc warnings v2

### DIFF
--- a/docs/source/constants.rst
+++ b/docs/source/constants.rst
@@ -1,7 +1,7 @@
 .. _constants:
 
 ``constants``
-======
+=============
 This module contains constants that are used in the tudatpy library or commonly used in astrodynamic calculations.
 
 References

--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -1,7 +1,7 @@
 .. _data:
 
 ``data``
-======
+========
 Interfacing of Tudat(py) to and from other applications.
 
 

--- a/docs/source/ephemeris.rst
+++ b/docs/source/ephemeris.rst
@@ -142,7 +142,7 @@ Classes
 
    CustomEphemerisSettings
 
-   KeplerianEphemerisSettings
+   KeplerEphemerisSettings
 
    TabulatedEphemerisSettings
 
@@ -169,7 +169,7 @@ Classes
 .. autoclass:: tudatpy.numerical_simulation.environment_setup.ephemeris.CustomEphemerisSettings
    :members:
 
-.. autoclass:: tudatpy.numerical_simulation.environment_setup.ephemeris.KeplerianEphemerisSettings
+.. autoclass:: tudatpy.numerical_simulation.environment_setup.ephemeris.KeplerEphemerisSettings
    :members:
 
 .. autoclass:: tudatpy.numerical_simulation.environment_setup.ephemeris.TabulatedEphemerisSettings

--- a/docs/source/estimation.rst
+++ b/docs/source/estimation.rst
@@ -58,14 +58,6 @@ Classes
 
    ObservationViabilityCalculator
 
-   ObservationViabilityCalculator_1
-
-   ObservationViabilityCalculator_2
-
-   ObservationViabilityCalculator_3
-
-   ObservationViabilityCalculator_6
-
    ObservationSimulator
 
    ObservationCollection
@@ -90,18 +82,6 @@ Classes
    :members:
 
 .. autoclass:: tudatpy.numerical_simulation.estimation.ObservationViabilityCalculator
-   :members:
-
-.. autoclass:: tudatpy.numerical_simulation.estimation.ObservationViabilityCalculator_1
-   :members:
-
-.. autoclass:: tudatpy.numerical_simulation.estimation.ObservationViabilityCalculator_2
-   :members:
-
-.. autoclass:: tudatpy.numerical_simulation.estimation.ObservationViabilityCalculator_3
-   :members:
-
-.. autoclass:: tudatpy.numerical_simulation.estimation.ObservationViabilityCalculator_6
    :members:
 
 .. autoclass:: tudatpy.numerical_simulation.estimation.ObservationSimulator

--- a/docs/source/fundamentals.rst
+++ b/docs/source/fundamentals.rst
@@ -1,7 +1,7 @@
 .. _fundamentals:
 
 ``fundamentals``
-===============
+================
 Functions for fundamental astrodynamic calculations
 
 

--- a/docs/source/ground_station.rst
+++ b/docs/source/ground_station.rst
@@ -12,8 +12,7 @@ influence the numerical propagation (unless a custom model imposing this
 is implemented by the user). Ground stations can be defined through the 
 ``BodySettings`` as any other model. But, as the rest of the environment 
 does not depend on them, they can safely be added to a body after it is 
-created. The process is similar to the one described for :ref:`decorate_empty_body`. 
-Specifically, ground station settings are created, and these are then used 
+created. Specifically, ground station settings are created, and these are then used 
 to create a ground station and add it to the body. The specifics of creating
 ground station settings is described 
 `in the API documentation <https://py.api.tudat.space/en/latest/ground_stations.html>`_. 

--- a/src/tudatpy/astro/element_conversion/expose_element_conversion.cpp
+++ b/src/tudatpy/astro/element_conversion/expose_element_conversion.cpp
@@ -44,86 +44,116 @@ void expose_element_conversion( py::module& m )
     py::enum_< toec::KeplerianElementIndices >( m,
                                                 "KeplerianElementIndices",
                                                 R"doc(
-         Enumeration for indices of Keplerian elements"
-      )doc" )
+
+Enumeration for indices of Keplerian elements
+
+)doc" )
             .value( "semi_major_axis_index",
                     toec::KeplerianElementIndices::semiMajorAxisIndex,
                     R"doc(
- Element 0 in vector of Keplerian elements (for eccentricity not equal to 1.0)
-      )doc" )
+
+Element 0 in vector of Keplerian elements (for eccentricity not equal to 1.0)
+
+)doc" )
             .value( "semi_latus_rectum_index",
                     toec::KeplerianElementIndices::semiLatusRectumIndex,
                     R"doc(
- Element 0 in vector of Keplerian elements (for eccentricity equal to 1.0)
-      )doc" )
+
+Element 0 in vector of Keplerian elements (for eccentricity equal to 1.0)
+
+)doc" )
             .value( "eccentricity_index",
                     toec::KeplerianElementIndices::eccentricityIndex,
                     R"doc(
- Element 1 in vector of Keplerian elements
-      )doc" )
+
+Element 1 in vector of Keplerian elements
+
+)doc" )
             .value( "inclination_index",
                     toec::KeplerianElementIndices::inclinationIndex,
                     R"doc(
- Element 2 in vector of Keplerian elements
-      )doc" )
+
+Element 2 in vector of Keplerian elements
+
+)doc" )
             .value( "argument_of_periapsis_index",
                     toec::KeplerianElementIndices::argumentOfPeriapsisIndex,
                     R"doc(
- Element 3 in vector of Keplerian elements
-      )doc" )
+
+Element 3 in vector of Keplerian elements
+
+)doc" )
             .value( "longitude_of_ascending_node_index",
                     toec::KeplerianElementIndices::longitudeOfAscendingNodeIndex,
                     R"doc(
- Element 4 in vector of Keplerian elements
-      )doc" )
+
+Element 4 in vector of Keplerian elements
+
+)doc" )
             .value( "true_anomaly_index",
                     toec::KeplerianElementIndices::trueAnomalyIndex,
                     R"doc(
- Element 5 in vector of Keplerian elements
-      )doc" )
+
+Element 5 in vector of Keplerian elements
+
+)doc" )
             .export_values( );
 
     py::enum_< toec::SphericalOrbitalStateElementIndices >( m,
                                                             "SphericalOrbitalStateElementIndices",
                                                             R"doc(
-         Enumeration for indices of spherical orbital state elements"
-      )doc" )
+
+Enumeration for indices of spherical orbital state elements"
+
+)doc" )
             .value( "radius_index",
                     toec::SphericalOrbitalStateElementIndices::radiusIndex,
                     R"doc(
- Element 0 in vector of spherical orbital state elements
-      )doc" )
+
+Element 0 in vector of spherical orbital state elements
+
+)doc" )
             .value( "latitude_index",
                     toec::SphericalOrbitalStateElementIndices::latitudeIndex,
                     R"doc(
- Element 1 in vector of spherical orbital state elements
-      )doc" )
+
+Element 1 in vector of spherical orbital state elements
+
+)doc" )
             .value( "longitude_index",
                     toec::SphericalOrbitalStateElementIndices::longitudeIndex,
                     R"doc(
- Element 2 in vector of spherical orbital state elements
-      )doc" )
+
+Element 2 in vector of spherical orbital state elements
+
+)doc" )
             .value( "speed_index",
                     toec::SphericalOrbitalStateElementIndices::speedIndex,
                     R"doc(
- Element 3 in vector of spherical orbital state elements
-      )doc" )
+
+Element 3 in vector of spherical orbital state elements
+
+)doc" )
             .value( "flight_path_index",
                     toec::SphericalOrbitalStateElementIndices::flightPathIndex,
                     R"doc(
- Element 4 in vector of spherical orbital state elements
-      )doc" )
+
+Element 4 in vector of spherical orbital state elements
+
+)doc" )
             .value( "heading_angle_index",
                     toec::SphericalOrbitalStateElementIndices::headingAngleIndex,
                     R"doc(
- Element 5 in vector of spherical orbital state elements
-      )doc" )
+
+Element 5 in vector of spherical orbital state elements
+
+)doc" )
             .export_values( );
 
     py::enum_< tcc::PositionElementTypes >( m,
                                             "PositionElementTypes",
                                             R"doc(
- Enumeration describing different types of position element types (typically used for body-centered, body-0fixed position)
+Enumeration describing different types of position element types (typically used for body-centered, body-fixed position)
       )doc" )
             .value( "cartesian_position_type", tcc::PositionElementTypes::cartesian_position )
             .value( "spherical_position_type", tcc::PositionElementTypes::spherical_position )

--- a/src/tudatpy/data/mission_data_downloader.py
+++ b/src/tudatpy/data/mission_data_downloader.py
@@ -287,8 +287,7 @@ class LoadPDS:
             - timeout (int, optional): The timeout duration for the SPACIT process, default is 5 seconds.
 
         Output:
-            - str: The path to the output file (either .ck or .bsp), depending on the input file type.
-            If the output file already exists, the function returns the existing output file path.
+            - str: The path to the output file (either .ck or .bsp), depending on the input file type. If the output file already exists, the function returns the existing output file path.
 
         Notes:
             If the conversion fails or times out, an error message is printed.
@@ -510,7 +509,7 @@ class LoadPDS:
             - `input_mission` (`str`): The name of the mission
             - `url` (`str`): The base URL where the kernel files are hosted.
             - `wanted_files` (`list`, optional): A list of specific filenames to be downloaded from the URL.
-            - `wanted_files_pattern` (`str`, optional): A pattern (e.g., '*.tf') to match filenames for downloading.
+            - `wanted_files_pattern` (`str`, optional): A pattern (e.g., '\*.tf') to match filenames for downloading.
             - `custom_output` (`str`, optional): The local directory where the downloaded files will be stored.
 
         Output:
@@ -2235,14 +2234,10 @@ class LoadPDS:
 
         Outputs:
             - (`dict`, `dict`, `dict`): A tuple containing:
-                - `kernel_files_to_load` (`dict`): A dictionary where the keys are kernel types
-                (e.g., 'ck', 'spk', 'fk', 'sclk') and values are lists of paths to the successfully downloaded and loaded kernel files.
-                - `radio_science_files_to_load` (`dict`): A dictionary where keys are categories of
-                radio science data (e.g., 'ifms_dp2', 'dsn_dps') and values are lists of paths
-                to the successfully downloaded radio science files.
-                - `ancillary_files_to_load` (`dict`): A dictionary where keys are categories
-                of ancillary data (e.g., 'ion', 'tropospheric') and values are lists of paths
-                to the successfully downloaded ancillary files, such as tropospheric and ionospheric corrections.
+
+                - `kernel_files_to_load` (`dict`): A dictionary where the keys are kernel types (e.g., 'ck', 'spk', 'fk', 'sclk') and values are lists of paths to the successfully downloaded and loaded kernel files.
+                - `radio_science_files_to_load` (`dict`): A dictionary where keys are categories of radio science data (e.g., 'ifms_dp2', 'dsn_dps') and values are lists of paths to the successfully downloaded radio science files.
+                - `ancillary_files_to_load` (`dict`): A dictionary where keys are categories of ancillary data (e.g., 'ion', 'tropospheric') and values are lists of paths to the successfully downloaded ancillary files, such as tropospheric and ionospheric corrections.
         """
 
         self.radio_science_files_to_load = {}
@@ -2551,25 +2546,22 @@ class LoadPDS:
     ):
         """
         Description:
+
         Filters a mapping dictionary to extract entries based on a specified observation type and a date range.
         The function returns a new dictionary where each key corresponds to a filtered set of entries that match
         the specified observation type and fall within the given start and end dates.
 
         Inputs:
-            - mapping_dict (`dict`): A dictionary where keys represent categories and values are lists of entries.
-              Each entry is expected to be a dictionary containing:
-                - `start_date_utc` (`str`): The start date in UTC (format: YYYY-MM-DD).
-                - `radio_observation_type` (`str`): The type of observation.
+            - mapping_dict (`dict`): A dictionary where keys represent categories and values are lists of entries. Each entry is expected to be a dictionary containing:
+              - `start_date_utc` (`str`): The start date in UTC (format: YYYY-MM-DD).
+              - `radio_observation_type` (`str`): The type of observation.
 
             - radio_observation_type (`str`): The type of observation to filter by (e.g., 'Phobos Gravity').
-
             - start_date_mex (`str`): The start date for filtering in UTC (format: YYYY-MM-DD).
-
             - end_date_mex (`str`): The end date for filtering in UTC (format: YYYY-MM-DD).
 
         Outputs:
-            - `filtered_dict` (`dict`): A dictionary where keys are the same as in `mapping_dict`, and values are lists
-              of filtered entries that match the specified observation type and fall within the date range.
+            - `filtered_dict` (`dict`): A dictionary where keys are the same as in `mapping_dict`, and values are lists of filtered entries that match the specified observation type and fall within the date range.
         """
 
         filtered_dict = {
@@ -2600,15 +2592,12 @@ class LoadPDS:
         the specified observation type and fall within the given start and end dates.
 
         Inputs:
-            - mapping_dict (`dict`): A dictionary where keys represent categories and values are lists of entries.
-              Each entry is expected to be a dictionary containing:
+            - mapping_dict (`dict`): A dictionary where keys represent categories and values are lists of entries. Each entry is expected to be a dictionary containing:
                 - `start_date_utc` (`str`): The start date in UTC (format: YYYY-MM-DD).
                 - `radio_observation_type` (`str`): The type of observation.
 
             - radio_observation_type (`str`): The type of observation to filter by (e.g., 'Phobos Gravity').
-
             - start_date_mex (`str`): The start date for filtering in UTC (format: YYYY-MM-DD).
-
             - end_date_mex (`str`): The end date for filtering in UTC (format: YYYY-MM-DD).
 
         Outputs:
@@ -2645,12 +2634,13 @@ class LoadPDS:
             - url (`str`): The URL from which to fetch the data (plain text format).
 
         Outputs:
-            - `mapping_dict` (`dict`): A dictionary where keys are tuples of (start_date_utc, end_date_utc),
-              and values are dictionaries with:
+            - `mapping_dict` (`dict`): A dictionary where keys are tuples of (start_date_utc, end_date_utc), and values are dictionaries with:
+
                 - `volume_id` (`str`): The volume ID.
                 - `start_date_file` (`str`): Start date (YYYY-MM-DD).
                 - `end_date_file` (`str`): End date (YYYY-MM-DD).
                 - `radio_observation_type` (`str`): Type of observation.
+
         """
 
         # Step 1: Fetch content from the URL

--- a/src/tudatpy/math/interpolators/expose_interpolators.cpp
+++ b/src/tudatpy/math/interpolators/expose_interpolators.cpp
@@ -59,11 +59,11 @@ void expose_interpolators( py::module &m )
 {
     py::enum_< ti::BoundaryInterpolationType >( m, "BoundaryInterpolationType", R"doc(
 
-         Enumeration of types of behaviour to be used beyond the edges of the interpolation domain.
+Enumeration of types of behaviour to be used beyond the edges of the interpolation domain.
 
-         Enumeration of types of behaviour to be used beyond the edges of the interpolation domain. For independent variable
-         data in the range :math:`[t_{0}...t_{N}]`, this enum is used to define the behaviour of the interpolator at
-         :math:`t<t_{0}` and :math:`t>t_{N}`
+Enumeration of types of behaviour to be used beyond the edges of the interpolation domain. For independent variable
+data in the range :math:`[t_{0}...t_{N}]`, this enum is used to define the behaviour of the interpolator at
+:math:`t<t_{0}` and :math:`t>t_{N}`
 
 
 
@@ -73,27 +73,37 @@ void expose_interpolators( py::module &m )
             .value( "throw_exception_at_boundary",
                     ti::BoundaryInterpolationType::throw_exception_at_boundary,
                     R"doc(
- The program will terminate with an error message when the interpolator is interrogated beyond the range :math:`[t_{0}...t_{N}]`
+
+The program will terminate with an error message when the interpolator is interrogated beyond the range :math:`[t_{0}...t_{N}]`.
+
       )doc" )
             .value( "use_boundary_value",
                     ti::BoundaryInterpolationType::use_boundary_value,
                     R"doc(
- The value :math:`\mathbf{x}_{0}` is returned for :math:`t<t_{0}` (and :math:`\mathbf{x}_{N}` if :math:`t>t_{N}`)
+
+The value :math:`\mathbf{x}_{0}` is returned for :math:`t<t_{0}` (and :math:`\mathbf{x}_{N}` if :math:`t>t_{N}`).
+
       )doc" )
             .value( "use_boundary_value_with_warning",
                     ti::BoundaryInterpolationType::use_boundary_value_with_warning,
                     R"doc(
- Same as ``use_boundary_value``, but a warning is printed to the terminal
+
+Same as ``use_boundary_value``, but a warning is printed to the terminal.
+
       )doc" )
             .value( "extrapolate_at_boundary",
                     ti::BoundaryInterpolationType::extrapolate_at_boundary,
                     R"doc(
- The interpolation scheme is extended beyond the range :math:`t_{0}...t_{N}` without any warning. That is, the mathematical equation used to compute the value of :math:`x` in the range :math:`[t_{0}...t_{1}]` is used without any checks for :math:`t<t_{0}`  (and equivalently for :math:`t>t_{N}`). Warning, using this setting can result in divergent/unrealistic behaviour
+
+The interpolation scheme is extended beyond the range :math:`t_{0}...t_{N}` without any warning. That is, the mathematical equation used to compute the value of :math:`x` in the range :math:`[t_{0}...t_{1}]` is used without any checks for :math:`t<t_{0}`  (and equivalently for :math:`t>t_{N}`). Warning, using this setting can result in divergent/unrealistic behaviour.
+
       )doc" )
             .value( "extrapolate_at_boundary_with_warning",
                     ti::BoundaryInterpolationType::extrapolate_at_boundary_with_warning,
                     R"doc(
- Same as ``extrapolate_at_boundary``, but a warning is printed to the terminal
+
+Same as ``extrapolate_at_boundary``, but a warning is printed to the terminal.
+
       )doc" )
             //            .value("use_default_value",
             //            ti::BoundaryInterpolationType::use_default_value)
@@ -105,12 +115,12 @@ void expose_interpolators( py::module &m )
                                             "AvailableLookupScheme",
                                             R"doc(
 
-         Enumeration of types of behaviour to be used beyond the edges of the interpolation domain.
+Enumeration of types of behaviour to be used beyond the edges of the interpolation domain.
 
-         When the interpolation is performed, the interpolator scheme will typically start by finding the nearest neighbor of
-         the requested value of the independent variable :math:`t` in the data set :math:`[t_{0}...t_{N}]`.
-         The choice of lookup scheme can have a significant influence on computational efficiency for large data sets and/or simple
-         interpolation algorithms
+When the interpolation is performed, the interpolator scheme will typically start by finding the nearest neighbor of
+the requested value of the independent variable :math:`t` in the data set :math:`[t_{0}...t_{N}]`.
+The choice of lookup scheme can have a significant influence on computational efficiency for large data sets and/or simple
+interpolation algorithms
 
 
 
@@ -120,23 +130,27 @@ void expose_interpolators( py::module &m )
             .value( "hunting_algorithm",
                     ti::AvailableLookupScheme::huntingAlgorithm,
                     R"doc(
- With this option, the interpolator 'remembers' which value of :math:`t_{i}` was the nearest neighbor during the previous call to the interpolate function, and starts looking at/near this entry of the data set :math:`[t_{i}]` to find the nearest neighbor.
+
+With this option, the interpolator 'remembers' which value of :math:`t_{i}` was the nearest neighbor during the previous call to the interpolate function, and starts looking at/near this entry of the data set :math:`[t_{i}]` to find the nearest neighbor.
+
       )doc" )
             .value( "binary_search",
                     ti::AvailableLookupScheme::binarySearch,
                     R"doc(
- With this option, the algorithm uses a binary search algorithm to find the nearest neighbor, initially starting with the full data range :math:`[t_{0}...t_{N}]`.
+
+With this option, the algorithm uses a binary search algorithm to find the nearest neighbor, initially starting with the full data range :math:`[t_{0}...t_{N}]`.
+
       )doc" )
             .export_values( );
 
     py::enum_< ti::LagrangeInterpolatorBoundaryHandling >(
             m, "LagrangeInterpolatorBoundaryHandling", R"doc(
 
-         Enumeration of types of behaviour to be used close to the edges of the interpolation domain, for the Lagrange interpolator.
+Enumeration of types of behaviour to be used close to the edges of the interpolation domain, for the Lagrange interpolator.
 
-         Enumeration of types of behaviour to be used close to the edges of the interpolation domain, for the Lagrange interpolator.
-         As explained for :func:`lagrange_interpolation`, the algorithm for the Lagrange interpolation breaks down at the edges of
-         the interpolation domain. This enum provides the available options a user has to deal with this.
+Enumeration of types of behaviour to be used close to the edges of the interpolation domain, for the Lagrange interpolator.
+As explained for :func:`lagrange_interpolation`, the algorithm for the Lagrange interpolation breaks down at the edges of
+the interpolation domain. This enum provides the available options a user has to deal with this.
 
 
 
@@ -147,12 +161,16 @@ void expose_interpolators( py::module &m )
                     ti::LagrangeInterpolatorBoundaryHandling::
                             lagrange_cubic_spline_boundary_interpolation,
                     R"doc(
- A cubic-spline interpolator is created from the first and last :math:`\max(m/2-1,4)` data points of the full data set, and these cubic spline interpolators are used when an interpolation at :math:`t<t_{(m/2-1)}` or :math:`t<t_{N-(m/2)}` is called
+
+A cubic-spline interpolator is created from the first and last :math:`\max(m/2-1,4)` data points of the full data set, and these cubic spline interpolators are used when an interpolation at :math:`t<t_{(m/2-1)}` or :math:`t<t_{N-(m/2)}` is called.
+
       )doc" )
             .value( "lagrange_no_boundary_interpolation",
                     ti::LagrangeInterpolatorBoundaryHandling::lagrange_no_boundary_interpolation,
                     R"doc(
- The program will terminate with an exception when the Lagrange interpolator is interrogated beyond its valid range
+
+The program will terminate with an exception when the Lagrange interpolator is interrogated beyond its valid range.
+
       )doc" )
             .export_values( );
 

--- a/src/tudatpy/math/root_finders/expose_root_finders.cpp
+++ b/src/tudatpy/math/root_finders/expose_root_finders.cpp
@@ -55,18 +55,24 @@ Enumeration of types of behaviour to be used when the convergence criterion on m
             .value( "accept_result",
                     trf::MaximumIterationHandling::accept_result,
                     R"doc(
-The program will accept the root at the final iteration, without any additional output
-      )doc" )
+
+The program will accept the root at the final iteration, without any additional output.
+
+)doc" )
             .value( "accept_result_with_warning",
                     trf::MaximumIterationHandling::accept_result_with_warning,
                     R"doc(
-The program will accept the root at the final iteration, but will print a warning to the terminal that the root finder may not have converged
+
+The program will accept the root at the final iteration, but will print a warning to the terminal that the root finder may not have converged.
+
       )doc" )
             .value( "throw_exception",
                     trf::MaximumIterationHandling::throw_exception,
                     R"doc(
-The program will not accept the root at the final iteration, and will throw an exception
-      )doc" )
+
+The program will not accept the root at the final iteration, and will throw an exception.
+
+)doc" )
             .export_values( );
 
     py::class_< trf::RootFinder< double >, std::shared_ptr< trf::RootFinder< double > > >(

--- a/src/tudatpy/numerical_simulation/environment/expose_environment.cpp
+++ b/src/tudatpy/numerical_simulation/environment/expose_environment.cpp
@@ -133,11 +133,7 @@ void expose_environment( py::module &m )
             "AerodynamicCoefficientsIndependentVariables",
             R"doc(
 
-         Enumeration of the independent variables that can be used to compute aerodynamic coefficients.
-
-
-
-
+Enumeration of the independent variables that can be used to compute aerodynamic coefficients.
 
       )doc" )
             .value( "mach_number_dependent",
@@ -208,46 +204,52 @@ void expose_environment( py::module &m )
             .value( "undefined_independent_variable",
                     ta::AerodynamicCoefficientsIndependentVariables::undefined_independent_variable,
                     R"doc(
- Can be used for a custom coefficient interface with other variables, at the expense of being able to use the FlightConditions class to automatically updates the aerodynamic coefficients during propagation.
-      )doc" )
+
+Can be used for a custom coefficient interface with other variables, at the expense of being able to use the FlightConditions class to automatically updates the aerodynamic coefficients during propagation.
+
+)doc" )
             .export_values( );
 
     py::enum_< ta::AerodynamicCoefficientFrames >( m,
                                                    "AerodynamicCoefficientFrames",
                                                    R"doc(
 
-         Enumeration of reference frames used for definition of aerodynamic coefficients.
+Enumeration of reference frames used for definition of aerodynamic coefficients.
 
-         Enumeration of reference frames used for definition of aerodynamic coefficients. There is a partial overlap between this enum
-         and the :class:`~tudatpy.numerical_simulation.environment.AerodynamicsReferenceFrames`. This enum combines a subset of those
-         frames (which are typically used for aerodynamic coefficient definition), and a swap in sign. For instance, aerodynamic
-         force coefficients are often defined positive along *negative* axes of the aerodynamic frame (drag, side force and lift coefficients)
-
-
-
-
+Enumeration of reference frames used for definition of aerodynamic coefficients. There is a partial overlap between this enum
+and the :class:`~tudatpy.numerical_simulation.environment.AerodynamicsReferenceFrames`. This enum combines a subset of those
+frames (which are typically used for aerodynamic coefficient definition), and a swap in sign. For instance, aerodynamic
+force coefficients are often defined positive along *negative* axes of the aerodynamic frame (drag, side force and lift coefficients)
 
       )doc" )
             .value( "positive_body_fixed_frame_coefficients",
                     ta::AerodynamicCoefficientFrames::body_fixed_frame_coefficients,
                     R"doc(
- The coefficients are defined in the body-fixed frame, with the directions the same as the body-fixed axes. For aerodynamic forces and moments, this results in the typical :math:`C_{x}, C_{y}, C_{y}` (force) and :math:`C_{l}, C_{m}, C_{n}` (moment) coefficients
-      )doc" )
+
+The coefficients are defined in the body-fixed frame, with the directions the same as the body-fixed axes. For aerodynamic forces and moments, this results in the typical :math:`C_{x}, C_{y}, C_{y}` (force) and :math:`C_{l}, C_{m}, C_{n}` (moment) coefficients
+
+)doc" )
             .value( "negative_body_fixed_frame_coefficients",
                     ta::AerodynamicCoefficientFrames::negative_body_fixed_frame_coefficients,
                     R"doc(
- Same as ``positive_body_fixed_frame_coefficients``, but opposite in direction (so axes along negative body-fixed frame axes)
-      )doc" )
+
+Same as ``positive_body_fixed_frame_coefficients``, but opposite in direction (so axes along negative body-fixed frame axes)
+
+)doc" )
             .value( "positive_aerodynamic_frame_coefficients",
                     ta::AerodynamicCoefficientFrames::positive_aerodynamic_frame_coefficients,
                     R"doc(
- Same as ``negative_aerodynamic_frame_coefficients``, but opposite in direction (so axes along positive aerodynamic frame axes)
-      )doc" )
+
+Same as ``negative_aerodynamic_frame_coefficients``, but opposite in direction (so axes along positive aerodynamic frame axes)
+
+)doc" )
             .value( "negative_aerodynamic_frame_coefficients",
                     ta::AerodynamicCoefficientFrames::negative_aerodynamic_frame_coefficients,
                     R"doc(
- The coefficients are defined in aerodynamic frame, with the directions the same as the negative axes. For aerodynamic forces, this results in the typical :math:`C_{D}, C_{S}, C_{D}` force coefficients
-      )doc" )
+
+The coefficients are defined in aerodynamic frame, with the directions the same as the negative axes. For aerodynamic forces, this results in the typical :math:`C_{D}, C_{S}, C_{D}` force coefficients
+
+)doc" )
             .export_values( );
 
     py::enum_< ta::AtmosphericCompositionSpecies >(
@@ -1102,49 +1104,57 @@ void expose_environment( py::module &m )
                                                    "AerodynamicsReferenceFrames",
                                                    R"doc(
 
-         Enumeration of reference frame identifiers typical for aerodynamic calculations.
+Enumeration of reference frame identifiers typical for aerodynamic calculations.
 
-         Enumeration of reference frame identifiers typical for aerodynamic calculations. Note that the frames are also defined
-         in the absence of any aerodynamic forces and/or atmosphere. They define frames of a body w.r.t. a central body, with
-         the details given by Mooij (1994). The chain of frames starts from the inertial frame, to the frame fixed to the
-         central body (corotating), to the vertical frame (defined by the body's relative position), the trajectory and aerodynamic frames
-         (defined by the body's relative velocity) and finally the body's own body-fixed frame.
-
-
-
-
+Enumeration of reference frame identifiers typical for aerodynamic calculations. Note that the frames are also defined
+in the absence of any aerodynamic forces and/or atmosphere. They define frames of a body w.r.t. a central body, with
+the details given by Mooij (1994). The chain of frames starts from the inertial frame, to the frame fixed to the
+central body (corotating), to the vertical frame (defined by the body's relative position), the trajectory and aerodynamic frames
+(defined by the body's relative velocity) and finally the body's own body-fixed frame.
 
       )doc" )
             .value( "inertial_frame",
                     trf::AerodynamicsReferenceFrames::inertial_frame,
                     R"doc(
- The global orientation (which is by definition inertial).
-      )doc" )
+
+The global orientation (which is by definition inertial).
+
+)doc" )
             .value( "corotating_frame",
                     trf::AerodynamicsReferenceFrames::corotating_frame,
                     R"doc(
- The body-fixed frame of the central body.
-      )doc" )
+
+The body-fixed frame of the central body.
+
+)doc" )
             .value( "vertical_frame",
                     trf::AerodynamicsReferenceFrames::vertical_frame,
                     R"doc(
- Frame with z-axis pointing towards origin of central body, the x-axis lies in the meridian plane and points towards the central-body-fixed z-axis (the y-axis completes the frame).
-      )doc" )
+
+Frame with z-axis pointing towards origin of central body, the x-axis lies in the meridian plane and points towards the central-body-fixed z-axis (the y-axis completes the frame).
+
+)doc" )
             .value( "trajectory_frame",
                     trf::AerodynamicsReferenceFrames::trajectory_frame,
                     R"doc(
- The (airspeed-based) trajectory frame has the x-axis in the direction of the velocity vector relative to the atmosphere (airspeed-based velocity vector), z-axis lies in the vertical plane and points downwards (the y-axis completes the frame).
-      )doc" )
+
+The (airspeed-based) trajectory frame has the x-axis in the direction of the velocity vector relative to the atmosphere (airspeed-based velocity vector), z-axis lies in the vertical plane and points downwards (the y-axis completes the frame).
+
+)doc" )
             .value( "aerodynamic_frame",
                     trf::AerodynamicsReferenceFrames::aerodynamic_frame,
                     R"doc(
- The (airspeed-based) aerodynamic frame has the x-axis in the direction of the velocity vector relative to the atmosphere (airspeed-based velocity vector), z-axis co-linear with the aerodynamic lift vector, pointing in the opposite direction (the y-axis completes the frame)..
-      )doc" )
+
+The (airspeed-based) aerodynamic frame has the x-axis in the direction of the velocity vector relative to the atmosphere (airspeed-based velocity vector), z-axis co-linear with the aerodynamic lift vector, pointing in the opposite direction (the y-axis completes the frame)..
+
+)doc" )
             .value( "body_frame",
                     trf::AerodynamicsReferenceFrames::body_frame,
                     R"doc(
- The body-fixed frame of the body itself.
-      )doc" )
+
+The body-fixed frame of the body itself.
+
+)doc" )
             .export_values( );
 
     py::class_< trf::AerodynamicAngleCalculator,

--- a/src/tudatpy/numerical_simulation/environment_setup/aerodynamic_coefficients/expose_aerodynamic_coefficients.cpp
+++ b/src/tudatpy/numerical_simulation/environment_setup/aerodynamic_coefficients/expose_aerodynamic_coefficients.cpp
@@ -199,49 +199,44 @@ void expose_aerodynamic_coefficient_setup( py::module &m )
            py::arg( "force_coefficients_frame" ) = ta::negative_aerodynamic_frame_coefficients,
            R"doc(
 
- Function for creating aerodynamic interface model settings entirely from constant coefficients.
+Function for creating aerodynamic interface model settings entirely from constant coefficients.
 
- Function for settings object, defining aerodynamic interface model entirely from constant aerodynamic coefficients,
- i.e. coefficients are not a function of any independent variables.
+Function for settings object, defining aerodynamic interface model entirely from constant aerodynamic coefficients,
+i.e. coefficients are not a function of any independent variables.
 
+Parameters
+----------
+reference_area : float
+    Reference area with which aerodynamic forces and moments are non-dimensionalized.
+constant_force_coefficient : numpy.ndarray
+    Constant force coefficients.
+force_coefficients_frame : AerodynamicCoefficientFrames, default = negative_aerodynamic_frame_coefficients
+    Variable defining the frame in which the force coefficients are defined. By default, this is the negative aerodynamic
+    frame, so that the coefficients are for drag, side force and lift
 
- Parameters
- ----------
- reference_area : float
-     Reference area with which aerodynamic forces and moments are non-dimensionalized.
- constant_force_coefficient : numpy.ndarray
-     Constant force coefficients.
- force_coefficients_frame : AerodynamicCoefficientFrames, default = negative_aerodynamic_frame_coefficients
-     Variable defining the frame in which the force coefficients are defined. By default, this is the negative aerodynamic
-     frame, so that the coefficients are for drag, side force and lift
+Returns
+-------
+ConstantAerodynamicCoefficientSettings
+    Instance of the :class:`~tudatpy.numerical_simulation.environment_setup.aerodynamic_coefficients.AerodynamicCoefficientSettings` derived :class:`~tudatpy.numerical_simulation.environment_setup.aerodynamic_coefficients.ConstantAerodynamicCoefficientSettings` class
 
- Returns
- -------
- ConstantAerodynamicCoefficientSettings
-     Instance of the :class:`~tudatpy.numerical_simulation.environment_setup.aerodynamic_coefficients.AerodynamicCoefficientSettings` derived :class:`~tudatpy.numerical_simulation.environment_setup.aerodynamic_coefficients.ConstantAerodynamicCoefficientSettings` class
+Examples
+--------
+In this example, we create :class:`~tudatpy.numerical_simulation.environment_setup.aerodynamic_coefficients.AerodynamicCoefficientSettings` for the artificial body "Vehicle", using only constant aerodynamic coefficients:
 
+.. code-block:: python
 
-
-
-
- Examples
- --------
- In this example, we create :class:`~tudatpy.numerical_simulation.environment_setup.aerodynamic_coefficients.AerodynamicCoefficientSettings` for the artificial body "Vehicle", using only constant aerodynamic coefficients:
-
- .. code-block:: python
-
-   # Define the reference area and constant aerodynamic coefficients
-   reference_area = 20.0
-   drag_coefficient = 1.5
-   lift_coefficient = 0.3
-   # Create the aerodynamic interface settings
-   aero_coefficient_settings = environment_setup.aerodynamic_coefficients.constant(
-       reference_area,
-       constant_force_coefficient=[drag_coefficient, 0, lift_coefficient],
-       force_coefficients_frame=environment.negative_aerodynamic_frame_coefficients,
-   )
-   # Assign aerodynamic interface to the vehicle
-   environment_setup.add_aerodynamic_coefficient_interface(bodies, "Vehicle", aero_coefficient_settings)
+    # Define the reference area and constant aerodynamic coefficients
+    reference_area = 20.0
+    drag_coefficient = 1.5
+    lift_coefficient = 0.3
+    # Create the aerodynamic interface settings
+    aero_coefficient_settings = environment_setup.aerodynamic_coefficients.constant(
+        reference_area,
+        constant_force_coefficient=[drag_coefficient, 0, lift_coefficient],
+        force_coefficients_frame=environment.negative_aerodynamic_frame_coefficients,
+    )
+    # Assign aerodynamic interface to the vehicle
+    environment_setup.add_aerodynamic_coefficient_interface(bodies, "Vehicle", aero_coefficient_settings)
 
 
      )doc" );
@@ -255,63 +250,6 @@ void expose_aerodynamic_coefficient_setup( py::module &m )
            py::arg( "constant_moment_coefficient" ),
            py::arg( "force_coefficients_frame" ) = ta::negative_aerodynamic_frame_coefficients,
            py::arg( "moment_coefficients_frame" ) = ta::body_fixed_frame_coefficients,
-           R"doc(
-
- Function for creating aerodynamic interface model settings entirely from constant coefficients.
-
- Function for settings object, defining aerodynamic interface model entirely from constant aerodynamic coefficients,
- i.e. coefficients are not a function of any independent variables.
-
-
- Parameters
- ----------
- reference_area : float
-     Reference area with which aerodynamic forces and moments are non-dimensionalized.
- constant_force_coefficient : numpy.ndarray
-     Constant force coefficients.
- force_coefficients_frame : AerodynamicCoefficientFrames, default = negative_aerodynamic_frame_coefficients
-     Variable defining the frame in which the force coefficients are defined. By default, this is the negative aerodynamic
-     frame, so that the coefficients are for drag, side force and lift
-
- Returns
- -------
- ConstantAerodynamicCoefficientSettings
-     Instance of the :class:`~tudatpy.numerical_simulation.environment_setup.aerodynamic_coefficients.AerodynamicCoefficientSettings` derived :class:`~tudatpy.numerical_simulation.environment_setup.aerodynamic_coefficients.ConstantAerodynamicCoefficientSettings` class
-
-
-
-
-
- Examples
- --------
- In this example, we create :class:`~tudatpy.numerical_simulation.environment_setup.aerodynamic_coefficients.AerodynamicCoefficientSettings` for the artificial body "Vehicle", using only constant aerodynamic coefficients:
-
- .. code-block:: python
-
-   # Define the reference area and constant aerodynamic coefficients
-   reference_area = 20.0
-   drag_coefficient = 1.5
-   lift_coefficient = 0.3
-   # Create the aerodynamic interface settings
-   aero_coefficient_settings = environment_setup.aerodynamic_coefficients.constant(
-       reference_area,
-       constant_force_coefficient=[drag_coefficient, 0, lift_coefficient],
-       force_coefficients_frame=environment.negative_aerodynamic_frame_coefficients,
-   )
-   # Assign aerodynamic interface to the vehicle
-   environment_setup.add_aerodynamic_coefficient_interface(bodies, "Vehicle", aero_coefficient_settings)
-
-
-     )doc" );
-
-    m.def( "constant",
-           py::overload_cast< const double,
-                              const Eigen::Vector3d &,
-                              const ta::AerodynamicCoefficientFrames >(
-                   &tss::constantAerodynamicCoefficientSettings ),
-           py::arg( "reference_area" ),
-           py::arg( "constant_force_coefficient" ),
-           py::arg( "force_coefficients_frame" ) = ta::negative_aerodynamic_frame_coefficients,
            R"doc(
 
  Function for creating aerodynamic interface model settings entirely from constant coefficients.

--- a/src/tudatpy/numerical_simulation/environment_setup/gravity_field/expose_gravity_field.cpp
+++ b/src/tudatpy/numerical_simulation/environment_setup/gravity_field/expose_gravity_field.cpp
@@ -135,58 +135,73 @@ void expose_gravity_field_setup( py::module& m )
     py::enum_< tss::SphericalHarmonicsModel >( m,
                                                "PredefinedSphericalHarmonicsModel",
                                                R"doc(
+Enumeration of predefined spherical harmonics models.
 
-         Enumeration of predefined spherical harmonics models.
-
-         Enumeration of predefined spherical harmonics models supported by tudat, for which thee coefficient files are automatically available (downloaded from
-         `here <https://github.com/tudat-team/tudat-resources/tree/master/resource/gravity_models>`__). The directory where these files are stored can be
-         extracted using the :func:`~tudatpy.data.get_gravity_models_path` function.
-
-
-
-
-
-      )doc" )
+Enumeration of predefined spherical harmonics models supported by tudat, for which thee coefficient files are automatically available (downloaded from
+`here <https://github.com/tudat-team/tudat-resources/tree/master/resource/gravity_models>`_). The directory where these files are stored can be
+extracted using the :func:`~tudatpy.data.get_gravity_models_path` function.
+                 
+        )doc" )
             .value( "egm96",
                     tss::SphericalHarmonicsModel::egm96,
                     R"doc(
- Coefficients for EGM96 Earth gravity field up to degree and order 200, (see `link <https://cddis.gsfc.nasa.gov/926/egm96/egm96.html>`__ )
-      )doc" )
+
+Coefficients for EGM96 Earth gravity field up to degree and order 200, (see `link <https://cddis.gsfc.nasa.gov/926/egm96/egm96.html>`__ )
+
+)doc" )
             .value( "ggm02c",
                     tss::SphericalHarmonicsModel::ggm02c,
                     R"doc(
- Coefficients for the combined GGM02 Earth gravity field up to degree and order 200, (see `link <https://www2.csr.utexas.edu/grace/gravity/ggm02/>`__ )
-      )doc" )
+
+Coefficients for the combined GGM02 Earth gravity field up to degree and order 200, (see `link <https://www2.csr.utexas.edu/grace/gravity/ggm02/>`__ )
+
+                    )doc" )
             .value( "ggm02s",
                     tss::SphericalHarmonicsModel::ggm02s,
                     R"doc(
- Coefficients for the GRACE-only GGM02 Earth gravity field up to degree and order 160, (see `link <https://www2.csr.utexas.edu/grace/gravity/ggm02/>`__ )
-      )doc" )
+
+Coefficients for the GRACE-only GGM02 Earth gravity field up to degree and order 160, (see `link <https://www2.csr.utexas.edu/grace/gravity/ggm02/>`__ )
+
+)doc" )
             .value( "goco05c",
                     tss::SphericalHarmonicsModel::goco05c,
                     R"doc(
- Coefficients for the GOCO05c combined Earth gravity field up to degree and order 719, (see `link <https://www2.csr.utexas.edu/grace/gravity/ggm02/>`__ )
-      )doc" )
+
+Coefficients for the GOCO05c combined Earth gravity field up to degree and order 719, (see `link <https://www2.csr.utexas.edu/grace/gravity/ggm02/>`__ )
+
+    )doc" )
             .value( "glgm3150", tss::SphericalHarmonicsModel::glgm3150, R"doc(
- Coefficients for the GLGM3150 Moon gravity field up to degree and order 150, (see `link <https://pds.nasa.gov/ds-view/pds/viewProfile.jsp?dsid=LP-L-RSS-5-GLGM3/GRAVITY-V1.0>`__ )
-      )doc" )
+
+Coefficients for the GLGM3150 Moon gravity field up to degree and order 150, (see `link <https://pds.nasa.gov/ds-view/pds/viewProfile.jsp?dsid=LP-L-RSS-5-GLGM3/GRAVITY-V1.0>`__ )
+
+)doc" )
             .value( "lpe200",
                     tss::SphericalHarmonicsModel::lpe200,
                     R"doc(
- Coefficients for the LPE200 Moon gravity field up to degree and order 200, (see `link <https://pds.nasa.gov/ds-view/pds/viewProfile.jsp?dsid=LP-L-RSS-5-GLGM3/GRAVITY-V1.0>`__ )
-      )doc" )
+
+Coefficients for the LPE200 Moon gravity field up to degree and order 200, (see `link <https://pds.nasa.gov/ds-view/pds/viewProfile.jsp?dsid=LP-L-RSS-5-GLGM3/GRAVITY-V1.0>`__ )
+
+    )doc" )
             .value( "gggrx1200", tss::SphericalHarmonicsModel::gggrx1200, R"doc(
- Coefficients for the GRGM1200A Moon gravity field up to degree and order 1199, (see `link <https://pgda.gsfc.nasa.gov/products/50>`__ )
-      )doc" )
+
+Coefficients for the GRGM1200A Moon gravity field up to degree and order 1199, (see `link <https://pgda.gsfc.nasa.gov/products/50>`__ )
+
+)doc" )
             .value( "jgmro120d", tss::SphericalHarmonicsModel::jgmro120d, R"doc(
- Coefficients for the MRO120D Moon gravity field up to degree and order 120, (see `link <https://pds-geosciences.wustl.edu/mro/mro-m-rss-5-sdp-v1/mrors_1xxx/data/shadr/>`__ )
-      )doc" )
+
+Coefficients for the MRO120D Moon gravity field up to degree and order 120, (see `link <https://pds-geosciences.wustl.edu/mro/mro-m-rss-5-sdp-v1/mrors_1xxx/data/shadr/>`__ )
+
+)doc" )
             .value( "jgmess160a", tss::SphericalHarmonicsModel::jgmess160a, R"doc(
- Coefficients for the MESS160A Moon gravity field up to degree and order 160, (see `link <https://pds-geosciences.wustl.edu/messenger/mess-h-rss_mla-5-sdp-v1/messrs_1001/data/shadr/jgmess_160a_sha.lbl>`__ )
-      )doc" )
+
+Coefficients for the MESS160A Moon gravity field up to degree and order 160, (see `link <https://pds-geosciences.wustl.edu/messenger/mess-h-rss_mla-5-sdp-v1/messrs_1001/data/shadr/jgmess_160a_sha.lbl>`__ )
+
+)doc" )
             .value( "shgj180u", tss::SphericalHarmonicsModel::shgj180u, R"doc(
- Coefficients for the SHGJ180U Moon gravity field up to degree and order 180, (see `link <https://pds-geosciences.wustl.edu/mgn/mgn-v-rss-5-gravity-l2-v1/mg_5201/gravity/shgj120u.lbl>`__ )
-      )doc" )
+
+Coefficients for the SHGJ180U Moon gravity field up to degree and order 180, (see `link <https://pds-geosciences.wustl.edu/mgn/mgn-v-rss-5-gravity-l2-v1/mg_5201/gravity/shgj120u.lbl>`__ )
+
+)doc" )
             .export_values( );
 
     py::class_< tss::GravityFieldSettings, std::shared_ptr< tss::GravityFieldSettings > >(

--- a/src/tudatpy/numerical_simulation/environment_setup/gravity_field_variation/expose_gravity_field_variation.cpp
+++ b/src/tudatpy/numerical_simulation/environment_setup/gravity_field_variation/expose_gravity_field_variation.cpp
@@ -341,21 +341,20 @@ void expose_gravity_field_variation_setup( py::module& m )
            py::arg( "love_number_per_degree_and_order" ),
            R"doc(
 
- Function for creating solid body tides.
+Function for creating solid body tides.
 
- As :func:`~tudatpy.numerical_simulation.environment_setup.gravity_field_variation.solid_body_tide_degree_order_variable_k`, but with complex values for the Love number.
+As :func:`~tudatpy.numerical_simulation.environment_setup.gravity_field_variation.solid_body_tide_degree_order_variable_k`, but with complex values for the Love number.
 
-
- Parameters
- ----------
- tide_raising_body : str
-     Name of body raising the tide.
- love_number_per_degree : dict( int, list( complex ) )
-     Dictionary of Love numbers for each degree that is to be taken into account, with the key representing the degree :math:`l` of the Love number, and value containing the list of Love numbers :math:`k_{lm}` at this degree. Note that, for Love numbers at degree :math:`l`, the associated list should contain :math:`l+1` entries, representing the Love numbers (in order) :math:`k_{l0}`, :math:`k_{l1}`...:math:`k_{ll}`.
- Returns
- -------
- BasicSolidBodyGravityFieldVariationSettings
-     Instance of the :class:`~tudatpy.numerical_simulation.environment_setup.gravity_field_variation.BasicSolidBodyGravityFieldVariationSettings` derived :class:`~tudatpy.numerical_simulation.environment_setup.gravity_field_variation.GravityFieldVariationSettings` class
+Parameters
+----------
+tide_raising_body : str
+    Name of body raising the tide.
+love_number_per_degree : dict( int, list( complex ) )
+    Dictionary of Love numbers for each degree that is to be taken into account, with the key representing the degree :math:`l` of the Love number, and value containing the list of Love numbers :math:`k_{lm}` at this degree. Note that, for Love numbers at degree :math:`l`, the associated list should contain :math:`l+1` entries, representing the Love numbers (in order) :math:`k_{l0}`, :math:`k_{l1}`...:math:`k_{ll}`.
+Returns
+-------
+BasicSolidBodyGravityFieldVariationSettings
+    Instance of the :class:`~tudatpy.numerical_simulation.environment_setup.gravity_field_variation.BasicSolidBodyGravityFieldVariationSettings` derived :class:`~tudatpy.numerical_simulation.environment_setup.gravity_field_variation.GravityFieldVariationSettings` class
 
 
 
@@ -372,21 +371,20 @@ void expose_gravity_field_variation_setup( py::module& m )
            py::arg( "love_number_per_degree_and_order" ),
            R"doc(
 
- Function for creating solid body tides.
+Function for creating solid body tides.
 
- As :func:`~tudatpy.numerical_simulation.environment_setup.gravity_field_variation.solid_body_tide_degree_order_variable_k`, but with complex values for the Love number.
+As :func:`~tudatpy.numerical_simulation.environment_setup.gravity_field_variation.solid_body_tide_degree_order_variable_k`, but with complex values for the Love number.
 
-
- Parameters
- ----------
- tide_raising_body : str
-     Name of body raising the tide.
- love_number_per_degree : dict( int, list( complex ) )
-     Dictionary of Love numbers for each degree that is to be taken into account, with the key representing the degree :math:`l` of the Love number, and value containing the list of Love numbers :math:`k_{lm}` at this degree. Note that, for Love numbers at degree :math:`l`, the associated list should contain :math:`l+1` entries, representing the Love numbers (in order) :math:`k_{l0}`, :math:`k_{l1}`...:math:`k_{ll}`.
- Returns
- -------
- BasicSolidBodyGravityFieldVariationSettings
-     Instance of the :class:`~tudatpy.numerical_simulation.environment_setup.gravity_field_variation.BasicSolidBodyGravityFieldVariationSettings` derived :class:`~tudatpy.numerical_simulation.environment_setup.gravity_field_variation.GravityFieldVariationSettings` class
+Parameters
+----------
+tide_raising_body : str
+    Name of body raising the tide.
+love_number_per_degree : dict( int, list( complex ) )
+    Dictionary of Love numbers for each degree that is to be taken into account, with the key representing the degree :math:`l` of the Love number, and value containing the list of Love numbers :math:`k_{lm}` at this degree. Note that, for Love numbers at degree :math:`l`, the associated list should contain :math:`l+1` entries, representing the Love numbers (in order) :math:`k_{l0}`, :math:`k_{l1}`...:math:`k_{ll}`.
+Returns
+-------
+BasicSolidBodyGravityFieldVariationSettings
+    Instance of the :class:`~tudatpy.numerical_simulation.environment_setup.gravity_field_variation.BasicSolidBodyGravityFieldVariationSettings` derived :class:`~tudatpy.numerical_simulation.environment_setup.gravity_field_variation.GravityFieldVariationSettings` class
 
 
 

--- a/src/tudatpy/numerical_simulation/estimation/expose_estimation_observation_collection.cpp
+++ b/src/tudatpy/numerical_simulation/estimation/expose_estimation_observation_collection.cpp
@@ -197,12 +197,12 @@ void expose_estimation_observation_collection( py::module& m )
                                                        TIME_TYPE >::setObservations ),
                   py::arg( "observations" ),
                   R"doc(
-         Function to reset the full list of observable values. The order of the observations must be the same as for :attr:`~ObservationCollection.concatenated_observations`
+Function to reset the full list of observable values. The order of the observations must be the same as for :attr:`~ObservationCollection.concatenated_observations`
 
-         Parameters
-         ----------
-         observations : np.ndarray
-             New list of observable values
+Parameters
+----------
+observations : np.ndarray
+    New list of observable values
      )doc" )
             .def( "set_observations",
                   py::overload_cast< const Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 >&,
@@ -212,16 +212,16 @@ void expose_estimation_observation_collection( py::module& m )
                   py::arg( "observations" ),
                   py::arg( "observation_parser" ),
                   R"doc(
-         Function to reset a subset of all observable values, with this subset defined by the ``observation_parser`` input.
-         The order and size of the new observation vector must be the same as when calling :attr:`~ObservationCollection.concatenated_observations` on
-         an ``ObservationCollection`` containing only the parsed observation.
+Function to reset a subset of all observable values, with this subset defined by the ``observation_parser`` input.
+The order and size of the new observation vector must be the same as when calling :attr:`~ObservationCollection.concatenated_observations` on
+an ``ObservationCollection`` containing only the parsed observation.
 
-         Parameters
-         ----------
-         observations : np.ndarray
-             New list of observable values
-         observation_parser : ObservationCollectionParser
-             Observation parser with which to select the subset of observations that is to be reset
+Parameters
+----------
+observations : np.ndarray
+    New list of observable values
+observation_parser : ObservationCollectionParser
+    Observation parser with which to select the subset of observations that is to be reset
      )doc" )
             .def( "set_observations",
                   py::overload_cast< const std::map<
@@ -231,19 +231,19 @@ void expose_estimation_observation_collection( py::module& m )
                                                        TIME_TYPE >::setObservations ),
                   py::arg( "observations_per_parser" ),
                   R"doc(
-         Function to reset a subset of all observable values, with this subset defined by a list of observation parsers input.
-         Each observation parser is associated with a new set of observable values.
-         The order and size of the new observation vector for each parser must be the same as when calling :attr:`~ObservationCollection.concatenated_observations` on
-         an ``ObservationCollection`` containing only the parsed observation (from a single parser). NOTE: since the multiple parsers
-         are handled in order (iterating over the keys of ``observations_per_parser``) some observations may be reset several times,
-         in case
+Function to reset a subset of all observable values, with this subset defined by a list of observation parsers input.
+Each observation parser is associated with a new set of observable values.
+The order and size of the new observation vector for each parser must be the same as when calling :attr:`~ObservationCollection.concatenated_observations` on
+an ``ObservationCollection`` containing only the parsed observation (from a single parser). NOTE: since the multiple parsers
+are handled in order (iterating over the keys of ``observations_per_parser``) some observations may be reset several times,
+in case.
 
-         Parameters
-         ----------
-         observations : np.ndarray
-             New list of observable values
-         observation_parser : ObservationCollectionParser
-             Observation parser with which to select the subset of observations that is to be reset
+Parameters
+----------
+observations : np.ndarray
+    New list of observable values
+observation_parser : ObservationCollectionParser
+    Observation parser with which to select the subset of observations that is to be reset
      )doc" )
             .def( "set_residuals",
                   py::overload_cast< const Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 >& >(

--- a/src/tudatpy/numerical_simulation/estimation_setup/parameter/expose_parameter.cpp
+++ b/src/tudatpy/numerical_simulation/estimation_setup/parameter/expose_parameter.cpp
@@ -200,9 +200,11 @@ void expose_estimated_parameter_setup( py::module& m )
  The function uses the propagator settings to determine which type of initial state parameter (single/multi/hybrid-arc; translational/rotational/... dynamics) is to be estimated,
  e.g. if a single-arc translational state propagator is defined, the function will automatically create the parameters for the associated initial state parameter
 
- .. note:: This function return lists of parameter settings objects.
- This means that the return of this function cannot simply be added to the parameter settings objects of single parameters in a list creation statement.
- Instead, list concatenation is recommended. Please see the following example:
+ .. note::
+ 
+    This function return lists of parameter settings objects.
+    This means that the return of this function cannot simply be added to the parameter settings objects of single parameters in a list creation statement.
+    Instead, list concatenation is recommended. Please see the following example:
 
  .. code-block:: python
 
@@ -359,8 +361,9 @@ void expose_estimated_parameter_setup( py::module& m )
  Function for creating a (linear sensitivity) parameter settings object for arc-wise radiation pressure coefficients (arc-wise version of :func:`~tudatpy.numerical_simulation.estimation_setup.parameter.radiation_pressure_coefficient`).
  Using the radiation pressure coefficient as an estimatable parameter requires:
 
- * A :func:`~tudatpy.numerical_simulation.environment_setup.radiation_pressure.cannonball` radiation pressure interface to be defined for the body specified by the ``body`` parameter
- * The body specified by the ``body`` parameter to undergo :func:`~tudatpy.numerical_simulation.propagation_setup.acceleration.cannonball_radiation_pressure` acceleration
+ * A :func:`~tudatpy.numerical_simulation.environment_setup.radiation_pressure.cannonball_radiation_target` target model to be defined for the body specified by the ``body`` parameter
+ * The body specified by the ``body`` parameter to undergo :func:`~tudatpy.numerical_simulation.propagation_setup.acceleration.radiation_pressure` acceleration
+ 
  The radiation pressure coefficient is defined according to the universal convention for a cannonball model and thus no further model information is given.
 
  .. note:: This parameter may be estimated for a single-arc propagation, or a multi-arc propagation. In the latter case, the arcs selected for the estimation of the radiation pressure coefficient may, but need not, correspond to the arcs used for a multi-arc propagation.

--- a/src/tudatpy/numerical_simulation/propagation_setup/acceleration/expose_acceleration.cpp
+++ b/src/tudatpy/numerical_simulation/propagation_setup/acceleration/expose_acceleration.cpp
@@ -957,51 +957,46 @@ void expose_acceleration_setup( py::module &m )
            py::arg( "explicit_libraional_tide_on_satellite" ) = false,
            R"doc(
 
- Creates settings for tidal acceleration.
+Creates settings for tidal acceleration.
 
- Creates settings for tidal accelerations. The direct of tidal effects in a satellite system is applied directly as
- an acceleration (as opposed to a modification of spherical harmonic coefficients).
- The model is based on Lainey et al. (2007, 2012). It can compute the acceleration due to tides, and in
- particular tidal dissipation, on a planetary satellite. The acceleration computed can account for either the
- effect of tide raised on the satellite by the planet or on the planet by the satellite. The satellite is assumed
- to be tidally locked to the planet.
+Creates settings for tidal accelerations. The direct of tidal effects in a satellite system is applied directly as
+an acceleration (as opposed to a modification of spherical harmonic coefficients).
+The model is based on Lainey et al. (2007, 2012). It can compute the acceleration due to tides, and in
+particular tidal dissipation, on a planetary satellite. The acceleration computed can account for either the
+effect of tide raised on the satellite by the planet or on the planet by the satellite. The satellite is assumed
+to be tidally locked to the planet.
 
+Parameters
+----------
+k2_love_number : float
+    Value of the k2 Love number.
+time_lag : float
+    Value of the tidal time lag.
+include_direct_radial_component : bool, default=True
+    It denotes whether the term independent of the time lag is to be computed.
+use_tide_raised_on_planet : bool, default=True
+    It denotes whether the tide raised on the planet is to be modelled (if true) or the tide raised on the satellite (if false).
+Returns
+-------
+DirectTidalDissipationAccelerationSettings
+    Direct tidal dissipation acceleration settings object.
 
- Parameters
- ----------
- k2_love_number : float
-     Value of the k2 Love number.
- time_lag : float
-     Value of the tidal time lag.
- include_direct_radial_component : bool, default=True
-     It denotes whether the term independent of the time lag is to be computed.
- use_tide_raised_on_planet : bool, default=True
-     It denotes whether the tide raised on the planet is to be modelled (if true) or the tide raised on the satellite (if false).
- Returns
- -------
- DirectTidalDissipationAccelerationSettings
-     Direct tidal dissipation acceleration settings object.
+Examples
+--------
+In this example, we define the tidal dissipation exerted by Jupiter on Io directly, instead of computing it
+through the spherical harmonic gravity:
 
-
-
-
-
- Examples
- --------
- In this example, we define the tidal dissipation exerted by Jupiter on Io directly, instead of computing it
- through the spherical harmonic gravity:
-
- .. code-block:: python
+.. code-block:: python
 
     # Define parameters
     love_number = 0.1
     time_lag = 100.0
     # Add entry to acceleration settings dict
     acceleration_settings_on_io["Jupiter"] = [propagation_setup.acceleration.direct_tidal_dissipation(
-       love_number,
-       time_lag,
-       False,
-       False)]
+    love_number,
+    time_lag,
+    False,
+    False)]
 
 
      )doc" );
@@ -1016,51 +1011,46 @@ void expose_acceleration_setup( py::module &m )
            py::arg( "explicit_libraional_tide_on_satellite" ) = false,
            R"doc(
 
- Creates settings for tidal acceleration.
+Creates settings for tidal acceleration.
 
- Creates settings for tidal accelerations. The direct of tidal effects in a satellite system is applied directly as
- an acceleration (as opposed to a modification of spherical harmonic coefficients).
- The model is based on Lainey et al. (2007, 2012). It can compute the acceleration due to tides, and in
- particular tidal dissipation, on a planetary satellite. The acceleration computed can account for either the
- effect of tide raised on the satellite by the planet or on the planet by the satellite. The satellite is assumed
- to be tidally locked to the planet.
+Creates settings for tidal accelerations. The direct of tidal effects in a satellite system is applied directly as
+an acceleration (as opposed to a modification of spherical harmonic coefficients).
+The model is based on Lainey et al. (2007, 2012). It can compute the acceleration due to tides, and in
+particular tidal dissipation, on a planetary satellite. The acceleration computed can account for either the
+effect of tide raised on the satellite by the planet or on the planet by the satellite. The satellite is assumed
+to be tidally locked to the planet.
 
+Parameters
+----------
+k2_love_number : float
+    Value of the k2 Love number.
+time_lag : float
+    Value of the tidal time lag.
+include_direct_radial_component : bool, default=True
+    It denotes whether the term independent of the time lag is to be computed.
+use_tide_raised_on_planet : bool, default=True
+    It denotes whether the tide raised on the planet is to be modelled (if true) or the tide raised on the satellite (if false).
+Returns
+-------
+DirectTidalDissipationAccelerationSettings
+    Direct tidal dissipation acceleration settings object.
 
- Parameters
- ----------
- k2_love_number : float
-     Value of the k2 Love number.
- time_lag : float
-     Value of the tidal time lag.
- include_direct_radial_component : bool, default=True
-     It denotes whether the term independent of the time lag is to be computed.
- use_tide_raised_on_planet : bool, default=True
-     It denotes whether the tide raised on the planet is to be modelled (if true) or the tide raised on the satellite (if false).
- Returns
- -------
- DirectTidalDissipationAccelerationSettings
-     Direct tidal dissipation acceleration settings object.
+Examples
+--------
+In this example, we define the tidal dissipation exerted by Jupiter on Io directly, instead of computing it
+through the spherical harmonic gravity:
 
-
-
-
-
- Examples
- --------
- In this example, we define the tidal dissipation exerted by Jupiter on Io directly, instead of computing it
- through the spherical harmonic gravity:
-
- .. code-block:: python
+.. code-block:: python
 
     # Define parameters
     love_number = 0.1
     time_lag = 100.0
     # Add entry to acceleration settings dict
     acceleration_settings_on_io["Jupiter"] = [propagation_setup.acceleration.direct_tidal_dissipation(
-       love_number,
-       time_lag,
-       False,
-       False)]
+        love_number,
+        time_lag,
+        False,
+        False)]
 
 
      )doc" );

--- a/src/tudatpy/numerical_simulation/propagation_setup/dependent_variable/expose_dependent_variable.cpp
+++ b/src/tudatpy/numerical_simulation/propagation_setup/dependent_variable/expose_dependent_variable.cpp
@@ -441,7 +441,6 @@ void expose_dependent_variable_setup( py::module &m )
  w.r.t. the atmosphere of body 'Earth', use:
 
  .. code-block:: python
-    :emphasize-lines: 18
 
     # Define save settings for Mach number
     propagation_setup.dependent_variable.mach_number( "Spacecraft", "Earth" )
@@ -825,7 +824,6 @@ void expose_dependent_variable_setup( py::module &m )
  exerted by a body named 'Earth', use:
 
  .. code-block:: python
-    :emphasize-lines: 18
 
     # Define save settings for point-mass acceleration on Spacecraft by Earth
     propagation_setup.dependent_variable.single_acceleration(
@@ -869,7 +867,6 @@ void expose_dependent_variable_setup( py::module &m )
  exerted by a body named 'Earth', use:
 
  .. code-block:: python
-    :emphasize-lines: 18
 
     # Define save settings for point-mass acceleration on Spacecraft by Earth
     propagation_setup.dependent_variable.single_acceleration_norm(
@@ -1071,7 +1068,6 @@ void expose_dependent_variable_setup( py::module &m )
  nine entries (three acceleration components for 2/0, 2/1 and 2/2, respectively).
 
  .. code-block:: python
-    :emphasize-lines: 18
 
     # Define degree/order combinations for which to save acceleration contributions
     spherical_harmonic_terms = [ (2,0), (2,1), (2,2) ]
@@ -1119,7 +1115,6 @@ void expose_dependent_variable_setup( py::module &m )
  three entries (one acceleration norm for 2/0, 2/1 and 2/2, respectively).
 
  .. code-block:: python
-    :emphasize-lines: 18
 
 
     # Define degree/order combinations for which to save acceleration contributions

--- a/src/tudatpy/numerical_simulation/propagation_setup/integrator/expose_integrator.cpp
+++ b/src/tudatpy/numerical_simulation/propagation_setup/integrator/expose_integrator.cpp
@@ -45,7 +45,7 @@ void expose_integrator_setup( py::module &m )
     py::enum_< tni::MinimumIntegrationTimeStepHandling >(
             m, "MinimumIntegrationTimeStepHandling", R"doc(
 
-         Enumeration defining possible behaviours when :math:`\Delta t_{rec}<\Delta t_{\min}`. in step-size control (e.g. recommended time step is smaller than minimum time step)
+Enumeration defining possible behaviours when :math:`\Delta t_{rec}<\Delta t_{\min}`. in step-size control (e.g. recommended time step is smaller than minimum time step)
 
 
 
@@ -55,23 +55,31 @@ void expose_integrator_setup( py::module &m )
             .value( "throw_exception_below_minimum",
                     tni::MinimumIntegrationTimeStepHandling::throw_exception_below_minimum,
                     R"doc(
- Exception is throw, and propagation is terminated
-      )doc" )
+
+Exception is throw, and propagation is terminated
+
+)doc" )
             .value( "set_to_minimum_step_silently",
                     tni::MinimumIntegrationTimeStepHandling::set_to_minimum_step_silently,
                     R"doc(
- The final time step is set to :math:`\Delta t=\Delta t_{\min}`, violating requirements of step-size control algorithm, without any message to user"
-      )doc" )
-            .value( "set_to_minimum_step_single_warning",
+
+The final time step is set to :math:`\Delta t=\Delta t_{\min}`, violating requirements of step-size control algorithm, without any message to user"
+
+)doc" )
+      .value( "set_to_minimum_step_single_warning",
                     tni::MinimumIntegrationTimeStepHandling::set_to_minimum_step_single_warning,
                     R"doc(
- The final time step is set to :math:`\Delta t=\Delta t_{\min}`, violating requirements of step-size control algorithm, a warning is printed to the terminal the first time this happens during a propagation"
-      )doc" )
+
+The final time step is set to :math:`\Delta t=\Delta t_{\min}`, violating requirements of step-size control algorithm, a warning is printed to the terminal the first time this happens during a propagation"
+
+)doc" )
             .value( "set_to_minimum_step_every_time_warning",
                     tni::MinimumIntegrationTimeStepHandling::set_to_minimum_step_every_time_warning,
                     R"doc(
- The final time step is set to :math:`\Delta t=\Delta t_{\min}`, violating requirements of step-size control algorithm, a warning is printed to the terminal every time this happens during a propagation"
-      )doc" )
+
+The final time step is set to :math:`\Delta t=\Delta t_{\min}`, violating requirements of step-size control algorithm, a warning is printed to the terminal every time this happens during a propagation"
+
+)doc" )
             .export_values( );
 
     py::enum_< tni::AvailableIntegrators >( m, "AvailableIntegrators", R"doc(
@@ -100,126 +108,168 @@ void expose_integrator_setup( py::module &m )
                                        "CoefficientSets",
                                        R"doc(
 
-         Coefficient sets for Runge-Kutta-type integrators.
+Coefficient sets for Runge-Kutta-type integrators.
 
-         Coefficient sets for Runge-Kutta-type integrators. The coefficients are defined
-         in a Butcher Tableau, with an coefficient set yielding an x(y) method yielding an integrator
-         with global truncation error of :math:`O(\Delta t^{x})`. Some of these coefficients also contain an embedded integrator of :math:`O(\Delta t^{y})`
-         for step size control.
+Coefficient sets for Runge-Kutta-type integrators. The coefficients are defined
+in a Butcher Tableau, with an coefficient set yielding an x(y) method yielding an integrator
+with global truncation error of :math:`O(\Delta t^{x})`. Some of these coefficients also contain an embedded integrator of :math:`O(\Delta t^{y})`
+for step size control.
 
       )doc" )
             .value( "euler_forward",
                     tni::forwardEuler,
                     R"doc(
- Coefficients for the classic forward Euler method
-      )doc" )
+
+Coefficients for the classic forward Euler method
+
+)doc" )
             .value( "rk_4",
                     tni::rungeKutta4Classic,
                     R"doc(
- Coefficients for the original Runge-Kutta method of order 4
-      )doc" )
+
+Coefficients for the original Runge-Kutta method of order 4
+
+)doc" )
             .value( "explicit_mid_point",
                     tni::explicitMidPoint,
                     R"doc(
- Coefficients for the explicit midpoint method
-      )doc" )
+
+Coefficients for the explicit midpoint method
+
+)doc" )
             .value( "explicit_trapezoid_rule",
                     tni::explicitTrapezoidRule,
                     R"doc(
- Coefficients for the explicit trapezoid rule, also called Heun's method or improved Euler's method
-      )doc" )
+
+Coefficients for the explicit trapezoid rule, also called Heun's method or improved Euler's method
+
+)doc" )
             .value( "ralston",
                     tni::ralston,
                     R"doc(
- Coefficients for Ralston's method
-      )doc" )
+
+Coefficients for Ralston's method
+
+)doc" )
             .value( "rk_3",
                     tni::rungeKutta3,
                     R"doc(
- Coefficients for the Runge-Kutta method of order 3
-      )doc" )
+
+Coefficients for the Runge-Kutta method of order 3
+
+)doc" )
             .value( "ralston_3",
                     tni::ralston3,
                     R"doc(
- Coefficients for Ralston's third-order method
-      )doc" )
+
+Coefficients for Ralston's third-order method
+
+)doc" )
             .value( "SSPRK3",
                     tni::SSPRK3,
                     R"doc(
- Coefficients for the Strong Stability Preserving Runge-Kutta third-order method
-      )doc" )
+
+Coefficients for the Strong Stability Preserving Runge-Kutta third-order method
+
+)doc" )
             .value( "ralston_4",
                     tni::ralston4,
                     R"doc(
- Coefficients for Ralston's fourth-order method
-      )doc" )
+
+Coefficients for Ralston's fourth-order method
+
+)doc" )
             .value( "three_eight_rule_rk_4",
                     tni::threeEighthRuleRK4,
                     R"doc(
- Coefficients for the classic Runge Kutta 3/8-rule fourth-order method
-      )doc" )
+
+Coefficients for the classic Runge Kutta 3/8-rule fourth-order method
+
+)doc" )
             .value( "heun_euler",
                     tni::heunEuler,
                     R"doc(
- Coefficients for the Heun's method of order 2 with an embedded Euler method of order 1
-      )doc" )
+
+Coefficients for the Heun's method of order 2 with an embedded Euler method of order 1
+
+)doc" )
             .value( "rkf_12",
                     tni::rungeKuttaFehlberg12,
                     R"doc(
- Coefficients for the Runge-Kutta-Fehlberg method of order 2 with an embedded 1st order
-      )doc" )
+
+Coefficients for the Runge-Kutta-Fehlberg method of order 2 with an embedded 1st order
+
+)doc" )
             .value( "rkf_45",
                     tni::rungeKuttaFehlberg45,
                     R"doc(
- Coefficients for the Runge-Kutta-Fehlberg method of order 5 with an embedded 4th order
-      )doc" )
+
+Coefficients for the Runge-Kutta-Fehlberg method of order 5 with an embedded 4th order
+
+)doc" )
             .value( "rkf_56",
                     tni::rungeKuttaFehlberg56,
                     R"doc(
- Coefficients for the Runge-Kutta-Fehlberg method of order 6 with an embedded 5th order
-      )doc" )
+
+Coefficients for the Runge-Kutta-Fehlberg method of order 6 with an embedded 5th order
+
+)doc" )
             .value( "rkf_78",
                     tni::rungeKuttaFehlberg78,
                     R"doc(
- Coefficients for the Runge-Kutta-Fehlberg method of order 8 with an embedded 7th order
-      )doc" )
+
+Coefficients for the Runge-Kutta-Fehlberg method of order 8 with an embedded 7th order
+
+)doc" )
             .value( "rkdp_87",
                     tni::rungeKutta87DormandPrince,
                     R"doc(
- Coefficients for the Dormand-Prince method of order 7 with an embedded 8th order
-      )doc" )
+
+Coefficients for the Dormand-Prince method of order 7 with an embedded 8th order
+
+)doc" )
             .value( "rkf_89",
                     tni::rungeKuttaFehlberg89,
                     R"doc(
- Coefficients for the Runge-Kutta-Fehlberg method of order 9 with an embedded 8th order
-      )doc" )
+
+Coefficients for the Runge-Kutta-Fehlberg method of order 9 with an embedded 8th order
+
+)doc" )
             .value( "rkv_89",
                     tni::rungeKuttaVerner89,
                     R"doc(
- Coefficients for the Runge-Kutta-Verner method of order 9 with an embedded 8th order
-      )doc" )
+
+Coefficients for the Runge-Kutta-Verner method of order 9 with an embedded 8th order
+
+)doc" )
             .value( "rkf_108",
                     tni::rungeKuttaFeagin108,
                     R"doc(
- Coefficients for the Runge-Kutta-Feagin method of order 8 with an embedded 10th order
-      )doc" )
+
+Coefficients for the Runge-Kutta-Feagin method of order 8 with an embedded 10th order
+
+)doc" )
             .value( "rkf_1210",
                     tni::rungeKuttaFeagin1210,
                     R"doc(
- Coefficients for the Runge-Kutta-Feagin method of order 10 with an embedded 12ve order
-      )doc" )
+
+Coefficients for the Runge-Kutta-Feagin method of order 10 with an embedded 12ve order
+
+)doc" )
             .value( "rkf_1412",
                     tni::rungeKuttaFeagin1412,
                     R"doc(
- Coefficients for the Runge-Kutta-Feagin method of order 12 with an embedded 14th order
-      )doc" )
+
+Coefficients for the Runge-Kutta-Feagin method of order 12 with an embedded 14th order
+
+)doc" )
             .export_values( );
 
     py::enum_< tni::RungeKuttaCoefficients::OrderEstimateToIntegrate >( m,
                                                                         "OrderToIntegrate",
                                                                         R"doc(
 
-         Enumeration defining Which integrator order needs to be integrated, only used for coefficient sets with an embedded order.
+Enumeration defining Which integrator order needs to be integrated, only used for coefficient sets with an embedded order.
 
 
 
@@ -229,20 +279,24 @@ void expose_integrator_setup( py::module &m )
             .value( "lower",
                     tni::RungeKuttaCoefficients::OrderEstimateToIntegrate::lower,
                     R"doc(
- For a method of order :math:`p`, with embedded method of order :math:`q`, the step is taken using the method with order :math:`\min(p,q)`
-      )doc" )
+
+For a method of order :math:`p`, with embedded method of order :math:`q`, the step is taken using the method with order :math:`\min(p,q)`
+
+)doc" )
             .value( "higher",
                     tni::RungeKuttaCoefficients::OrderEstimateToIntegrate::higher,
                     R"doc(
- For a method of order :math:`p`, with embedded method of order :math:`q`, the step is taken using the method with order :math:`\max(p,q)`
-      )doc" )
+
+For a method of order :math:`p`, with embedded method of order :math:`q`, the step is taken using the method with order :math:`\max(p,q)`
+
+)doc" )
             .export_values( );
 
     py::enum_< tni::ExtrapolationMethodStepSequences >( m,
                                                         "ExtrapolationMethodStepSequences",
                                                         R"doc(
 
-         Enumeration of available extrapolation method substep sequences, with :math:`n_{j}` defining the number of substeps in iteration :math:`j`.
+Enumeration of available extrapolation method substep sequences, with :math:`n_{j}` defining the number of substeps in iteration :math:`j`.
 
 
 
@@ -252,13 +306,17 @@ void expose_integrator_setup( py::module &m )
             .value( "bulirsch_stoer_sequence",
                     tni::ExtrapolationMethodStepSequences::bulirsch_stoer_sequence,
                     R"doc(
- Sequence for which :math:`n_{j}=2n_{j-2}` (2, 4, 6, 8, 12, 16, 24, ....)
-      )doc" )
+
+Sequence for which :math:`n_{j}=2n_{j-2}` (2, 4, 6, 8, 12, 16, 24, ....)
+
+)doc" )
             .value( "deufelhard_sequence",
                     tni::ExtrapolationMethodStepSequences::deufelhard_sequence,
                     R"doc(
- Sequence for which :math:`n_{j}=2(j+1)` (2, 4, 6, 8, 10, 12, 14, ....)
-      )doc" )
+
+Sequence for which :math:`n_{j}=2(j+1)` (2, 4, 6, 8, 10, 12, 14, ....)
+
+)doc" )
             .export_values( );
 
     // CLASSES
@@ -1227,44 +1285,43 @@ void expose_integrator_setup( py::module &m )
            py::arg( "bandwidth" ) = 200.0,
            R"doc(
 
- Creates the settings for the Adams-Bashforth-Moulton integrator.
+Creates the settings for the Adams-Bashforth-Moulton integrator.
 
- Function to create settings for the Adams-Bashforth-Moulton multistep integrator.
- For this integrator, the step size and order are both according to a control algorithm
- similar to :func:`~tudatpy.numerical_simulation.propagation_setup.integrator.step_size_control_elementwise_scalar_tolerance`.
- The integrator is initialized using an RKF7(8) integrator.
+Function to create settings for the Adams-Bashforth-Moulton multistep integrator.
+For this integrator, the step size and order are both according to a control algorithm
+similar to :func:`~tudatpy.numerical_simulation.propagation_setup.integrator.step_size_control_elementwise_scalar_tolerance`.
+The integrator is initialized using an RKF7(8) integrator.
 
- NOTE: this integrator's step-size and order control algorithm work in a method that is overly simplistic,
- when increasing/decreasing the order, existing function evaluations are re-used, without any recomputations.
- Similarly, when halving or doubling the time-step, the existing interpolating polynomial is evaluated at the relevant points.
- This can lead to unwanted behaviour, where the time-step reduces to unrealistically low values. It is strongly
- recommended that a reasonable minimum step is provided to this function, to partially mitigate this behaviour.
+NOTE: this integrator's step-size and order control algorithm work in a method that is overly simplistic,
+when increasing/decreasing the order, existing function evaluations are re-used, without any recomputations.
+Similarly, when halving or doubling the time-step, the existing interpolating polynomial is evaluated at the relevant points.
+This can lead to unwanted behaviour, where the time-step reduces to unrealistically low values. It is strongly
+recommended that a reasonable minimum step is provided to this function, to partially mitigate this behaviour.
 
-
- Parameters
- ----------
- initial_time_step : float
-     Initial time step to be used.
- minimum_step_size : float
-     Minimum time step to be used during the integration.
- maximum_step_size : float
-     Maximum time step to be used during the integration.
- relative_error_tolerance : float, default=1.0E-12
-     Relative tolerance to adjust the time step.
- absolute_error_tolerance : float, default=1.0E-12
-     Relative tolerance to adjust the time step.
- minimum_order
-     Minimum order of the integrator.
- maximum_order
-     Maximum order of the integrator.
- assess_termination_on_minor_steps : bool, default=false
-     Whether the propagation termination conditions should be evaluated during the intermediate sub-steps of the integrator (true) or only at the end of each integration step (false).
- bandwidth : float, default=200.0
-     Maximum error factor for doubling the step size.
- Returns
- -------
- IntegratorSettings
-     Object containing settings for the integrator.
+Parameters
+----------
+initial_time_step : float
+    Initial time step to be used.
+minimum_step_size : float
+    Minimum time step to be used during the integration.
+maximum_step_size : float
+    Maximum time step to be used during the integration.
+relative_error_tolerance : float, default=1.0E-12
+    Relative tolerance to adjust the time step.
+absolute_error_tolerance : float, default=1.0E-12
+    Relative tolerance to adjust the time step.
+minimum_order
+    Minimum order of the integrator.
+maximum_order
+    Maximum order of the integrator.
+assess_termination_on_minor_steps : bool, default=false
+    Whether the propagation termination conditions should be evaluated during the intermediate sub-steps of the integrator (true) or only at the end of each integration step (false).
+bandwidth : float, default=200.0
+    Maximum error factor for doubling the step size.
+Returns
+-------
+IntegratorSettings
+    Object containing settings for the integrator.
 
 
 
@@ -1285,34 +1342,33 @@ void expose_integrator_setup( py::module &m )
            py::arg( "bandwidth" ) = 200.0,
            R"doc(
 
- Creates the settings for the Adams-Bashforth-Moulton integrator of fixed order.
+Creates the settings for the Adams-Bashforth-Moulton integrator of fixed order.
 
- Same as :func:`~tudatpy.numerical_simulation.propagation_setup.integrator.adams_bashforth_moulton`, but
- with fixed order and variable step
+Same as :func:`~tudatpy.numerical_simulation.propagation_setup.integrator.adams_bashforth_moulton`, but
+with fixed order and variable step
 
-
- Parameters
- ----------
- initial_time_step : float
-     Initial time step to be used.
- minimum_step_size : float
-     Minimum time step to be used during the integration.
- maximum_step_size : float
-     Maximum time step to be used during the integration.
- relative_error_tolerance : float, default=1.0E-12
-     Relative tolerance to adjust the time step.
- absolute_error_tolerance : float, default=1.0E-12
-     Relative tolerance to adjust the time step.
- order
-     Order of the integrator.
- assess_termination_on_minor_steps : bool, default=false
-     Whether the propagation termination conditions should be evaluated during the intermediate sub-steps of the integrator (true) or only at the end of each integration step (false).
- bandwidth : float, default=200.0
-     Maximum error factor for doubling the step size.
- Returns
- -------
- IntegratorSettings
-     Object containing settings for the integrator.
+Parameters
+----------
+initial_time_step : float
+    Initial time step to be used.
+minimum_step_size : float
+    Minimum time step to be used during the integration.
+maximum_step_size : float
+    Maximum time step to be used during the integration.
+relative_error_tolerance : float, default=1.0E-12
+    Relative tolerance to adjust the time step.
+absolute_error_tolerance : float, default=1.0E-12
+    Relative tolerance to adjust the time step.
+order
+    Order of the integrator.
+assess_termination_on_minor_steps : bool, default=false
+    Whether the propagation termination conditions should be evaluated during the intermediate sub-steps of the integrator (true) or only at the end of each integration step (false).
+bandwidth : float, default=200.0
+    Maximum error factor for doubling the step size.
+Returns
+-------
+IntegratorSettings
+    Object containing settings for the integrator.
 
 
 

--- a/src/tudatpy/numerical_simulation/propagation_setup/propagator/expose_propagator.cpp
+++ b/src/tudatpy/numerical_simulation/propagation_setup/propagator/expose_propagator.cpp
@@ -726,13 +726,6 @@ Enumeration of possible propagation termination types
          `PropagatorSettings`-derived class to define settings for single-arc dynamics.
 
 
-         Attributes
-         ----------
-         termination_settings : PropagationTerminationSettings
-             Settings for creating the object that checks whether the propagation is finished.
-
-
-
 
       )doc" )
             .def_property( "termination_settings",
@@ -740,7 +733,10 @@ Enumeration of possible propagation termination types
                                                              TIME_TYPE >::getTerminationSettings,
                            &tp::SingleArcPropagatorSettings< STATE_SCALAR_TYPE,
                                                              TIME_TYPE >::resetTerminationSettings,
-                           R"doc(No propagator documentation found.)doc" )
+                           R"doc(Settings for creating the object that checks whether the propagation is finished.
+                           
+                           :type: PropagationTerminationSettings
+                           )doc" )
             .def_property( "integrator_settings",
                            &tp::SingleArcPropagatorSettings< STATE_SCALAR_TYPE,
                                                              TIME_TYPE >::getIntegratorSettings,

--- a/src/tudatpy/numerical_simulation/propagation_setup/propagator/expose_propagator.cpp
+++ b/src/tudatpy/numerical_simulation/propagation_setup/propagator/expose_propagator.cpp
@@ -514,39 +514,53 @@ Enumeration of available translational propagator types.
             .value( "cowell",
                     tp::TranslationalPropagatorType::cowell,
                     R"doc(
+
 Propagation of Cartesian elements (state vector size 6), without any transformations
-      )doc" )
+
+)doc" )
             .value( "encke",
                     tp::TranslationalPropagatorType::encke,
                     R"doc(
+
 Propagation of the difference in Cartesian elements of the orbit w.r.t. an unperturbed reference orbit. The reference orbit is generated from the initial state/central body, and not updated during the propagation (see Wakker, 2015 [2]_)
-      )doc" )
+
+)doc" )
             .value( "gauss_keplerian",
                     tp::TranslationalPropagatorType::gauss_keplerian,
                     R"doc(
+
 Propagation of Keplerian elements (state vector size 6), with true anomaly as the 'fast' element  (see Vallado, 2001 [4]_)
-      )doc" )
+
+)doc" )
             .value( "gauss_modified_equinoctial",
                     tp::TranslationalPropagatorType::gauss_modified_equinoctial,
                     R"doc(
+
 Propagation of Modified equinoctial elements (state vector size 6), with the element :math:`I` defining the location of the singularity based on the initial condition (see Hintz, 2008 [3]_)
-      )doc" )
+
+)doc" )
             .value( "unified_state_model_quaternions",
                     tp::TranslationalPropagatorType::unified_state_model_quaternions,
                     R"doc(
+
 Propagation of Unified state model using quaternions (state vector size 7, see Vittaldev et al., 2012 [1]_)
-      )doc" )
+
+)doc" )
             .value( "unified_state_model_modified_rodrigues_parameters",
                     tp::TranslationalPropagatorType::
                             unified_state_model_modified_rodrigues_parameters,
                     R"doc(
+
 Propagation of Unified state model using modified Rodrigues parameters (state vector size 7, last element represents shadow parameter, see Vittaldev et al., 2012 [1]_)
-      )doc" )
+
+)doc" )
             .value( "unified_state_model_exponential_map",
                     tp::unified_state_model_exponential_map,
                     R"doc(
+
 Propagation of Unified state model using exponential map (state vector size 7, last element represents shadow parameter, see Vittaldev et al., 2012 [1]_)
-      )doc" )
+
+)doc" )
             .export_values( );
 
     py::enum_< tp::RotationalPropagatorType >( m,
@@ -567,24 +581,30 @@ Enumeration of available rotational propagator types.
             .value( "quaternions",
                     tp::RotationalPropagatorType::quaternions,
                     R"doc(
+
 Entries 1-4: The quaternion defining the rotation from inertial to body-fixed frame (see `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/environment_setup/frames_in_environment.html#definition-of-rotational-state>`__)
 
 Entries 5-7: The body's angular velocity vector, expressed in its body-fixed frame.
-      )doc" )
+
+)doc" )
             .value( "modified_rodrigues_parameters",
                     tp::RotationalPropagatorType::modified_rodrigues_parameters,
                     R"doc(
+
 Entries 1-4: The modified Rodrigues parameters defining the rotation from inertial to body-fixed frame (with entry four the shadow parameter)
 
 Entries 5-7: The body's angular velocity vector, expressed in its body-fixed frame.
-      )doc" )
+
+)doc" )
             .value( "exponential_map",
                     tp::RotationalPropagatorType::exponential_map,
                     R"doc(
+
 Entries 1-4: The exponential map defining the rotation from inertial to body-fixed frame (with entry four the shadow parameter)
 
 Entries 5-7: The body's angular velocity vector, expressed in its body-fixed frame.
-      )doc" )
+
+)doc" )
             .export_values( );
 
     py::enum_< tp::PropagationTerminationTypes >( m,
@@ -619,7 +639,7 @@ Enumeration of possible propagation termination types
                                           "StateType",
                                           R"doc(
 
-         Enumeration of available integrated state types.
+Enumeration of available integrated state types.
 
 
 


### PR DESCRIPTION
Second iteration of #270. All outstanding warnings when building the API docs have been fixed - no more red in the build process!

Main changes:
- Remove some duplicate and no-longer exposed functions
- Add blank lines around enum member docstrings. When pybind generates the docstring for enums, the enum member names are appended to a `"\n\n  "` string (see [pybind11.h#L2574](https://github.com/pybind/pybind11/blob/bc4a66dff0464d0c87291b00a3688999fea5bedc/include/pybind11/pybind11.h#L2574)). The two spaces before the member name make Sphinx interpret the member name as an indented quotation, which needs to be surrounded by blank lines. The user-defined docstrings are then [simply appended in pybind](https://github.com/pybind/pybind11/blob/bc4a66dff0464d0c87291b00a3688999fea5bedc/include/pybind11/pybind11.h#L2578) without any blank lines, which causes all the Sphinx warnings. To get rid of these warnings, blank lines have been added around all member docstrings.