### PR TITLE
Add `.git-blame-ignore-revs` file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# valeriof7: Apply clang formatting
+e3e2cc90d6db3afc9db83c09d975f192dbd30f7f
+# valeriof7: Apply clang formatting to the codebase. 
+2c22390a38c30138f56867e91736cfd2c9bed795
+# alfonsoSR: Run clang formatter on exposure files
+e03a54f40813f78f781415806af97e7ab8ff2b8c
+# alfonsoSR: Reformated C++
+77968f0fd7b9fffb8095850df0f0c35783d9d25f


### PR DESCRIPTION
This file is used by editors to ignore commits in the inline blame, where no changes to the content have been made (such as reformatting commits). It can also be used from the command line in the `git blame` command, by adding the `--ignore-revs-file .git-blame-ignore-revs` flag.