### PR TITLE
Minor api doc fixes

### DIFF
--- a/docs/source/aerodynamic_coefficients.rst
+++ b/docs/source/aerodynamic_coefficients.rst
@@ -75,6 +75,38 @@ Functions
 
 
 
+Enumerations
+------------
+.. currentmodule:: tudatpy.numerical_simulation.environment_setup.aerodynamic_coefficients
+
+.. autosummary::
+
+   AerodynamicsReferenceFrameAngles
+   
+   AerodynamicsReferenceFrames
+
+   AerodynamicCoefficientFrames
+
+   AerodynamicCoefficientsIndependentVariables
+   
+   AtmosphericCompositionSpecies
+
+
+.. autoclass:: tudatpy.numerical_simulation.environment_setup.aerodynamic_coefficients.AerodynamicsReferenceFrameAngles
+   :members:
+
+.. autoclass:: tudatpy.numerical_simulation.environment_setup.aerodynamic_coefficients.AerodynamicsReferenceFrames
+   :members:
+
+.. autoclass:: tudatpy.numerical_simulation.environment_setup.aerodynamic_coefficients.AerodynamicCoefficientFrames
+   :members:
+
+.. autoclass:: tudatpy.numerical_simulation.environment_setup.aerodynamic_coefficients.AerodynamicCoefficientsIndependentVariables
+   :members:
+
+.. autoclass:: tudatpy.numerical_simulation.environment_setup.aerodynamic_coefficients.AtmosphericCompositionSpecies
+   :members:
+
 
 
 Classes

--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -38,38 +38,6 @@ Functions
 .. autofunction:: tudatpy.numerical_simulation.environment.transform_to_inertial_orientation
 
 
-
-Enumerations
-------------
-.. currentmodule:: tudatpy.numerical_simulation.environment
-
-.. autosummary::
-
-   AerodynamicsReferenceFrames
-
-   AerodynamicCoefficientFrames
-
-   AerodynamicCoefficientsIndependentVariables
-   
-   AtmosphericCompositionSpecies
-
-
-.. autoclass:: tudatpy.numerical_simulation.environment.AerodynamicsReferenceFrameAngles
-   :members:
-
-.. autoclass:: tudatpy.numerical_simulation.environment.AerodynamicsReferenceFrames
-   :members:
-
-.. autoclass:: tudatpy.numerical_simulation.environment.AerodynamicCoefficientFrames
-   :members:
-
-.. autoclass:: tudatpy.numerical_simulation.environment.AerodynamicCoefficientsIndependentVariables
-   :members:
-
-.. autoclass:: tudatpy.numerical_simulation.environment.AtmosphericCompositionSpecies
-   :members:
-
-
 Classes
 -------
 .. currentmodule:: tudatpy.numerical_simulation.environment

--- a/docs/source/thrust.rst
+++ b/docs/source/thrust.rst
@@ -22,8 +22,6 @@ Functions
 
 .. autosummary::
 
-   get_propulsion_input_variables
-
    constant_thrust_magnitude
 
    custom_thrust_magnitude
@@ -35,8 +33,6 @@ Functions
    custom_thrust_acceleration_magnitude_fixed_isp
 
 
-
-.. autofunction:: tudatpy.numerical_simulation.propagation_setup.thrust.get_propulsion_input_variables
 
 .. autofunction:: tudatpy.numerical_simulation.propagation_setup.thrust.constant_thrust_magnitude
 

--- a/src/tudatpy/astro/two_body_dynamics/expose_two_body_dynamics.cpp
+++ b/src/tudatpy/astro/two_body_dynamics/expose_two_body_dynamics.cpp
@@ -126,18 +126,6 @@ void expose_two_body_dynamics( py::module &m )
      needed to achieve the specified excess velocity at infinity and the current orbital velocity at the
      pericenter.
 
-    py::class_< tms::PericenterFindingFunctions, std::shared_ptr< tms::PericenterFindingFunctions > >( m, "PericenterFindingFunctions" )
-            .def( py::init< const double, const double, const double >( ),
-                  py::arg( "absolute_incoming_semi_major_axis" ),
-                  py::arg( "absolute_outgoing_semi_major_axis" ),
-                  py::arg( "bending_angle" ) )
-            .def( "compute_pericenter_radius_fn", &tms::PericenterFindingFunctions::computePericenterRadiusFunction )
-            .def( "compute_derivative_pericenter_radius_fn",
-                  &tms::PericenterFindingFunctions::computeFirstDerivativePericenterRadiusFunction );
-
-
-
-
 
      )doc" );
 

