### PR TITLE
Make all kernel imports absolute

### DIFF
--- a/src/tudatpy/astro/__init__.py
+++ b/src/tudatpy/astro/__init__.py
@@ -1,9 +1,1 @@
-from ..kernel.astro import (
-    element_conversion,
-    frame_conversion,
-    fundamentals,
-    gravitation,
-    polyhedron_utilities,
-    time_conversion,
-    two_body_dynamics,
-)
+from tudatpy.kernel.astro import *

--- a/src/tudatpy/astro/element_conversion/__init__.py
+++ b/src/tudatpy/astro/element_conversion/__init__.py
@@ -1,1 +1,1 @@
-from ...kernel.astro.element_conversion import *
+from tudatpy.kernel.astro.element_conversion import *

--- a/src/tudatpy/astro/frame_conversion/__init__.py
+++ b/src/tudatpy/astro/frame_conversion/__init__.py
@@ -1,1 +1,1 @@
-from ...kernel.astro.frame_conversion import *
+from tudatpy.kernel.astro.frame_conversion import *

--- a/src/tudatpy/astro/fundamentals/__init__.py
+++ b/src/tudatpy/astro/fundamentals/__init__.py
@@ -1,1 +1,1 @@
-from ...kernel.astro.fundamentals import *
+from tudatpy.kernel.astro.fundamentals import *

--- a/src/tudatpy/astro/gravitation/__init__.py
+++ b/src/tudatpy/astro/gravitation/__init__.py
@@ -1,1 +1,1 @@
-from ...kernel.astro.gravitation import *
+from tudatpy.kernel.astro.gravitation import *

--- a/src/tudatpy/astro/polyhedron_utilities/__init__.py
+++ b/src/tudatpy/astro/polyhedron_utilities/__init__.py
@@ -1,1 +1,1 @@
-from ...kernel.astro.polyhedron_utilities import *
+from tudatpy.kernel.astro.polyhedron_utilities import *

--- a/src/tudatpy/astro/time_conversion/__init__.py
+++ b/src/tudatpy/astro/time_conversion/__init__.py
@@ -1,1 +1,1 @@
-from ...kernel.astro.time_conversion import *
+from tudatpy.kernel.astro.time_conversion import *

--- a/src/tudatpy/astro/two_body_dynamics/__init__.py
+++ b/src/tudatpy/astro/two_body_dynamics/__init__.py
@@ -1,1 +1,1 @@
-from ...kernel.astro.two_body_dynamics import *
+from tudatpy.kernel.astro.two_body_dynamics import *

--- a/src/tudatpy/constants/__init__.py
+++ b/src/tudatpy/constants/__init__.py
@@ -1,1 +1,1 @@
-from ..kernel.constants import *
+from tudatpy.kernel.constants import *

--- a/src/tudatpy/data/__init__.py
+++ b/src/tudatpy/data/__init__.py
@@ -1,3 +1,3 @@
-from ..kernel.data import *
+from tudatpy.kernel.data import *
 from ._support import save2txt, save_time_history_to_file
 from .mission_data_downloader import LoadPDS

--- a/src/tudatpy/data/__init__.py
+++ b/src/tudatpy/data/__init__.py
@@ -1,3 +1,4 @@
 from tudatpy.kernel.data import *
 from ._support import save2txt, save_time_history_to_file
 from .mission_data_downloader import LoadPDS
+from . import horizons, mpc, sbdb

--- a/src/tudatpy/interface/__init__.py
+++ b/src/tudatpy/interface/__init__.py
@@ -1,1 +1,1 @@
-from ..kernel.interface import spice
+from tudatpy.kernel.interface import *

--- a/src/tudatpy/interface/spice/__init__.py
+++ b/src/tudatpy/interface/spice/__init__.py
@@ -1,1 +1,1 @@
-from ...kernel.interface.spice import *
+from tudatpy.kernel.interface.spice import *

--- a/src/tudatpy/math/__init__.py
+++ b/src/tudatpy/math/__init__.py
@@ -1,7 +1,1 @@
-from ..kernel.math import (
-    geometry,
-    interpolators,
-    numerical_integrators,
-    root_finders,
-    statistics,
-)
+from tudatpy.kernel.math import *

