### PR TITLE
Feature/nrlmsise utc latitude setters

### DIFF
--- a/docs/source/element_conversion.rst
+++ b/docs/source/element_conversion.rst
@@ -111,6 +111,8 @@ Functions
 
    convert_cartesian_to_geodetic_coordinates
 
+   convert_geographic_to_geodetic_latitude
+
    cartesian_to_keplerian
 
    keplerian_to_cartesian
@@ -195,6 +197,8 @@ Functions
 .. autofunction:: tudatpy.astro.element_conversion.convert_position_elements
 
 .. autofunction:: tudatpy.astro.element_conversion.convert_cartesian_to_geodetic_coordinates
+
+.. autofunction:: tudatpy.astro.element_conversion.convert_geographic_to_geodetic_latitude
 
 .. autofunction:: tudatpy.astro.element_conversion.cartesian_to_keplerian
 

--- a/docs/source/spice.rst
+++ b/docs/source/spice.rst
@@ -31,6 +31,8 @@ Functions
 
    convert_date_string_to_ephemeris_time
 
+   get_approximate_utc_from_tdb
+
    get_body_cartesian_state_at_epoch
 
    get_body_cartesian_position_at_epoch
@@ -68,6 +70,8 @@ Functions
 .. autofunction:: tudatpy.interface.spice.convert_ephemeris_time_to_julian_date
 
 .. autofunction:: tudatpy.interface.spice.convert_date_string_to_ephemeris_time
+
+.. autofunction:: tudatpy.interface.spice.get_approximate_utc_from_tdb
 
 .. autofunction:: tudatpy.interface.spice.get_body_cartesian_state_at_epoch
 

--- a/src/tudatpy/astro/element_conversion/expose_element_conversion.cpp
+++ b/src/tudatpy/astro/element_conversion/expose_element_conversion.cpp
@@ -187,6 +187,48 @@ Enumeration describing different types of position element types (typically used
 
      )doc" );
 
+    m.def( "convert_geographic_to_geodetic_latitude",
+    &tcc::convertGeographicToGeodeticLatitude,
+    py::arg( "geographic_latitude" ),
+    py::arg( "equatorial_radius" ),
+    py::arg( "flattening" ),
+    py::arg( "altitude" ),
+    py::arg( "tolerance" ),
+    py::arg( "maximum_number_of_iterations" ),
+    R"doc(
+
+ Convert geographic latitude to geodetic latitude.
+
+ This function converts a geographic latitude to a geodetic latitude, given the equatorial radius, flattening, altitude, 
+ and a convergence tolerance. The conversion is performed iteratively, with a maximum number of iterations allowed.
+
+ Parameters
+ ----------
+ geographic_latitude : float
+     Geographic latitude (in radians) to be converted.
+ equatorial_radius : float
+     Equatorial radius of the reference ellipsoid (in meters).
+ flattening : float
+     Flattening of the reference ellipsoid.
+ altitude : float
+     Altitude above the reference ellipsoid (in meters).
+ tolerance : float
+     Convergence tolerance for the iterative conversion (in radians).
+ maximum_number_of_iterations : int
+     Maximum number of iterations allowed for the conversion process.
+
+ Returns
+ -------
+ float
+     Geodetic latitude (in radians), as computed from the geographic latitude input.
+
+ Raises
+ ------
+ RuntimeError
+     If the maximum number of iterations is exceeded without achieving the desired tolerance.
+
+     )doc" );
+
     m.def( "convert_position_elements",
            &tcc::convertPositionElements,
            py::arg( "original_elements" ),

--- a/src/tudatpy/interface/spice/expose_spice.cpp
+++ b/src/tudatpy/interface/spice/expose_spice.cpp
@@ -90,6 +90,29 @@ void expose_spice( py::module &m )
 
      )doc" );
 
+
+    m.def( "get_approximate_utc_from_tdb",
+       &tudat::spice_interface::getApproximateUtcFromTdb,
+       py::arg( "ephemeris_time" ),
+       R"doc(
+
+ Get an approximate UTC time from ephemeris time (TDB).
+
+ This function computes an approximate UTC time from the given ephemeris time (TDB). 
+ It uses the `deltet_c` Spice function to calculate the offset between TDB and UTC.
+
+ Parameters
+ ----------
+ ephemeris_time : float
+     Ephemeris time (TDB) to be converted to UTC.
+
+ Returns
+ -------
+ utc_time : float
+     Approximate UTC time corresponding to the given ephemeris time.
+
+     )doc" );
+
     //  m.def("jd2tdb",
     //  m.attr("convert_julian_date_to_ephemeris_time"));
 

