### PR TITLE
Stubs for plotting module

### DIFF
--- a/src/tudatpy/plotting/__init__.py
+++ b/src/tudatpy/plotting/__init__.py
@@ -1,10 +1,10 @@
-from ._ground_track import *
-from ._helpers import *
+# from ._ground_track import *
+from ._helpers import dual_y_axis, trajectory_3d, pareto_front
 
 __all__ = [
     # "plot_blue_marble_ground_track",
     # "plot_miller_ground_track",
     "dual_y_axis",
     "trajectory_3d",
-    "pareto_front"
+    "pareto_front",
 ]


### PR DESCRIPTION
This PR fixes the imports of the plotting module such that stubs can be generated:
- Comment out deprecated ground track function imports
- Add explicit imports for plotting helper functions