### PR TITLE
String and repr dunder methods for DateTime class

### DIFF
--- a/src/tudatpy/astro/time_conversion/expose_time_conversion.cpp
+++ b/src/tudatpy/astro/time_conversion/expose_time_conversion.cpp
@@ -216,6 +216,13 @@ void expose_time_conversion( py::module& m )
                   py::arg( "hour" ) = 12,
                   py::arg( "minute" ) = 0,
                   py::arg( "seconds" ) = 0.0L )
+            .def( "__str__", []( tba::DateTime& datetime ) { return datetime.isoString( ); } )
+            .def( "__repr__",
+                  []( const tba::DateTime& datetime ) {
+                      return "DateTime(" + std::to_string( datetime.getYear( ) ) + ", " + std::to_string( datetime.getMonth( ) ) + ", " +
+                              std::to_string( datetime.getDay( ) ) + ", " + std::to_string( datetime.getHour( ) ) + ", " +
+                              std::to_string( datetime.getMinute( ) ) + ", " + std::to_string( datetime.getSeconds( ) ) + ")";
+                  } )
             .def_property( "year", &tba::DateTime::getYear, &tba::DateTime::setYear, R"doc(
 
  Calendar year


### PR DESCRIPTION
This PR adds `__str__` and `__repr__` methods for the `DateTime` class.

At present, the string representation of DateTime objects is the default one generated by pybind, which only shows a memory address and is therefore not really helpful:
```
>>>print(DateTime(2000, 1, 1, 0, 0, 0))
<tudatpy.kernel.astro.time_conversion.DateTime object at 0x7f057ae283f0>
```
With the added dunder methods, the following output is produced from the `__str__` method:
```
>>>print(DateTime(2000, 1, 1, 0, 0, 0))
2000-01-01 00:00:00.000000000000000
```

and similarly from the `__repr__` method:
```
>>>DateTime(2000, 1, 1, 0, 0, 0)
DateTime(2000, 1, 1, 0, 0, 0.000000)
```