--- a/src/tudatpy/math/geometry/__init__.py
+++ b/src/tudatpy/math/geometry/__init__.py
@@ -1,1 +1,1 @@
-from ...kernel.math.geometry import *
+from tudatpy.kernel.math.geometry import *

--- a/src/tudatpy/math/interpolators/__init__.py
+++ b/src/tudatpy/math/interpolators/__init__.py
@@ -1,1 +1,1 @@
-from ...kernel.math.interpolators import *
+from tudatpy.kernel.math.interpolators import *

--- a/src/tudatpy/math/numerical_integrators/__init__.py
+++ b/src/tudatpy/math/numerical_integrators/__init__.py
@@ -1,1 +1,1 @@
-from ...kernel.math.numerical_integrators import *
+from tudatpy.kernel.math.numerical_integrators import *

--- a/src/tudatpy/math/root_finders/__init__.py
+++ b/src/tudatpy/math/root_finders/__init__.py
@@ -1,1 +1,1 @@
-from ...kernel.math.root_finders import *
+from tudatpy.kernel.math.root_finders import *

--- a/src/tudatpy/math/statistics/__init__.py
+++ b/src/tudatpy/math/statistics/__init__.py
@@ -1,1 +1,1 @@
-from ...kernel.math.statistics import *
+from tudatpy.kernel.math.statistics import *

--- a/src/tudatpy/numerical_simulation/__init__.py
+++ b/src/tudatpy/numerical_simulation/__init__.py
@@ -1,9 +1,1 @@
-from ..kernel.numerical_simulation import (
-    environment,
-    environment_setup,
-    estimation,
-    estimation_setup,
-    propagation,
-    propagation_setup,
-)
-from ..kernel.numerical_simulation import *
+from tudatpy.kernel.numerical_simulation import *

--- a/src/tudatpy/numerical_simulation/environment/__init__.py
+++ b/src/tudatpy/numerical_simulation/environment/__init__.py
@@ -1,1 +1,1 @@
-from ...kernel.numerical_simulation.environment import *
+from tudatpy.kernel.numerical_simulation.environment import *

--- a/src/tudatpy/numerical_simulation/environment_setup/__init__.py
+++ b/src/tudatpy/numerical_simulation/environment_setup/__init__.py
@@ -1,14 +1,1 @@
-from ...kernel.numerical_simulation.environment_setup import (
-    aerodynamic_coefficients,
-    atmosphere,
-    gravity_field,
-    gravity_field_variation,
-    ground_station,
-    radiation_pressure,
-    rigid_body,
-    rotation_model,
-    shape,
-    shape_deformation,
-    vehicle_systems,
-)
-from ...kernel.numerical_simulation.environment_setup import *
+from tudatpy.kernel.numerical_simulation.environment_setup import *

--- a/src/tudatpy/numerical_simulation/environment_setup/aerodynamic_coefficients/__init__.py
+++ b/src/tudatpy/numerical_simulation/environment_setup/aerodynamic_coefficients/__init__.py
@@ -1,1 +1,1 @@
-from ....kernel.numerical_simulation.environment_setup.aerodynamic_coefficients import *
+from tudatpy.kernel.numerical_simulation.environment_setup.aerodynamic_coefficients import *

--- a/src/tudatpy/numerical_simulation/environment_setup/atmosphere/__init__.py
+++ b/src/tudatpy/numerical_simulation/environment_setup/atmosphere/__init__.py
@@ -1,1 +1,1 @@
-from ....kernel.numerical_simulation.environment_setup.atmosphere import *
+from tudatpy.kernel.numerical_simulation.environment_setup.atmosphere import *

--- a/src/tudatpy/numerical_simulation/environment_setup/ephemeris/__init__.py
+++ b/src/tudatpy/numerical_simulation/environment_setup/ephemeris/__init__.py
@@ -1,2 +1,2 @@
-from ....kernel.numerical_simulation.environment_setup.ephemeris import *
+from tudatpy.kernel.numerical_simulation.environment_setup.ephemeris import *
 from .horizons_wrapper import jpl_horizons, HorizonsBatch, HorizonsQuery