--- a/src/tudatpy/numerical_simulation/environment_setup/atmosphere/expose_atmosphere.cpp
+++ b/src/tudatpy/numerical_simulation/environment_setup/atmosphere/expose_atmosphere.cpp
@@ -485,35 +485,36 @@ void expose_atmosphere_setup( py::module &m )
            py::arg( "use_anomalous_oxygen" ) = true,
                R"doc(
 
- Function for creating NRLMSISE-00 atmospheric model settings.
+Function for creating NRLMSISE-00 atmospheric model settings.
 
- Function for settings object, defining atmosphere model in accordance to the NRLMSISE-00 global reference model for Earth's atmosphere.
- The NRLMSISE-00 model implementation uses the code `here <https://github.com/tudat-team/nrlmsise-00-cmake>`_.
+Function for settings object, defining atmosphere model in accordance to the NRLMSISE-00 global reference model for Earth's atmosphere.
+The NRLMSISE-00 model implementation uses the code from `tudat-team/nrlmsise-00-cmake <https://github.com/tudat-team/nrlmsise-00-cmake>`_.
 
 
- Parameters
- ----------
+Parameters
+----------
 space_weather_file : str, default = :func:`~tudatpy.data.get_space_weather_path` + 'sw19571001.txt'
-    File to be used for space weather characteristics as a function of time (e.g. F10.7, Kp, etc.). The file is typically taken from here `celestrak <https://celestrak.org/SpaceData/sw19571001.txt>`_ (note that the file in your resources path will not be the latest version of this file; download and replace your existing file if required). Documentation on the file is given `here <https://celestrak.org/SpaceData/SpaceWx-format.php>`_
+    File to be used for space weather characteristics as a function of time (e.g. F10.7, Kp, etc.). The file is typically taken from `celestrak <https://celestrak.org/SpaceData/sw19571001.txt>`_ (note that the file in your resources path will not be the latest version of this file; download and replace your existing file if required). Documentation on the file is given on the `celestrak website <https://celestrak.org/SpaceData/SpaceWx-format.php>`_
 use_storm_conditions : bool, default = false
     Boolean to define whether to use sub-daily Ap values when querying the NRLMSISE model, which is relevant under geomagnetic storm conditions (see `NRLMSISE code <https://github.com/tudat-team/nrlmsise-00-cmake/blob/master/nrlmsise-00.h>`_, setting this variable to true sets ``switches[9]`` to -1, with resulting details of Ap values defined in ``ap_array``).
 use_anomalous_oxygen : bool, default = true
     Boolean to define whether to use anomalous oxygen when querying the NRLMSISE model (if true, using ``gtd7d`` function, if false using ``gtd7`` function in `NRLMSISE code <https://github.com/tudat-team/nrlmsise-00-cmake/blob/master/nrlmsise-00.h>`_)
+
 Returns
- -------
- AtmosphereSettings
-     Instance of the :class:`~tudatpy.numerical_simulation.environment_setup.atmosphere.AtmosphereSettings` class
+-------
+AtmosphereSettings
+    Instance of the :class:`~tudatpy.numerical_simulation.environment_setup.atmosphere.AtmosphereSettings` class
 
 
 
 
 
- Examples
- --------
- In this example, we create :class:`~tudatpy.numerical_simulation.environment_setup.atmosphere.AtmosphereSettings` for Earth,
- using the NRLMSISE-00 global reference model:
+Examples
+--------
+In this example, we create :class:`~tudatpy.numerical_simulation.environment_setup.atmosphere.AtmosphereSettings` for Earth,
+using the NRLMSISE-00 global reference model:
 
- .. code-block:: python
+.. code-block:: python
 
     # create atmosphere settings and add to body settings of body "Earth"
     body_settings.get( "Earth" ).atmosphere_settings = environment_setup.atmosphere.nrlmsise00()

--- a/src/tudatpy/numerical_simulation/propagation_setup/propagator/expose_propagator.cpp
+++ b/src/tudatpy/numerical_simulation/propagation_setup/propagator/expose_propagator.cpp
@@ -285,44 +285,9 @@ Enumeration of available integrated state types.
          detail `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/processed_propagated_elements.html>`__.
          Summarizing: the processed state is the 'typical' formulation of the state (for translational dynamics: Cartesian states).
 
-         .. note:: The same information can be retrieved from the
-                   :py:attr:`SingleArcSimulationResults.processed_state_ids`
-                   attribute.
+         .. note::
 
