### PR TITLE
Use path to solar weather data file as input instead of actual data

### DIFF
--- a/src/tudatpy/numerical_simulation/estimation_setup/observation/expose_observation.cpp
+++ b/src/tudatpy/numerical_simulation/estimation_setup/observation/expose_observation.cpp
@@ -2190,9 +2190,7 @@ Examples
            &tom::jakowskiIonosphericCorrectionSettings,
            py::arg( "ionosphere_height" ) = 400.0e3,
            py::arg( "first_order_delay_coefficient" ) = 40.3,
-           py::arg( "solar_activity_data" ) =
-                   tudat::input_output::solar_activity::readSolarActivityData(
-                           tudat::paths::getSpaceWeatherDataPath( ) + "/sw19571001.txt" ),
+           py::arg( "solar_activity_data_path" ) = tudat::paths::getSpaceWeatherDataPath( ) + "/sw19571001.txt" ,
            py::arg( "geomagnetic_pole_latitude" ) = tuc::convertDegreesToRadians( 80.9 ),
            py::arg( "geomagnetic_pole_longitude" ) = tuc::convertDegreesToRadians( -72.6 ),
            py::arg( "use_utc_for_local_time_computation" ) = false,


### PR DESCRIPTION
This PR modifies how the solar activity data is loaded in the Jakowski ionospheric correction. Instead of passing the data, the file path is given as an input. This fixes #290.