--- a/src/tudatpy/numerical_simulation/environment_setup/ephemeris/horizons_wrapper.py
+++ b/src/tudatpy/numerical_simulation/environment_setup/ephemeris/horizons_wrapper.py
@@ -11,16 +11,14 @@ import math
 import numpy as np
 import pandas as pd
 
-from typing import Union, List, Tuple, Any, TYPE_CHECKING
+from typing import Union, List, Any
 import datetime
 
-from .... import constants
-from ....kernel.numerical_simulation.environment_setup import ephemeris
-
-if TYPE_CHECKING:
-    from ....kernel.numerical_simulation.environment_setup import (
-        BodyListSettings,
-    )
+from tudatpy import constants
+from tudatpy.kernel.numerical_simulation.environment_setup import (
+    ephemeris,
+    BodySettings,
+)
 
 
 class HorizonsQuery:

--- a/src/tudatpy/numerical_simulation/environment_setup/gravity_field/__init__.py
+++ b/src/tudatpy/numerical_simulation/environment_setup/gravity_field/__init__.py
@@ -1,2 +1,2 @@
-from ....kernel.numerical_simulation.environment_setup.gravity_field import *
+from tudatpy.kernel.numerical_simulation.environment_setup.gravity_field import *
 from .sbdb_wrapper import central_sbdb, central_sbdb_density

--- a/src/tudatpy/numerical_simulation/environment_setup/gravity_field_variation/__init__.py
+++ b/src/tudatpy/numerical_simulation/environment_setup/gravity_field_variation/__init__.py
@@ -1,1 +1,1 @@
-from ....kernel.numerical_simulation.environment_setup.gravity_field_variation import *
+from tudatpy.kernel.numerical_simulation.environment_setup.gravity_field_variation import *

--- a/src/tudatpy/numerical_simulation/environment_setup/ground_station/__init__.py
+++ b/src/tudatpy/numerical_simulation/environment_setup/ground_station/__init__.py
@@ -1,1 +1,1 @@
-from ....kernel.numerical_simulation.environment_setup.ground_station import *
+from tudatpy.kernel.numerical_simulation.environment_setup.ground_station import *

--- a/src/tudatpy/numerical_simulation/environment_setup/radiation_pressure/__init__.py
+++ b/src/tudatpy/numerical_simulation/environment_setup/radiation_pressure/__init__.py
@@ -1,1 +1,1 @@
-from ....kernel.numerical_simulation.environment_setup.radiation_pressure import *
+from tudatpy.kernel.numerical_simulation.environment_setup.radiation_pressure import *

--- a/src/tudatpy/numerical_simulation/environment_setup/rigid_body/__init__.py
+++ b/src/tudatpy/numerical_simulation/environment_setup/rigid_body/__init__.py
@@ -1,1 +1,1 @@
-from ....kernel.numerical_simulation.environment_setup.rigid_body import *
+from tudatpy.kernel.numerical_simulation.environment_setup.rigid_body import *

--- a/src/tudatpy/numerical_simulation/environment_setup/rotation_model/__init__.py
+++ b/src/tudatpy/numerical_simulation/environment_setup/rotation_model/__init__.py
@@ -1,1 +1,1 @@
-from ....kernel.numerical_simulation.environment_setup.rotation_model import *
+from tudatpy.kernel.numerical_simulation.environment_setup.rotation_model import *

--- a/src/tudatpy/numerical_simulation/environment_setup/shape/__init__.py
+++ b/src/tudatpy/numerical_simulation/environment_setup/shape/__init__.py
@@ -1,1 +1,1 @@
-from ....kernel.numerical_simulation.environment_setup.shape import *
+from tudatpy.kernel.numerical_simulation.environment_setup.shape import *