-    py::class_< tp::SingleArcPropagatorProcessingSettings,
-                std::shared_ptr< tp::SingleArcPropagatorProcessingSettings >,
-                tp::PropagatorProcessingSettings >(
-            m, "SingleArcPropagatorProcessingSettings", get_docstring( "SingleArcPropagatorProcessingSettings" ).c_str( ) )
-            .def_property_readonly( "print_settings",
-                                    &tp::SingleArcPropagatorProcessingSettings::getPrintSettings,
-                                    get_docstring( "SingleArcPropagatorProcessingSettings.print_settings" ).c_str( ) )
-            .def_property( "results_save_frequency_in_steps",
-                           &tp::SingleArcPropagatorProcessingSettings::getResultsSaveFrequencyInSteps,
-                           &tp::SingleArcPropagatorProcessingSettings::setResultsSaveFrequencyInSteps,
-                           get_docstring( "SingleArcPropagatorProcessingSettings.results_save_frequency_in_steps" ).c_str( ) )
-            .def_property( "results_save_frequency_in_seconds",
-                           &tp::SingleArcPropagatorProcessingSettings::getResultsSaveFrequencyInSeconds,
-                           &tp::SingleArcPropagatorProcessingSettings::setResultsSaveFrequencyInSeconds,
-                           get_docstring( "SingleArcPropagatorProcessingSettings.results_save_frequency_in_seconds" ).c_str( ) );
-
-    py::class_< tp::MultiArcPropagatorProcessingSettings,
-                std::shared_ptr< tp::MultiArcPropagatorProcessingSettings >,
-                tp::PropagatorProcessingSettings >(
-            m, "MultiArcPropagatorProcessingSettings", get_docstring( "MultiArcPropagatorProcessingSettings" ).c_str( ) )
-            .def( "set_print_settings_for_all_arcs",
-                  &tp::MultiArcPropagatorProcessingSettings::resetAndApplyConsistentSingleArcPrintSettings,
-                  py::arg( "single_arc_print_settings" ),
-                  get_docstring( "MultiArcPropagatorProcessingSettings.set_print_settings_for_all_arcs" ).c_str( ) )
-            .def_property( "print_output_on_first_arc_only",
-                           &tp::MultiArcPropagatorProcessingSettings::getPrintFirstArcOnly,
-                           &tp::MultiArcPropagatorProcessingSettings::resetPrintFirstArcOnly,
-                           get_docstring( "MultiArcPropagatorProcessingSettings.print_output_on_first_arc_only" ).c_str( ) )
-            .def_property_readonly( "identical_settings_per_arc",
-                                    &tp::MultiArcPropagatorProcessingSettings::useIdenticalSettings,
-                                    get_docstring( "MultiArcPropagatorProcessingSettings.identical_settings_per_arc" ).c_str( ) )
-            .def_property_readonly( "single_arc_settings",
-                                    &tp::MultiArcPropagatorProcessingSettings::getSingleArcSettings,
-                                    get_docstring( "MultiArcPropagatorProcessingSettings.single_arc_settings" ).c_str( ) );
+             The same information can be retrieved from the :py:attr:`SingleArcSimulationResults.processed_state_ids` attribute.
 
          :type: bool
       )doc" )
@@ -709,14 +674,6 @@ Enumeration of available integrated state types.
          Functional base class to define settings for propagators.
 
          Base class to define settings for propagators. Derived classes are split into settings for single- and multi-arc dynamics.
-
-    py::class_< tp::TranslationalStatePropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE >,
-                std::shared_ptr< tp::TranslationalStatePropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE > >,
-                tp::SingleArcPropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE > >(
-            m, "TranslationalStatePropagatorSettings", get_docstring( "TranslationalStatePropagatorSettings" ).c_str( ) )
-
-
-
 
       )doc" )
             .def_property( "initial_states",
@@ -1398,12 +1355,6 @@ HybridArcPropagatorSettings
  This behaviour can be suppressed by providing the optional input argument
  ``terminate_exactly_on_final_condition=True``, in which case the final propagation step will be *exactly* on the
  specified time.
-
-    m.def( "non_sequential_termination",
-           &tp::nonSequentialPropagationTerminationSettings,
-           py::arg( "forward_termination_settings" ),
-           py::arg( "backward_termination_settings" ),
-           get_docstring( "non_sequential_termination" ).c_str( ) );
 
  Parameters
  ----------


### PR DESCRIPTION
Fix errors in API docs builds;
- move `AerodynamicsReferenceFrameAngles`, `AerodynamicsReferenceFrames`, `AerodynamicCoefficientFrames`, `AerodynamicCoefficientsIndependentVariables`, `AtmosphericCompositionSpecies` to `aerodynamic_coefficients` module
- remove `get_propulsion_input_variables`
- remove erroneous class definitions in docstrings of `compute_escape_or_capture_delta_v`, `print_processed_state_indices`
- fix warnings in `nrlmsise00` atmosphere settings