### PR TITLE
Fix test_nrlmsise00, expose geodetic latitude and UTC conversion

### DIFF
--- a/src/tudatpy/astro/element_conversion/expose_element_conversion.cpp
+++ b/src/tudatpy/astro/element_conversion/expose_element_conversion.cpp
@@ -187,6 +187,48 @@ Enumeration describing different types of position element types (typically used
 
      )doc" );
 
+    m.def( "convert_geographic_to_geodetic_latitude",
+    &tcc::convertGeographicToGeodeticLatitude,
+    py::arg( "geographic_latitude" ),
+    py::arg( "equatorial_radius" ),
+    py::arg( "flattening" ),
+    py::arg( "altitude" ),
+    py::arg( "tolerance" ),
+    py::arg( "maximum_number_of_iterations" ),
+    R"doc(
+
+ Convert geographic latitude to geodetic latitude.
+
+ This function converts a geographic latitude to a geodetic latitude, given the equatorial radius, flattening, altitude, 
+ and a convergence tolerance. The conversion is performed iteratively, with a maximum number of iterations allowed.
+
+ Parameters
+ ----------
+ geographic_latitude : float
+     Geographic latitude (in radians) to be converted.
+ equatorial_radius : float
+     Equatorial radius of the reference ellipsoid (in meters).
+ flattening : float
+     Flattening of the reference ellipsoid.
+ altitude : float
+     Altitude above the reference ellipsoid (in meters).
+ tolerance : float
+     Convergence tolerance for the iterative conversion (in radians).
+ maximum_number_of_iterations : int
+     Maximum number of iterations allowed for the conversion process.
+
+ Returns
+ -------
+ float
+     Geodetic latitude (in radians), as computed from the geographic latitude input.
+
+ Raises
+ ------
+ RuntimeError
+     If the maximum number of iterations is exceeded without achieving the desired tolerance.
+
+     )doc" );
+
     m.def( "convert_position_elements",
            &tcc::convertPositionElements,
            py::arg( "original_elements" ),

--- a/src/tudatpy/interface/spice/expose_spice.cpp
+++ b/src/tudatpy/interface/spice/expose_spice.cpp
@@ -90,6 +90,29 @@ void expose_spice( py::module &m )
 
      )doc" );
 
+
+    m.def( "get_approximate_utc_from_tdb",
+       &tudat::spice_interface::getApproximateUtcFromTdb,
+       py::arg( "ephemeris_time" ),
+       R"doc(
+
+ Get an approximate UTC time from ephemeris time (TDB).
+
+ This function computes an approximate UTC time from the given ephemeris time (TDB). 
+ It uses the `deltet_c` Spice function to calculate the offset between TDB and UTC.
+
+ Parameters
+ ----------
+ ephemeris_time : float
+     Ephemeris time (TDB) to be converted to UTC.
+
+ Returns
+ -------
+ utc_time : float
+     Approximate UTC time corresponding to the given ephemeris time.
+
+     )doc" );
+
     //  m.def("jd2tdb",
     //  m.attr("convert_julian_date_to_ephemeris_time"));
 

--- a/src/tudatpy/numerical_simulation/environment_setup/atmosphere/expose_atmosphere.cpp
+++ b/src/tudatpy/numerical_simulation/environment_setup/atmosphere/expose_atmosphere.cpp
@@ -112,7 +112,7 @@ void expose_atmosphere_setup( py::module &m )
                           std::shared_ptr< tio::solar_activity::SolarActivityData > >, const bool, const bool, const bool >( ),
                   py::arg( "solar_activity_data" ),
                   py::arg( "use_ideal_gas_law" ) = true,
-                  py::arg( "use_storm_conditions" ) = true,
+                  py::arg( "use_storm_conditions" ) = false,
                   py::arg( "use_anomalous_oxygen" ) = true )
             .def( "get_density",
                   &ta::NRLMSISE00Atmosphere::getDensity,


### PR DESCRIPTION
## Description

Exposed `convertGeographicToGeodeticLatitude` to fix `test_nrlmsise00.py` using converted geodetic latitudes, enabling the test to pass under its original `5e-6` tolerance. Also exposed `getApproximateUtcFromTdb` for fast, sufficiently accurate UTC conversion in user-defined density models. Finally, changed default `use_storm_conditions` to `False` for consistency in standalone `NRLMSISE00Atmosphere` creation.

## Related Issue(s)

Closes #279.

## Feature or Bug Fix Details

- Two C++ utility functions exposed to Python.
- Test updated to correct input.
- Standalone NRLMSISE model behaviour aligned with Tudat(py).

## Testing Details

- Verified test now passes with corrected inputs.
- Confirmed function usability from Python.

## Checklist

- [x] Branch name follows TUDAT convention (`fix/issue-279-nrlmsise-test-bug`)
- [x] Unit tests have been added or updated.
- [x] Code builds and runs without errors.
- [x] Latest changes from `develop` have been merged into the branch.
- [x] Code has been reviewed for clarity and maintainability.
- [x] The code follows TUDAT coding guidelines.

## Additional Notes

The exposed UTC function is not the only method to convert TBD to UTC time, but it offers faster and sufficiently accurate conversion for density calculations.