--- a/src/tudatpy/numerical_simulation/environment_setup/shape_deformation/__init__.py
+++ b/src/tudatpy/numerical_simulation/environment_setup/shape_deformation/__init__.py
@@ -1,1 +1,1 @@
-from ....kernel.numerical_simulation.environment_setup.shape_deformation import *
+from tudatpy.kernel.numerical_simulation.environment_setup.shape_deformation import *

--- a/src/tudatpy/numerical_simulation/environment_setup/vehicle_systems/__init__.py
+++ b/src/tudatpy/numerical_simulation/environment_setup/vehicle_systems/__init__.py
@@ -1,1 +1,1 @@
-from ....kernel.numerical_simulation.environment_setup.vehicle_systems import *
+from tudatpy.kernel.numerical_simulation.environment_setup.vehicle_systems import *

--- a/src/tudatpy/numerical_simulation/estimation/__init__.py
+++ b/src/tudatpy/numerical_simulation/estimation/__init__.py
@@ -1,1 +1,1 @@
-from ...kernel.numerical_simulation.estimation import *
+from tudatpy.kernel.numerical_simulation.estimation import *

--- a/src/tudatpy/numerical_simulation/estimation_setup/__init__.py
+++ b/src/tudatpy/numerical_simulation/estimation_setup/__init__.py
@@ -1,5 +1,1 @@
-from ...kernel.numerical_simulation.estimation_setup import (
-    observation,
-    parameter,
-)
-from ...kernel.numerical_simulation.estimation_setup import *
+from tudatpy.kernel.numerical_simulation.estimation_setup import *

--- a/src/tudatpy/numerical_simulation/estimation_setup/observation/__init__.py
+++ b/src/tudatpy/numerical_simulation/estimation_setup/observation/__init__.py
@@ -1,1 +1,1 @@
-from ....kernel.numerical_simulation.estimation_setup.observation import *
+from tudatpy.kernel.numerical_simulation.estimation_setup.observation import *

--- a/src/tudatpy/numerical_simulation/estimation_setup/parameter/__init__.py
+++ b/src/tudatpy/numerical_simulation/estimation_setup/parameter/__init__.py
@@ -1,1 +1,1 @@
-from ....kernel.numerical_simulation.estimation_setup.parameter import *
+from tudatpy.kernel.numerical_simulation.estimation_setup.parameter import *

