### PR TITLE
Allow for `sys.path.append` import [Backwards compatibility]

### DIFF
--- a/cmake/PythonExtension.cmake
+++ b/cmake/PythonExtension.cmake
@@ -95,3 +95,21 @@ macro (update_sources import_path sources)
     list(APPEND sources ${new_sources})
 
 endmacro()
+
+macro (copy_python_in_build)
+
+    # Copy python files to build directory
+    file(GLOB_RECURSE py_files "${TUDATPY_SOURCE_DIR}/**/*.py")
+    foreach(py_file ${py_files})
+        file(RELATIVE_PATH py_file_name ${TUDATPY_SOURCE_DIR} ${py_file})
+        get_filename_component(parents ${py_file_name} DIRECTORY)
+        file(COPY ${py_file_name} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/${parents})
+    endforeach()
+
+    # Copy __init__.py in base directory
+    file(
+        COPY ${TUDATPY_SOURCE_DIR}/__init__.py
+        DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+    )
+
+endmacro()

--- a/src/tudatpy/CMakeLists.txt
+++ b/src/tudatpy/CMakeLists.txt
@@ -8,6 +8,8 @@ configure_file(
 # include(YacmaExtension)
 include(PythonExtension)
 
+copy_python_in_build()
+
 # Setup the installation path.
 set(TUDATPY_INSTALL_PATH "${YACMA_PYTHON_MODULES_INSTALL_PATH}/tudatpy")
 # set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${TUDATPY_SOURCE_DIR})


### PR DESCRIPTION
Modified `CMakeLists.txt` with a macro to copy all the Python scripts in tudatpy to the build directory during build, as it was done before the new setup. This makes it possible to import `tudatpy` from a script by manually adding the path to the build at the beginning of it.

NOTE: The `install.py` and `uninstall.py` scripts are still the recommended methods to work with the library. This patch is just meant to ensure backwards compatibility.