--- a/src/tudatpy/numerical_simulation/environment_setup/atmosphere/expose_atmosphere.cpp
+++ b/src/tudatpy/numerical_simulation/environment_setup/atmosphere/expose_atmosphere.cpp
@@ -114,6 +114,14 @@ void expose_atmosphere_setup( py::module &m )
                   py::arg( "use_ideal_gas_law" ) = true,
                   py::arg( "use_storm_conditions" ) = false,
                   py::arg( "use_anomalous_oxygen" ) = true )
+            .def( "set_use_geodetic_latitude", &ta::NRLMSISE00Atmosphere::setUseGeodeticLatitude,
+                    R"doc(Set whether geodetic latitude is used for density computation instead of geocentric latitude.)doc" )
+            .def( "get_use_geodetic_latitude", &ta::NRLMSISE00Atmosphere::getUseGeodeticLatitude,
+                    R"doc(Get whether geodetic latitude is used for density computation instead of geocentric latitude.)doc" )
+            .def( "set_use_utc", &ta::NRLMSISE00Atmosphere::setUseUtc,
+                    R"doc(Set whether UTC time is used for density computation instead of seconds since J2000.)doc" )
+            .def( "get_use_utc", &ta::NRLMSISE00Atmosphere::getUseUtc,
+                    R"doc(Get whether UTC time is used for density computation instead of seconds since J2000.)doc" )
             .def( "get_density",
                   &ta::NRLMSISE00Atmosphere::getDensity,
                   py::arg( "altitude" ),

--- a/src/tudatpy/numerical_simulation/environment_setup/atmosphere/expose_atmosphere.cpp
+++ b/src/tudatpy/numerical_simulation/environment_setup/atmosphere/expose_atmosphere.cpp
@@ -112,7 +112,7 @@ void expose_atmosphere_setup( py::module &m )
                           std::shared_ptr< tio::solar_activity::SolarActivityData > >, const bool, const bool, const bool >( ),
                   py::arg( "solar_activity_data" ),
                   py::arg( "use_ideal_gas_law" ) = true,
-                  py::arg( "use_storm_conditions" ) = true,
+                  py::arg( "use_storm_conditions" ) = false,
                   py::arg( "use_anomalous_oxygen" ) = true )
             .def( "get_density",
                   &ta::NRLMSISE00Atmosphere::getDensity,

--- a/src/tudatpy/numerical_simulation/environment_setup/atmosphere/expose_atmosphere.cpp
+++ b/src/tudatpy/numerical_simulation/environment_setup/atmosphere/expose_atmosphere.cpp
@@ -114,14 +114,10 @@ void expose_atmosphere_setup( py::module &m )
                   py::arg( "use_ideal_gas_law" ) = true,
                   py::arg( "use_storm_conditions" ) = false,
                   py::arg( "use_anomalous_oxygen" ) = true )
-            .def( "set_use_geodetic_latitude", &ta::NRLMSISE00Atmosphere::setUseGeodeticLatitude,
-                    R"doc(Set whether geodetic latitude is used for density computation instead of geocentric latitude.)doc" )
-            .def( "get_use_geodetic_latitude", &ta::NRLMSISE00Atmosphere::getUseGeodeticLatitude,
-                    R"doc(Get whether geodetic latitude is used for density computation instead of geocentric latitude.)doc" )
-            .def( "set_use_utc", &ta::NRLMSISE00Atmosphere::setUseUtc,
-                    R"doc(Set whether UTC time is used for density computation instead of seconds since J2000.)doc" )
-            .def( "get_use_utc", &ta::NRLMSISE00Atmosphere::getUseUtc,
-                    R"doc(Get whether UTC time is used for density computation instead of seconds since J2000.)doc" )
+            .def( "set_use_geodetic_latitude", &ta::NRLMSISE00Atmosphere::setUseGeodeticLatitude)
+            .def( "get_use_geodetic_latitude", &ta::NRLMSISE00Atmosphere::getUseGeodeticLatitude)
+            .def( "set_use_utc", &ta::NRLMSISE00Atmosphere::setUseUtc)
+            .def( "get_use_utc", &ta::NRLMSISE00Atmosphere::getUseUtc)
             .def( "get_density",
                   &ta::NRLMSISE00Atmosphere::getDensity,
                   py::arg( "altitude" ),


### PR DESCRIPTION
## Description

Exposes `set_use_geodetic_latitude`, `get_use_geodetic_latitude`, `set_use_utc`, and `get_use_utc` methods to Python for the `NRLMSISE00Atmosphere` class.

## Related Issue(s)

Closes #282.

## Feature Details

- Four C++ utility functions exposed to Python.

## Testing Details

- Confirmed function usability from Python.

## Checklist

- [x] Branch name follows TUDAT convention (`feature/nrlmsise-utc-latitude-setters`)
- [ ] Unit tests have been added or updated.
- [x] Code builds and runs without errors.
- [x] Latest changes from `develop` have been merged into the branch.
- [ ] Code has been reviewed for clarity and maintainability.
- [x] The code follows TUDAT coding guidelines.