### PR TITLE
Create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/features---enhancements.md
+++ b/.github/ISSUE_TEMPLATE/features---enhancements.md
@@ -1,0 +1,17 @@
+---
+name: Features & Enhancements
+about: Something that tudatpy should have
+title: "[F&E]: <Short and descriptive title>"
+labels: ''
+assignees: ''
+
+---
+
+**Description**
+Provide a concise description of the new feature. Explain why this feature is important.
+
+**Possible Implementation**
+If you want, you can suggest a high level approach to implementing this feature.
+
+**Additional Context**
+Include any other relevant context or attach screenshots.

--- a/.github/ISSUE_TEMPLATE/report-a-bug.md
+++ b/.github/ISSUE_TEMPLATE/report-a-bug.md
@@ -11,7 +11,7 @@ assignees: ''
 A clear and concise description of what the bug is.
 
 **To Reproduce**
-List the steps to reproduce the bug. Include any relevant screenshots or code snippets.
+List the steps to reproduce the bug. Include any relevant screenshots or code snippets. You can also add a link to a file in a Github repository to make the problematic bit of source code easier to find.
 
 **Expected behavior**
 Describe what you expected to happen

--- a/.github/ISSUE_TEMPLATE/report-a-bug.md
+++ b/.github/ISSUE_TEMPLATE/report-a-bug.md
@@ -1,0 +1,27 @@
+---
+name: Report a bug
+about: Something is not working as expected
+title: "[BUG] <Short and descriptive title>"
+labels: 'type: bug'
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+List the steps to reproduce the bug. Include any relevant screenshots or code snippets.
+
+**Expected behavior**
+Describe what you expected to happen
+
+**Current behavior**
+Describe what happened instead.
+
+**Device information**
+ - OS: [e.g. Linux, macOS Intel/ARM, Windows]
+ - Python version: [e.g. 3.12]
+
+**Additional context**
+Include any other relevant context or attach screenshots.


### PR DESCRIPTION
Make it easier for users to follow new developing guidelines by setting up templates for pull requests.

The templates are based on the development guidelines suggested by @valeriof7 .