--- a/src/tudatpy/numerical_simulation/propagation/__init__.py
+++ b/src/tudatpy/numerical_simulation/propagation/__init__.py
@@ -1,4 +1,4 @@
-from ...kernel.numerical_simulation.propagation import *
+from tudatpy.kernel.numerical_simulation.propagation import *
 
 from .dependent_variable_dictionary import (
     DependentVariableDictionary,

--- a/src/tudatpy/numerical_simulation/propagation_setup/__init__.py
+++ b/src/tudatpy/numerical_simulation/propagation_setup/__init__.py
@@ -1,10 +1,1 @@
-from ...kernel.numerical_simulation.propagation_setup import (
-    acceleration,
-    dependent_variable,
-    integrator,
-    mass_rate,
-    propagator,
-    thrust,
-    torque,
-)
-from ...kernel.numerical_simulation.propagation_setup import *
+from tudatpy.kernel.numerical_simulation.propagation_setup import *

--- a/src/tudatpy/numerical_simulation/propagation_setup/acceleration/__init__.py
+++ b/src/tudatpy/numerical_simulation/propagation_setup/acceleration/__init__.py
@@ -1,1 +1,1 @@
-from ....kernel.numerical_simulation.propagation_setup.acceleration import *
+from tudatpy.kernel.numerical_simulation.propagation_setup.acceleration import *

--- a/src/tudatpy/numerical_simulation/propagation_setup/dependent_variable/__init__.py
+++ b/src/tudatpy/numerical_simulation/propagation_setup/dependent_variable/__init__.py
@@ -1,1 +1,1 @@
-from ....kernel.numerical_simulation.propagation_setup.dependent_variable import *
+from tudatpy.kernel.numerical_simulation.propagation_setup.dependent_variable import *

--- a/src/tudatpy/numerical_simulation/propagation_setup/integrator/__init__.py
+++ b/src/tudatpy/numerical_simulation/propagation_setup/integrator/__init__.py
@@ -1,1 +1,1 @@
-from ....kernel.numerical_simulation.propagation_setup.integrator import *
+from tudatpy.kernel.numerical_simulation.propagation_setup.integrator import *

--- a/src/tudatpy/numerical_simulation/propagation_setup/mass_rate/__init__.py
+++ b/src/tudatpy/numerical_simulation/propagation_setup/mass_rate/__init__.py
@@ -1,1 +1,1 @@
-from ....kernel.numerical_simulation.propagation_setup.mass_rate import *
+from tudatpy.kernel.numerical_simulation.propagation_setup.mass_rate import *

--- a/src/tudatpy/numerical_simulation/propagation_setup/propagator/__init__.py
+++ b/src/tudatpy/numerical_simulation/propagation_setup/propagator/__init__.py
@@ -1,1 +1,1 @@
-from ....kernel.numerical_simulation.propagation_setup.propagator import *
+from tudatpy.kernel.numerical_simulation.propagation_setup.propagator import *

--- a/src/tudatpy/numerical_simulation/propagation_setup/thrust/__init__.py
+++ b/src/tudatpy/numerical_simulation/propagation_setup/thrust/__init__.py
@@ -1,1 +1,1 @@
-from ....kernel.numerical_simulation.propagation_setup.thrust import *
+from tudatpy.kernel.numerical_simulation.propagation_setup.thrust import *

--- a/src/tudatpy/numerical_simulation/propagation_setup/torque/__init__.py
+++ b/src/tudatpy/numerical_simulation/propagation_setup/torque/__init__.py
@@ -1,1 +1,1 @@
-from ....kernel.numerical_simulation.propagation_setup.torque import *
+from tudatpy.kernel.numerical_simulation.propagation_setup.torque import *

--- a/src/tudatpy/trajectory_design/__init__.py
+++ b/src/tudatpy/trajectory_design/__init__.py
@@ -1,1 +1,2 @@
 from tudatpy.kernel.trajectory_design import *
+from . import porkchop

--- a/src/tudatpy/trajectory_design/__init__.py
+++ b/src/tudatpy/trajectory_design/__init__.py
@@ -1,1 +1,1 @@
-from ..kernel.trajectory_design import transfer_trajectory, shape_based_thrust
+from tudatpy.kernel.trajectory_design import *

--- a/src/tudatpy/trajectory_design/shape_based_thrust/__init__.py
+++ b/src/tudatpy/trajectory_design/shape_based_thrust/__init__.py
@@ -1,1 +1,1 @@
-from ...kernel.trajectory_design.shape_based_thrust import *
+from tudatpy.kernel.trajectory_design.shape_based_thrust import *

--- a/src/tudatpy/trajectory_design/transfer_trajectory/__init__.py
+++ b/src/tudatpy/trajectory_design/transfer_trajectory/__init__.py
@@ -1,1 +1,1 @@
-from ...kernel.trajectory_design.transfer_trajectory import *
+from tudatpy.kernel.trajectory_design.transfer_trajectory import *

--- a/src/tudatpy/util/__init__.py
+++ b/src/tudatpy/util/__init__.py
@@ -1,5 +1,16 @@
-from ._dse_functions import *
-from ._support import *
+from ._dse_functions import (
+    get_orthogonal_array,
+    get_yates_array,
+    anova_analysis,
+)
+from ._support import (
+    result2array,
+    compare_results,
+    redirect_std,
+    pareto_optimums,
+    split_history,
+    vector2matrix,
+)
 
 __all__ = [
     "result2array",


### PR DESCRIPTION
In the current version of the `develop` branch, all the imports from `kernel` are relative
```python
# In numerical_simulation.environment.__init__.py
from ...kernel.numerical_simulation.environment import *
```
This was an arbitrary choice I made out of habit, but using absolute imports produces the same result
```python
from tudatpy.kernel.numerical_simulation.environment import *
```
Although they are practically equivalent, using absolute imports removes complexity from the stub generation pipeline. For this reason, this pull request makes all the relative kernel imports in tudatpy absolute.