### PR TITLE
Add global bibliography to API docs

### DIFF
--- a/docs/source/aerodynamic_coefficients.rst
+++ b/docs/source/aerodynamic_coefficients.rst
@@ -75,6 +75,38 @@ Functions
 
 
 
+Enumerations
+------------
+.. currentmodule:: tudatpy.numerical_simulation.environment_setup.aerodynamic_coefficients
+
+.. autosummary::
+
+   AerodynamicsReferenceFrameAngles
+   
+   AerodynamicsReferenceFrames
+
+   AerodynamicCoefficientFrames
+
+   AerodynamicCoefficientsIndependentVariables
+   
+   AtmosphericCompositionSpecies
+
+
+.. autoclass:: tudatpy.numerical_simulation.environment_setup.aerodynamic_coefficients.AerodynamicsReferenceFrameAngles
+   :members:
+
+.. autoclass:: tudatpy.numerical_simulation.environment_setup.aerodynamic_coefficients.AerodynamicsReferenceFrames
+   :members:
+
+.. autoclass:: tudatpy.numerical_simulation.environment_setup.aerodynamic_coefficients.AerodynamicCoefficientFrames
+   :members:
+
+.. autoclass:: tudatpy.numerical_simulation.environment_setup.aerodynamic_coefficients.AerodynamicCoefficientsIndependentVariables
+   :members:
+
+.. autoclass:: tudatpy.numerical_simulation.environment_setup.aerodynamic_coefficients.AtmosphericCompositionSpecies
+   :members:
+
 
 
 Classes

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,11 +68,15 @@ extensions = [
     "sphinx_copybutton",
     # 'breathe',
     # 'exhale'
+    "sphinxcontrib.bibtex"
 ]
 autosummary_generate = True  # Turn on sphinx.ext.autosummary
 
 add_module_names = False
 autodoc_member_order = "groupwise"
+
+bibtex_bibfiles = ["refs.bib"]
+bibtex_default_style = "plain"
 
 # napoleon_type_aliases = {
 #     "Dict": ":class:`~typing.Dict`",

--- a/docs/source/constants.rst
+++ b/docs/source/constants.rst
@@ -4,14 +4,14 @@
 =============
 This module contains constants that are used in the tudatpy library or commonly used in astrodynamic calculations.
 
-References
-----------
-.. [1] NASA SSD. Astrodynamic Parameters, http://ssd.jpl.nasa.gov/?constants#ref, 6th September, 2011, last accessed: 21st February, 2012.
-.. [2] Standish, E.M. (1995) "Report of the IAU WGAS Sub-Group on Numerical Standards", in Highlights of Astronomy (I. Appenzeller, ed.), Table 1, Kluwer Academic Publishers, Dordrecht
-.. [3] IAU 2012, Resolution B2. https://www.iau.org/static/resolutions/IAU2012_English.pdf
-.. [4] Anderson, J.D. Jr. Hypersonic and High-Temperature Gas Dynamics, Second Edition, p469, 2006
-.. [5] NIST reference on constants, units and uncertainty. http://physics.nist.gov/cuu/Constants/index.html, last accessed: 11th January, 2013
-.. [6] Wolfram Research, http://scienceworld.wolfram.com/physics/Stefan-BoltzmannLaw.html, last accessed: 11th January 2013.
+.. References
+.. ----------
+.. .. [1] NASA SSD. Astrodynamic Parameters, http://ssd.jpl.nasa.gov/?constants#ref, 6th September, 2011, last accessed: 21st February, 2012.
+.. .. [2] Standish, E.M. (1995) "Report of the IAU WGAS Sub-Group on Numerical Standards", in Highlights of Astronomy (I. Appenzeller, ed.), Table 1, Kluwer Academic Publishers, Dordrecht
+.. .. [3] IAU 2012, Resolution B2. https://www.iau.org/static/resolutions/IAU2012_English.pdf
+.. .. [4] Anderson, J.D. Jr. Hypersonic and High-Temperature Gas Dynamics, Second Edition, p469, 2006
+.. .. [5] NIST reference on constants, units and uncertainty. http://physics.nist.gov/cuu/Constants/index.html, last accessed: 11th January, 2013
+.. .. [6] Wolfram Research, http://scienceworld.wolfram.com/physics/Stefan-BoltzmannLaw.html, last accessed: 11th January 2013.
 
 
 Constants
@@ -24,11 +24,11 @@ Constants
     
 .. autodata:: tudatpy.constants.JULIAN_DAY
     
-    Julian day in seconds [1]_.
+    Julian day in seconds :cite:p:`NASASSD2011`.
 
 .. autodata:: tudatpy.constants.JULIAN_YEAR_IN_DAYS
 
-    Julian year in Julian days [1]_.
+    Julian year in Julian days :cite:p:`NASASSD2011`.
 
 .. autodata:: tudatpy.constants.JULIAN_YEAR
 
@@ -36,11 +36,11 @@ Constants
 
 .. autodata:: tudatpy.constants.SIDEREAL_DAY
 
-    Sidereal day in seconds [1]_.
+    Sidereal day in seconds :cite:p:`NASASSD2011`.
 
 .. autodata:: tudatpy.constants.SIDEREAL_YEAR_IN_DAYS
 
-    Sidereal year in Julian days in quasar reference frame [1]_.
+    Sidereal year in Julian days in quasar reference frame :cite:p:`NASASSD2011`.
 
 .. autodata:: tudatpy.constants.SIDEREAL_YEAR
 
@@ -48,36 +48,36 @@ Constants
 
 .. autodata:: tudatpy.constants.SPEED_OF_LIGHT
 
-    Speed of light in meters per second [2]_.
+    Speed of light in meters per second :cite:p:`standish1995`.
 
 .. autodata:: tudatpy.constants.GRAVITATIONAL_CONSTANT
 
-    Gravitational constant in :math:`\mathrm{m}^3/\mathrm{s}^2` [2]_.
+    Gravitational constant in :math:`\mathrm{m}^3/\mathrm{s}^2` :cite:p:`standish1995`.
 
 .. autodata:: tudatpy.constants.ASTRONOMICAL_UNIT
 
-    Astronomical Unit in meters [3]_.
+    Astronomical Unit in meters :cite:p:`iau2012`.
 
 .. autodata:: tudatpy.constants.SPECIFIC_GAS_CONSTANT_AIR
 
-    The specific gas constant of air in :math:`\mathrm{J}/(\mathrm{kg} \, \mathrm{K})` [4]_.
+    The specific gas constant of air in :math:`\mathrm{J}/(\mathrm{kg} \, \mathrm{K})` :cite:p:`anderson2006`.
 
 .. autodata:: tudatpy.constants.MOLAR_GAS_CONSTANT
 
-    The molar gas constant in :math:`\mathrm{J}/(\mathrm{mol} \, \mathrm{K})` [5]_.
+    The molar gas constant in :math:`\mathrm{J}/(\mathrm{mol} \, \mathrm{K})` :cite:p:`nistconstants`.
     Also known as universal gas constant.
 
 .. autodata:: tudatpy.constants.PLANCK_CONSTANT
 
-    Planck's constant in :math:`\mathrm{m}^{2} \, \mathrm{kg}/\mathrm{s}` [5]_.
+    Planck's constant in :math:`\mathrm{m}^{2} \, \mathrm{kg}/\mathrm{s}` :cite:p:`nistconstants`.
 
 .. autodata:: tudatpy.constants.BOLTZMANN_CONSTANT
 
-    The Boltzmann constant (gas constant per particle) in  :math:`\mathrm{m}^{2} \, \mathrm{kg} / ( \mathrm{s}^{2} \, \mathrm{K} )`, [5]_.
+    The Boltzmann constant (gas constant per particle) in  :math:`\mathrm{m}^{2} \, \mathrm{kg} / ( \mathrm{s}^{2} \, \mathrm{K} )`, :cite:p:`nistconstants`.
 
 .. autodata:: tudatpy.constants.STEFAN_BOLTZMANN_CONSTANT
 
-    Stefan-Boltzmann constant, used for calculating black body radiation intensity in :math:`\mathrm{J} / (\mathrm{s} \, \mathrm{m}^{2} \, \mathrm{K}^{4} )` [6]_.
+    Stefan-Boltzmann constant, used for calculating black body radiation intensity in :math:`\mathrm{J} / (\mathrm{s} \, \mathrm{m}^{2} \, \mathrm{K}^{4} )` :cite:p:`wolfram2013`.
 
 .. autodata:: tudatpy.constants.INVERSE_SQUARE_SPEED_OF_LIGHT
 

--- a/docs/source/dependent_variable.rst
+++ b/docs/source/dependent_variable.rst
@@ -12,11 +12,11 @@ settings. Note that *all* output is in SI units (meters, radians, seconds). All 
 
 
 
-References
-----------
-.. [1] Mooij, E. The motion of a vehicle in a planetary atmosphere.
-       Delft University of Technology, Faculty of Aerospace Engineering,
-       Report LR-768 (1994).
+.. References
+.. ----------
+.. .. [1] Mooij, E. The motion of a vehicle in a planetary atmosphere.
+..        Delft University of Technology, Faculty of Aerospace Engineering,
+..        Report LR-768 (1994).
 
 
 

--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -38,38 +38,6 @@ Functions
 .. autofunction:: tudatpy.numerical_simulation.environment.transform_to_inertial_orientation
 
 
-
-Enumerations
-------------
-.. currentmodule:: tudatpy.numerical_simulation.environment
-
-.. autosummary::
-
-   AerodynamicsReferenceFrames
-
-   AerodynamicCoefficientFrames
-
-   AerodynamicCoefficientsIndependentVariables
-   
-   AtmosphericCompositionSpecies
-
-
-.. autoclass:: tudatpy.numerical_simulation.environment.AerodynamicsReferenceFrameAngles
-   :members:
-
-.. autoclass:: tudatpy.numerical_simulation.environment.AerodynamicsReferenceFrames
-   :members:
-
-.. autoclass:: tudatpy.numerical_simulation.environment.AerodynamicCoefficientFrames
-   :members:
-
-.. autoclass:: tudatpy.numerical_simulation.environment.AerodynamicCoefficientsIndependentVariables
-   :members:
-
-.. autoclass:: tudatpy.numerical_simulation.environment.AtmosphericCompositionSpecies
-   :members:
-
-
 Classes
 -------
 .. currentmodule:: tudatpy.numerical_simulation.environment

--- a/docs/source/frame_conversion.rst
+++ b/docs/source/frame_conversion.rst
@@ -49,12 +49,12 @@ Notes
 
 
 
-References
-----------
-.. [1] Archinal, B.A., Acton, C.H., A’Hearn, M.F. et al. Report of
-       the IAU Working Group on Cartographic Coordinates and
-       Rotational Elements: 2015. Celest Mech Dyn Astr 130, 22
-       (2018). https://doi.org/10.1007/s10569-017-9805-5
+.. References
+.. ----------
+.. .. [1] Archinal, B.A., Acton, C.H., A’Hearn, M.F. et al. Report of
+..        the IAU Working Group on Cartographic Coordinates and
+..        Rotational Elements: 2015. Celest Mech Dyn Astr 130, 22
+..        (2018). https://doi.org/10.1007/s10569-017-9805-5
 
 
 

--- a/docs/source/gravity_field.rst
+++ b/docs/source/gravity_field.rst
@@ -24,13 +24,13 @@ Rigid body properties will always be created automatically when a body is endowe
 
 
 
-References
-----------
-.. [1] Balmino, G. (1994). Gravitational potential harmonics from the shape of an homogeneous body. Celestial
-      Mechanics and Dynamical Astronomy, 60(3), 331-364.
-.. [2] Werner, R. A., and Scheeres, D. J. (1997). Exterior Gravitation of a Polyhedron Derived and Compared With
-      Harmonic and Mascon Gravitation Representations of Asteroid 4769 Castalia. Celestial Mechanics and Dynamical
-      Astronomy, 65, 313-344.
+.. References
+.. ----------
+.. .. [1] Balmino, G. (1994). Gravitational potential harmonics from the shape of an homogeneous body. Celestial
+..       Mechanics and Dynamical Astronomy, 60(3), 331-364.
+.. .. [2] Werner, R. A., and Scheeres, D. J. (1997). Exterior Gravitation of a Polyhedron Derived and Compared With
+..       Harmonic and Mascon Gravitation Representations of Asteroid 4769 Castalia. Celestial Mechanics and Dynamical
+..       Astronomy, 65, 313-344.
 
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,7 +34,8 @@ astrodynamics.
 
 
 
+Bibliography
+------------
 
-
-
-
+.. bibliography::
+   

--- a/docs/source/polyhedron_utilities.rst
+++ b/docs/source/polyhedron_utilities.rst
@@ -15,9 +15,9 @@ modify or retrieved information from the specified polyhedron mesh.
 
 
 
-References
-----------
-.. [1] Dobrovolskis, A. (1996). "Inertia of Any Polyhedron", Icarus, 124 (243), 698-704.
+.. References
+.. ----------
+.. .. [1] Dobrovolskis, A. (1996). "Inertia of Any Polyhedron", Icarus, 124 (243), 698-704.
 
 
 

--- a/docs/source/propagator.rst
+++ b/docs/source/propagator.rst
@@ -11,13 +11,13 @@ This module provides the functionality for creating propagator settings.
 
 
 
-References
-----------
-.. [1] Vittaldev, V., Mooij, E., & Naeije, M. C. (2012). Unified State Model theory and
-       application in Astrodynamics. Celestial Mechanics and Dynamical Astronomy, 112(3), 253-282.
-.. [2] Wakker, K. F. (2015). Fundamentals of astrodynamics.
-.. [3] Hintz, G. R. (2008). Survey of orbit element sets. Journal of guidance, control, and dynamics, 31(3), 785-790.
-.. [4] Vallado, D. A. (2001). Fundamentals of astrodynamics and applications (Vol. 12). Springer Science & Business Media.
+.. References
+.. ----------
+.. .. [1] Vittaldev, V., Mooij, E., & Naeije, M. C. (2012). Unified State Model theory and
+..        application in Astrodynamics. Celestial Mechanics and Dynamical Astronomy, 112(3), 253-282.
+.. .. [2] Wakker, K. F. (2015). Fundamentals of astrodynamics.
+.. .. [3] Hintz, G. R. (2008). Survey of orbit element sets. Journal of guidance, control, and dynamics, 31(3), 785-790.
+.. .. [4] Vallado, D. A. (2001). Fundamentals of astrodynamics and applications (Vol. 12). Springer Science & Business Media.
 
 
 

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -1,0 +1,241 @@
+@Article{Dobrovolskis1996,
+  author    = {Dobrovolskis, Anthony R.},
+  title     = {Inertia of Any Polyhedron},
+  doi       = {10.1006/icar.1996.0243},
+  issn      = {0019-1035},
+  number    = {2},
+  pages     = {698--704},
+  volume    = {124},
+  journal   = {Icarus},
+  month     = dec,
+  publisher = {Elsevier BV},
+  year      = {1996},
+}
+
+@Online{NASASSD2011,
+  author  = {{NASA SSD}},
+  date    = {2011-09-06},
+  title   = {Astrodynamic Parameters},
+  url     = {http://ssd.jpl.nasa.gov/?constants#ref},
+  urldate = {2012-02-21},
+}
+
+@article{standish1995, title={Report of the IAU WGAS Sub-group on Numerical Standards}, volume={10}, DOI={10.1017/S1539299600010893}, journal={Highlights of Astronomy}, author={Standish, E.M.}, year={1995}, pages={180-184}}
+
+@misc{iau2012,
+  author    = {{IAU}},
+  title     = {{Resolution B2}},
+  year      = {2012},
+  url       = {https://www.iau.org/static/resolutions/IAU2012_English.pdf}
+}
+
+@Book{anderson2006,
+  author    = {Anderson Jr., John D.},
+  date      = {2006-08},
+  title     = {Hypersonic and High-Temperature Gas Dynamics},
+  doi       = {https://doi.org/10.2514/4.861956},
+  isbn      = {9781600861956},
+  note      = {Second Edition, p469},
+  publisher = {American Institute of Aeronautics and Astronautics},
+  year      = {2006},
+}
+
+@misc{nistconstants,
+  title     = {NIST reference on constants, units and uncertainty},
+  url       = {http://physics.nist.gov/cuu/Constants/index.html},
+  urldate   = {2013-01-11}
+}
+
+@misc{wolfram2013,
+  author    = {{Wolfram Research}},
+  title     = {Stefan-Boltzmann Law},
+  url       = {http://scienceworld.wolfram.com/physics/Stefan-BoltzmannLaw.html},
+  urldate   = {2013-01-11}
+}
+
+@techreport{mooij1994,
+  author    = {E. Mooij},
+  title     = {The motion of a vehicle in a planetary atmosphere},
+  institution = {Delft University of Technology, Faculty of Aerospace Engineering},
+  number    = {Report LR-768},
+  year      = {1994}
+}
+
+@Article{balmino1994,
+  author       = {G. Balmino},
+  date         = {1994-11},
+  journaltitle = {Celestial Mechanics &amp; Dynamical Astronomy},
+  title        = {Gravitational potential harmonics from the shape of an homogeneous body},
+  doi          = {https://doi.org/10.1007/BF00691901},
+  issn         = {1572-9478},
+  number       = {3},
+  pages        = {331--364},
+  volume       = {60},
+  journal      = {Celestial Mechanics and Dynamical Astronomy},
+  publisher    = {Springer Science and Business Media LLC},
+  year         = {1994},
+}
+
+@Article{werner1997,
+  author       = {R. A. Werner and D. J. Scheeres},
+  date         = {1997},
+  journaltitle = {Celestial Mechanics and Dynamical Astronomy},
+  title        = {Exterior Gravitation of a Polyhedron Derived and Compared With Harmonic and Mascon Gravitation Representations of Asteroid 4769 Castalia},
+  doi          = {https://doi.org/10.1007/BF00053511},
+  issn         = {1572-9478},
+  number       = {3},
+  pages        = {313--344},
+  volume       = {65},
+  journal      = {Celestial Mechanics and Dynamical Astronomy},
+  publisher    = {Springer Science and Business Media LLC},
+  year         = {1997},
+}
+
+@Article{vittaldev2012,
+  author       = {V. Vittaldev and E. Mooij and M. C. Naeije},
+  date         = {2012-02},
+  journaltitle = {Celestial Mechanics and Dynamical Astronomy},
+  title        = {Unified State Model theory and application in Astrodynamics},
+  doi          = {https://doi.org/10.1007/s10569-011-9396-5},
+  issn         = {1572-9478},
+  number       = {3},
+  pages        = {253--282},
+  volume       = {112},
+  journal      = {Celestial Mechanics and Dynamical Astronomy},
+  publisher    = {Springer Science and Business Media LLC},
+  year         = {2012},
+}
+
+@Misc{wakker2015,
+  author    = {K. F. Wakker},
+  title     = {Fundamentals of astrodynamics},
+  year      = {2015}
+}
+
+@Article{hintz2008,
+  author       = {G. R. Hintz},
+  date         = {2008-05},
+  journaltitle = {Journal of Guidance, Control, and Dynamics},
+  title        = {Survey of Orbit Element Sets},
+  doi          = {https://doi.org/10.2514/1.32237},
+  issn         = {1533-3884},
+  number       = {3},
+  pages        = {785--790},
+  volume       = {31},
+  journal      = {Journal of guidance, control, and dynamics},
+  publisher    = {American Institute of Aeronautics and Astronautics (AIAA)},
+  year         = {2008},
+}
+
+@Book{vallado2001,
+  author    = {D. A. Vallado},
+  title     = {Fundamentals of astrodynamics and applications},
+  publisher = {Microcosm Press},
+  year      = {2001},
+}
+
+@Article{gondelach2015,
+  author       = {Gondelach, D. J. and Noomen, R.},
+  date         = {2015-05},
+  journaltitle = {Journal of Spacecraft and Rockets},
+  title        = {Hodographic-Shaping Method for Low-Thrust Interplanetary Trajectory Design},
+  doi          = {https://doi.org/10.2514/1.A32991},
+  issn         = {1533-6794},
+  number       = {3},
+  pages        = {728--738},
+  volume       = {52},
+  journal      = {Journal of Spacecraft and Rockets},
+  publisher    = {American Institute of Aeronautics and Astronautics (AIAA)},
+  year         = {2015},
+}
+
+@Misc{Kaplan2006,
+  author       = {G. Kaplan},
+  date         = {2006},
+  journaltitle = {United States Naval Observatory Circular No. 179, The IAU Resolutions on Astronomical Reference Systems, Time Scales, and Earth Rotation Models},
+  title        = {The IAU Resolutions on Astronomical Reference Systems, Time Scales, and Earth Rotation Models},
+  doi          = {https://doi.org/10.48550/arXiv.astro-ph/0602086},
+  comment      = {Chapter 2},
+  copyright    = {Assumed arXiv.org perpetual, non-exclusive license to distribute this article for submissions made before January 2004},
+  file         = {:kaplan - Chapter 2.pdf:PDF},
+  keywords     = {Astrophysics (astro-ph), FOS: Physical sciences, FOS: Physical sciences},
+  publisher    = {arXiv},
+}
+
+@Manual{sofa_ts_c,
+  author = {{IAU}},
+  title  = {SOFA Time Scale and Calendar Tools},
+  note   = {SOFA Documentation - disseminated by the International Astronomical Union},
+  series = {Standards of Fundamental Astronomy},
+  url    = {https://www.iausofa.org/sofa_ts_c.pdf},
+}
+
+@Article{Petit2010,
+  author  = {Petit, Gérard and Luzum, Brian},
+  title   = {{IERS conventions (2010)}},
+  pages   = {180},
+  volume  = {36},
+  comment = {Sections 5.5.3 and Chapter 10},
+  journal = {Tech. Rep. DTIC Document},
+  month   = {01},
+  year    = {2010},
+}
+
+@Article{izzo2007,
+  author       = {D. Izzo},
+  date         = {2007-11},
+  journaltitle = {Acta Astronautica},
+  title        = {1st ACT global trajectory optimisation competition: Problem description and summary of the results},
+  doi          = {https://doi.org/10.1016/j.actaastro.2007.03.003},
+  issn         = {0094-5765},
+  number       = {9},
+  pages        = {731--734},
+  url          = {https://doi.org/10.1016/j.actaastro.2007.03.003},
+  volume       = {61},
+  journal      = {Acta Astronautica},
+  publisher    = {Elsevier BV},
+  year         = {2007},
+}
+
+@Misc{musegaas2012,
+  author      = {P. Musegaas},
+  title       = {Optimization of Space Trajectories Including Multiple Gravity Assists and Deep Space Maneuvers},
+  type        = {MSc thesis},
+  url         = {https://resolver.tudelft.nl/02468c77-5c64-4df8-9a24-1ed7ad9d1408},
+  institution = {Delft University of Technology},
+  year        = {2012},
+}
+
+@Misc{roegiers2014,
+  author      = {T. Roegiers},
+  title       = {Application of the Spherical Shaping Method to a Low-Thrust Multiple Asteroid Rendezvous Mission: Implementation, Limitations and Solutions},
+  type        = {MSc thesis},
+  url         = {https://resolver.tudelft.nl/9994980c-e1df-47a6-880a-3a226797e34a},
+  institution = {Delft University of Technology},
+  year        = {2014},
+}
+
+@Misc{gondelach2012,
+  author      = {D. Gondelach},
+  title       = {A Hodographic-Shaping Method for Low-Thrust Trajectory Design},
+  type        = {MSc thesis},
+  url         = {https://resolver.tudelft.nl/6a4f1673-88b1-4823-b2ef-9d864c84ab11},
+  institution = {Delft University of Technology},
+  year        = {2012},
+}
+
+@Article{Archinal2018,
+  author       = {Archinal, B. A. and Acton, C. H. and A’Hearn, M. F. and Conrad, A. and Consolmagno, G. J. and Duxbury, T. and Hestroffer, D. and Hilton, J. L. and Kirk, R. L. and Klioner, S. A. and McCarthy, D. and Meech, K. and Oberst, J. and Ping, J. and Seidelmann, P. K. and Tholen, D. J. and Thomas, P. C. and Williams, I. P.},
+  date         = {2018-02},
+  year         = {2018},
+  journaltitle = {Celestial Mechanics and Dynamical Astronomy},
+  journal = {Celestial Mechanics and Dynamical Astronomy},
+  title        = {Report of the IAU Working Group on Cartographic Coordinates and Rotational Elements: 2015},
+  doi          = {10.1007/s10569-017-9805-5},
+  issn         = {1572-9478},
+  number       = {3},
+  volume       = {130},
+  publisher    = {Springer Science and Business Media LLC},
+}
+
+@Comment{jabref-meta: databaseType:biblatex;}

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -20,7 +20,7 @@
   urldate = {2012-02-21},
 }
 
-@article{standish1995, title={Report of the IAU WGAS Sub-group on Numerical Standards}, volume={10}, DOI={10.1017/S1539299600010893}, journal={Highlights of Astronomy}, author={Standish, E.M.}, year={1995}, pages={180-184}}
+@article{standish1995, title={{Report of the IAU WGAS Sub-group on Numerical Standards}}, volume={10}, DOI={10.1017/S1539299600010893}, journal={Highlights of Astronomy}, author={Standish, E.M.}, year={1995}, pages={180-184}}
 
 @misc{iau2012,
   author    = {{IAU}},
@@ -33,7 +33,7 @@
   author    = {Anderson Jr., John D.},
   date      = {2006-08},
   title     = {Hypersonic and High-Temperature Gas Dynamics},
-  doi       = {https://doi.org/10.2514/4.861956},
+  doi       = {10.2514/4.861956},
   isbn      = {9781600861956},
   note      = {Second Edition, p469},
   publisher = {American Institute of Aeronautics and Astronautics},
@@ -66,7 +66,7 @@
   date         = {1994-11},
   journaltitle = {Celestial Mechanics &amp; Dynamical Astronomy},
   title        = {Gravitational potential harmonics from the shape of an homogeneous body},
-  doi          = {https://doi.org/10.1007/BF00691901},
+  doi          = {10.1007/BF00691901},
   issn         = {1572-9478},
   number       = {3},
   pages        = {331--364},
@@ -81,7 +81,7 @@
   date         = {1997},
   journaltitle = {Celestial Mechanics and Dynamical Astronomy},
   title        = {Exterior Gravitation of a Polyhedron Derived and Compared With Harmonic and Mascon Gravitation Representations of Asteroid 4769 Castalia},
-  doi          = {https://doi.org/10.1007/BF00053511},
+  doi          = {10.1007/BF00053511},
   issn         = {1572-9478},
   number       = {3},
   pages        = {313--344},
@@ -96,7 +96,7 @@
   date         = {2012-02},
   journaltitle = {Celestial Mechanics and Dynamical Astronomy},
   title        = {Unified State Model theory and application in Astrodynamics},
-  doi          = {https://doi.org/10.1007/s10569-011-9396-5},
+  doi          = {10.1007/s10569-011-9396-5},
   issn         = {1572-9478},
   number       = {3},
   pages        = {253--282},
@@ -117,7 +117,7 @@
   date         = {2008-05},
   journaltitle = {Journal of Guidance, Control, and Dynamics},
   title        = {Survey of Orbit Element Sets},
-  doi          = {https://doi.org/10.2514/1.32237},
+  doi          = {10.2514/1.32237},
   issn         = {1533-3884},
   number       = {3},
   pages        = {785--790},
@@ -139,7 +139,7 @@
   date         = {2015-05},
   journaltitle = {Journal of Spacecraft and Rockets},
   title        = {Hodographic-Shaping Method for Low-Thrust Interplanetary Trajectory Design},
-  doi          = {https://doi.org/10.2514/1.A32991},
+  doi          = {10.2514/1.A32991},
   issn         = {1533-6794},
   number       = {3},
   pages        = {728--738},
@@ -151,13 +151,13 @@
 
 @Misc{Kaplan2006,
   author       = {G. Kaplan},
+  year         = {2006},
   date         = {2006},
   journaltitle = {United States Naval Observatory Circular No. 179, The IAU Resolutions on Astronomical Reference Systems, Time Scales, and Earth Rotation Models},
-  title        = {The IAU Resolutions on Astronomical Reference Systems, Time Scales, and Earth Rotation Models},
-  doi          = {https://doi.org/10.48550/arXiv.astro-ph/0602086},
+  title        = {{The IAU Resolutions on Astronomical Reference Systems, Time Scales, and Earth Rotation Models}},
+  doi          = {10.48550/arXiv.astro-ph/0602086},
   comment      = {Chapter 2},
   copyright    = {Assumed arXiv.org perpetual, non-exclusive license to distribute this article for submissions made before January 2004},
-  file         = {:kaplan - Chapter 2.pdf:PDF},
   keywords     = {Astrophysics (astro-ph), FOS: Physical sciences, FOS: Physical sciences},
   publisher    = {arXiv},
 }
@@ -186,7 +186,7 @@
   date         = {2007-11},
   journaltitle = {Acta Astronautica},
   title        = {1st ACT global trajectory optimisation competition: Problem description and summary of the results},
-  doi          = {https://doi.org/10.1016/j.actaastro.2007.03.003},
+  doi          = {10.1016/j.actaastro.2007.03.003},
   issn         = {0094-5765},
   number       = {9},
   pages        = {731--734},
@@ -230,12 +230,10 @@
   year         = {2018},
   journaltitle = {Celestial Mechanics and Dynamical Astronomy},
   journal = {Celestial Mechanics and Dynamical Astronomy},
-  title        = {Report of the IAU Working Group on Cartographic Coordinates and Rotational Elements: 2015},
+  title        = {{Report of the IAU Working Group on Cartographic Coordinates and Rotational Elements: 2015}},
   doi          = {10.1007/s10569-017-9805-5},
   issn         = {1572-9478},
   number       = {3},
   volume       = {130},
   publisher    = {Springer Science and Business Media LLC},
 }
-
-@Comment{jabref-meta: databaseType:biblatex;}

--- a/docs/source/shape_based_thrust.rst
+++ b/docs/source/shape_based_thrust.rst
@@ -7,7 +7,7 @@ Functionalities for shape-based low-thrust trajectory design.
 This module provides the functionality for creating shape-based low-thrust trajectory design legs.
 Without using any numerical propagation, this generates a preliminary low-thrust trajectory using
 relatively simple (semi-)analytical methods.
-For background information on the methods, see [1]_.
+For background information on the methods, see :cite:p:`gondelach2015`.
 
 
 
@@ -16,10 +16,10 @@ For background information on the methods, see [1]_.
 
 
 
-References
-----------
-.. [1] Gondelach, David J., and Ron Noomen. "Hodographic-shaping method for 
-       low-thrust interplanetary trajectory design." Journal of Spacecraft and Rockets 52.3 (2015): 728-738.
+.. References
+.. ----------
+.. .. [1] Gondelach, David J., and Ron Noomen. "Hodographic-shaping method for 
+..        low-thrust interplanetary trajectory design." Journal of Spacecraft and Rockets 52.3 (2015): 728-738.
 
 
 

--- a/docs/source/thrust.rst
+++ b/docs/source/thrust.rst
@@ -22,8 +22,6 @@ Functions
 
 .. autosummary::
 
-   get_propulsion_input_variables
-
    constant_thrust_magnitude
 
    custom_thrust_magnitude
@@ -35,8 +33,6 @@ Functions
    custom_thrust_acceleration_magnitude_fixed_isp
 
 
-
-.. autofunction:: tudatpy.numerical_simulation.propagation_setup.thrust.get_propulsion_input_variables
 
 .. autofunction:: tudatpy.numerical_simulation.propagation_setup.thrust.constant_thrust_magnitude
 

--- a/docs/source/time_conversion.rst
+++ b/docs/source/time_conversion.rst
@@ -26,9 +26,14 @@ Notes
 
 References
 ----------
-*  Chapter 2 of: Kaplan, G. `United States Naval Observatory Circular No. 179 <https://www.usno.navy.mil/USNO/astronomical-applications/publications/Circular_179.pdf/view>`_, The IAU Resolutions on Astronomical Reference Systems, Time Scales, and Earth Rotation Models.
-*  SOFA Documentation - `SOFA Time Scale and Calendar Tools <https://www.iausofa.org/sofa_ts_c.pdf>`_, disseminated by the International Astronomical Union
-*  Secions 5.5.3 and Chapter 10 of the `IERS 2010 Conventions <https://www.iers.org/SharedDocs/Publikationen/EN/IERS/Publications/tn/TechnNote36/tn36.pdf>`_, disseminated by the International Earth Rotation Service
+
+* :cite:t:`Kaplan2006{Chapter 2}`
+* :cite:t:`sofa_ts_c`
+* :cite:t:`Petit2010{Sections 5.5.3 and Chapter 10}`
+
+.. *  Chapter 2 of: Kaplan, G. `United States Naval Observatory Circular No. 179 <https://www.usno.navy.mil/USNO/astronomical-applications/publications/Circular_179.pdf/view>`_, The IAU Resolutions on Astronomical Reference Systems, Time Scales, and Earth Rotation Models.
+.. *  SOFA Documentation - `SOFA Time Scale and Calendar Tools <https://www.iausofa.org/sofa_ts_c.pdf>`_, disseminated by the International Astronomical Union
+.. *  Secions 5.5.3 and Chapter 10 of the `IERS 2010 Conventions <https://www.iers.org/SharedDocs/Publikationen/EN/IERS/Publications/tn/TechnNote36/tn36.pdf>`_, disseminated by the International Earth Rotation Service
 
 
 

--- a/docs/source/transfer_trajectory.rst
+++ b/docs/source/transfer_trajectory.rst
@@ -15,22 +15,22 @@ transfers with high-thrust legs, low-thrust legs or a mix of the two.
 
 
 
-References
-----------
-.. [1] Izzo, D. 1st ACT global trajectory optimisation competition: Problem
-      description and summary of the results. Acta Astronautica 61, 9 (2007).
-      https://doi.org/10.1016/j.actaastro.2007.03.003
-.. [2] Musegaas, P. Optimization of Space Trajectories Including Multiple
-      Gravity Assists and Deep Space Maneuvers. Delft University of Technology,
-      MSc thesis (2012).
-      http://resolver.tudelft.nl/uuid:02468c77-5c64-4df8-9a24-1ed7ad9d1408
-.. [3] Roegiers, T. Application of the Spherical Shaping Method to a Low-Thrust Multiple Asteroid Rendezvous
-      Mission: Implementation, Limitations and Solutions. Delft University of Technology,
-      MSc thesis (2014).
-      http://resolver.tudelft.nl/uuid:9994980c-e1df-47a6-880a-3a226797e34a
-.. [4] Gondelach, D. A Hodographic-Shaping Method for Low-Thrust Trajectory Design.
-      Delft University of Technology, MSc thesis (2012).
-      http://resolver.tudelft.nl/uuid:6a4f1673-88b1-4823-b2ef-9d864c84ab11
+.. References
+.. ----------
+.. .. [1] Izzo, D. 1st ACT global trajectory optimisation competition: Problem
+..       description and summary of the results. Acta Astronautica 61, 9 (2007).
+..       https://doi.org/10.1016/j.actaastro.2007.03.003
+.. .. [2] Musegaas, P. Optimization of Space Trajectories Including Multiple
+..       Gravity Assists and Deep Space Maneuvers. Delft University of Technology,
+..       MSc thesis (2012).
+..       http://resolver.tudelft.nl/uuid:02468c77-5c64-4df8-9a24-1ed7ad9d1408
+.. .. [3] Roegiers, T. Application of the Spherical Shaping Method to a Low-Thrust Multiple Asteroid Rendezvous
+..       Mission: Implementation, Limitations and Solutions. Delft University of Technology,
+..       MSc thesis (2014).
+..       http://resolver.tudelft.nl/uuid:9994980c-e1df-47a6-880a-3a226797e34a
+.. .. [4] Gondelach, D. A Hodographic-Shaping Method for Low-Thrust Trajectory Design.
+..       Delft University of Technology, MSc thesis (2012).
+..       http://resolver.tudelft.nl/uuid:6a4f1673-88b1-4823-b2ef-9d864c84ab11
 
 
 

--- a/src/tudatpy/astro/frame_conversion/expose_frame_conversion.cpp
+++ b/src/tudatpy/astro/frame_conversion/expose_frame_conversion.cpp
@@ -245,9 +245,7 @@ void expose_frame_conversion( py::module &m )
  This definition of a body-fixed orientation is used by, for
  instance, the IAU Working Group on Cartographic Coordinates and
  Rotational Elements. Rotation is performed by a successive z-x-z
- Euler angle rotation (see Archinal et al. [1]_).
-
-
+ Euler angle rotation (see :cite:t:`Archinal2018`).
 
 
      )doc" );
@@ -294,7 +292,7 @@ void expose_frame_conversion( py::module &m )
  This definition of a body-fixed orientation is used by,
  for instance, the IAU Working Group on Cartographic Coordinates
  and Rotational Elements. Rotation is performed by a successive z-x-z
- Euler angle rotation (see Archinal et al. [1]_).
+ Euler angle rotation (see :cite:t:`Archinal2018`).
 
 
 

--- a/src/tudatpy/astro/polyhedron_utilities/expose_polyhedron_utilities.cpp
+++ b/src/tudatpy/astro/polyhedron_utilities/expose_polyhedron_utilities.cpp
@@ -36,7 +36,7 @@ void expose_polyhedron_utilities( py::module &m )
            py::arg( "vertices_defining_each_facet" ),
            R"doc(
 
- Computes the surface area of a polyhedron [1]_.
+ Computes the surface area of a polyhedron :cite:p:`Dobrovolskis1996`.
 
 
  Parameters
@@ -56,10 +56,6 @@ void expose_polyhedron_utilities( py::module &m )
      Surface area.
 
 
-
-
-
-
      )doc" );
 
     m.def( "volume",
@@ -68,7 +64,7 @@ void expose_polyhedron_utilities( py::module &m )
            py::arg( "vertices_defining_each_facet" ),
            R"doc(
 
- Computes the volume of a polyhedron [1]_.
+ Computes the volume of a polyhedron :cite:p:`Dobrovolskis1996`.
 
 
  Parameters
@@ -100,7 +96,7 @@ void expose_polyhedron_utilities( py::module &m )
            py::arg( "vertices_defining_each_facet" ),
            R"doc(
 
- Computes the position of the centroid of a polyhedron [1]_.
+ Computes the position of the centroid of a polyhedron :cite:p:`Dobrovolskis1996`.
 
 
  Parameters
@@ -122,8 +118,6 @@ void expose_polyhedron_utilities( py::module &m )
 
 
 
-
-
      )doc" );
 
     m.def( "modify_centroid",
@@ -136,7 +130,7 @@ void expose_polyhedron_utilities( py::module &m )
  Modifies vertex coordinates of the polyhedron based on the desired position of the centroid.
 
  Modifies the coordinates of the polyhedron vertices, such that the centroid of the modified polyhedron coincides
- with the specified position. The centroid is computed according to Dobrovolskis [1]_.
+ with the specified position. The centroid is computed according to :cite:t:`Dobrovolskis1996`.
 
 
  Parameters
@@ -175,7 +169,7 @@ void expose_polyhedron_utilities( py::module &m )
 
  Compute the inertia tensor of a polyhedron, from the density.
 
- Computes the inertia tensor of a polyhedron, according to Dobrovolskis [1]_.
+ Computes the inertia tensor of a polyhedron, according to :cite:t:`Dobrovolskis1996`.
 
  The mass distribution is defined using the density of the polyhedron. To instead use the gravitational
  parameter see :func:`~tudatpy.astro.polyhedron_utilities.inertia_tensor_from_gravitational_parameter`.
@@ -220,7 +214,7 @@ void expose_polyhedron_utilities( py::module &m )
 
  Compute the inertia tensor of a polyhedron, from the gravitational parameter.
 
- Computes the inertia tensor of a polyhedron, according to Dobrovolskis [1]_.
+ Computes the inertia tensor of a polyhedron, according to :cite:t:`Dobrovolskis1996`.
 
  The mass distribution is defined using the gravitational parameter of the polyhedron. To instead use the density
  see :func:`~tudatpy.astro.polyhedron_utilities.inertia_tensor_from_density`.

--- a/src/tudatpy/astro/two_body_dynamics/expose_two_body_dynamics.cpp
+++ b/src/tudatpy/astro/two_body_dynamics/expose_two_body_dynamics.cpp
@@ -126,18 +126,6 @@ void expose_two_body_dynamics( py::module &m )
      needed to achieve the specified excess velocity at infinity and the current orbital velocity at the
      pericenter.
 
-    py::class_< tms::PericenterFindingFunctions, std::shared_ptr< tms::PericenterFindingFunctions > >( m, "PericenterFindingFunctions" )
-            .def( py::init< const double, const double, const double >( ),
-                  py::arg( "absolute_incoming_semi_major_axis" ),
-                  py::arg( "absolute_outgoing_semi_major_axis" ),
-                  py::arg( "bending_angle" ) )
-            .def( "compute_pericenter_radius_fn", &tms::PericenterFindingFunctions::computePericenterRadiusFunction )
-            .def( "compute_derivative_pericenter_radius_fn",
-                  &tms::PericenterFindingFunctions::computeFirstDerivativePericenterRadiusFunction );
-
-
-
-
 
      )doc" );
 

--- a/src/tudatpy/numerical_simulation/environment_setup/atmosphere/expose_atmosphere.cpp
+++ b/src/tudatpy/numerical_simulation/environment_setup/atmosphere/expose_atmosphere.cpp
@@ -485,35 +485,36 @@ void expose_atmosphere_setup( py::module &m )
            py::arg( "use_anomalous_oxygen" ) = true,
                R"doc(
 
- Function for creating NRLMSISE-00 atmospheric model settings.
+Function for creating NRLMSISE-00 atmospheric model settings.
 
- Function for settings object, defining atmosphere model in accordance to the NRLMSISE-00 global reference model for Earth's atmosphere.
- The NRLMSISE-00 model implementation uses the code `here <https://github.com/tudat-team/nrlmsise-00-cmake>`_.
+Function for settings object, defining atmosphere model in accordance to the NRLMSISE-00 global reference model for Earth's atmosphere.
+The NRLMSISE-00 model implementation uses the code from `tudat-team/nrlmsise-00-cmake <https://github.com/tudat-team/nrlmsise-00-cmake>`_.
 
 
- Parameters
- ----------
+Parameters
+----------
 space_weather_file : str, default = :func:`~tudatpy.data.get_space_weather_path` + 'sw19571001.txt'
-    File to be used for space weather characteristics as a function of time (e.g. F10.7, Kp, etc.). The file is typically taken from here `celestrak <https://celestrak.org/SpaceData/sw19571001.txt>`_ (note that the file in your resources path will not be the latest version of this file; download and replace your existing file if required). Documentation on the file is given `here <https://celestrak.org/SpaceData/SpaceWx-format.php>`_
+    File to be used for space weather characteristics as a function of time (e.g. F10.7, Kp, etc.). The file is typically taken from `celestrak <https://celestrak.org/SpaceData/sw19571001.txt>`_ (note that the file in your resources path will not be the latest version of this file; download and replace your existing file if required). Documentation on the file is given on the `celestrak website <https://celestrak.org/SpaceData/SpaceWx-format.php>`_
 use_storm_conditions : bool, default = false
     Boolean to define whether to use sub-daily Ap values when querying the NRLMSISE model, which is relevant under geomagnetic storm conditions (see `NRLMSISE code <https://github.com/tudat-team/nrlmsise-00-cmake/blob/master/nrlmsise-00.h>`_, setting this variable to true sets ``switches[9]`` to -1, with resulting details of Ap values defined in ``ap_array``).
 use_anomalous_oxygen : bool, default = true
     Boolean to define whether to use anomalous oxygen when querying the NRLMSISE model (if true, using ``gtd7d`` function, if false using ``gtd7`` function in `NRLMSISE code <https://github.com/tudat-team/nrlmsise-00-cmake/blob/master/nrlmsise-00.h>`_)
+
 Returns
- -------
- AtmosphereSettings
-     Instance of the :class:`~tudatpy.numerical_simulation.environment_setup.atmosphere.AtmosphereSettings` class
+-------
+AtmosphereSettings
+    Instance of the :class:`~tudatpy.numerical_simulation.environment_setup.atmosphere.AtmosphereSettings` class
 
 
 
 
 
- Examples
- --------
- In this example, we create :class:`~tudatpy.numerical_simulation.environment_setup.atmosphere.AtmosphereSettings` for Earth,
- using the NRLMSISE-00 global reference model:
+Examples
+--------
+In this example, we create :class:`~tudatpy.numerical_simulation.environment_setup.atmosphere.AtmosphereSettings` for Earth,
+using the NRLMSISE-00 global reference model:
 
- .. code-block:: python
+.. code-block:: python
 
     # create atmosphere settings and add to body settings of body "Earth"
     body_settings.get( "Earth" ).atmosphere_settings = environment_setup.atmosphere.nrlmsise00()

--- a/src/tudatpy/numerical_simulation/environment_setup/gravity_field/expose_gravity_field.cpp
+++ b/src/tudatpy/numerical_simulation/environment_setup/gravity_field/expose_gravity_field.cpp
@@ -738,7 +738,7 @@ Coefficients for the SHGJ180U Moon gravity field up to degree and order 180, (se
  It represents the frame in which the polyhedron field is defined.
 
  The gravitational potential, acceleration, Laplacian of potential and Hessian of potential are computed according
- to Werner and Scheeres [2]_.
+ to :cite:t:`werner1997`.
 
  This function uses the gravitational parameter to define the gravity field. To instead use the density
  constant see :func:`~tudatpy.astro.gravitation.polyhedron_from_density`. Since both models tend to be computationally intensive,
@@ -797,7 +797,7 @@ Coefficients for the SHGJ180U Moon gravity field up to degree and order 180, (se
  It represents the frame in which the polyhedron field is defined.
 
  The gravitational potential, acceleration, Laplacian of potential and Hessian of potential are computed according
- to Werner and Scheeres [2]_.
+ to :cite:t:`werner1997`.
 
  This function uses the density to define the gravity field. To instead use the
  gravitational parameter see :func:`~tudatpy.astro.gravitation.polyhedron_from_mu`.
@@ -862,7 +862,7 @@ Coefficients for the SHGJ180U Moon gravity field up to degree and order 180, (se
  Gravity fields from this setting object are expressed in normalized spherical harmonic coefficients.
  The constant mass distribution is defined by the density and gravitational constant (optional).
  The body-fixed x-, y- and z- axes are assumed to be along the A-, B- and C- axes.
- This function implements the models of (see Balmino [1]_).
+ This function implements the models of (see :cite:t:`balmino1994`).
 
 
  Parameters
@@ -887,8 +887,6 @@ Coefficients for the SHGJ180U Moon gravity field up to degree and order 180, (se
  -------
  SphericalHarmonicsGravityFieldSettings
      Instance of the :class:`~tudatpy.numerical_simulation.environment_setup.gravity_field.GravityFieldSettings` derived :class:`~tudatpy.numerical_simulation.environment_setup.gravity_field.SphericalHarmonicsGravityFieldSettings` class
-
-
 
 
 
@@ -937,7 +935,7 @@ Coefficients for the SHGJ180U Moon gravity field up to degree and order 180, (se
  Gravity fields from this setting object are expressed in normalized spherical harmonic coefficients.
  The constant mass distribution is defined by the gravitational parameter.
  The body-fixed x-, y- and z- axes are assumed to be along the A-, B- and C- axes.
- This function implements the models of (see Balmino [1]_).
+ This function implements the models of (see :cite:t:`balmino1994`).
 
 
  Parameters

--- a/src/tudatpy/numerical_simulation/propagation_setup/dependent_variable/expose_dependent_variable.cpp
+++ b/src/tudatpy/numerical_simulation/propagation_setup/dependent_variable/expose_dependent_variable.cpp
@@ -1162,7 +1162,7 @@ void expose_dependent_variable_setup( py::module &m )
 
  Function to add the aerodynamic moment coefficients to the dependent variables to save.
 
- Function to add the aerodynamic force coefficients to the dependent variables to save. It requires an aerodynamic coefficient interface to be defined for the vehicle. The coefficients are returned in the following order: C_l, C_m, C_n , respectively about the X, Y, Z axes of the body-fixed frame, see (see Mooij, 1994 [1]_)
+ Function to add the aerodynamic force coefficients to the dependent variables to save. It requires an aerodynamic coefficient interface to be defined for the vehicle. The coefficients are returned in the following order: C_l, C_m, C_n , respectively about the X, Y, Z axes of the body-fixed frame, see (see :cite:t:`mooij1994`)
 
  Parameters
  ----------
@@ -1174,9 +1174,6 @@ void expose_dependent_variable_setup( py::module &m )
  -------
  SingleDependentVariableSaveSettings
      Dependent variable settings object.
-
-
-
 
 
 
@@ -1302,7 +1299,7 @@ void expose_dependent_variable_setup( py::module &m )
 
  Function to add the heading angle to the dependent variables to save.
 
- Function to add the heading angle to the dependent variables to save, as defined by Mooij, 1994 [1]_ .
+ Function to add the heading angle to the dependent variables to save, as defined by :cite:t:`mooij1994`.
 
  Parameters
  ----------
@@ -1330,7 +1327,7 @@ void expose_dependent_variable_setup( py::module &m )
 
  Function to add the flight path angle to the dependent variables to save.
 
- Function to add the flight path angle to the dependent variables to save, as defined by Mooij, 1994 [1]_ .
+ Function to add the flight path angle to the dependent variables to save, as defined by :cite:t:`mooij1994`.
 
  Parameters
  ----------
@@ -1358,7 +1355,7 @@ void expose_dependent_variable_setup( py::module &m )
 
  Function to add the angle of attack to the dependent variables to save.
 
- Function to add the angle of attack angle to the dependent variables to save, as defined by Mooij, 1994 [1]_ .
+ Function to add the angle of attack angle to the dependent variables to save, as defined by :cite:t:`mooij1994`.
 
  Parameters
  ----------
@@ -1384,7 +1381,7 @@ void expose_dependent_variable_setup( py::module &m )
            py::arg( "central_body" ),
            R"doc(
 
- Function to add the sideslip angle to the dependent variables to save, as defined by Mooij, 1994 [1]_ .
+ Function to add the sideslip angle to the dependent variables to save, as defined by :cite:t:`mooij1994`.
 
 
  Parameters
@@ -1411,7 +1408,7 @@ void expose_dependent_variable_setup( py::module &m )
            py::arg( "central_body" ),
            R"doc(
 
- Function to add the bank angle to the dependent variables to save, as defined by Mooij, 1994 [1]_ .
+ Function to add the bank angle to the dependent variables to save, as defined by :cite:t:`mooij1994`.
 
 
  Parameters

--- a/src/tudatpy/numerical_simulation/propagation_setup/propagator/expose_propagator.cpp
+++ b/src/tudatpy/numerical_simulation/propagation_setup/propagator/expose_propagator.cpp
@@ -285,44 +285,9 @@ Enumeration of available integrated state types.
          detail `here <https://docs.tudat.space/en/latest/_src_user_guide/state_propagation/propagation_setup/processed_propagated_elements.html>`__.
          Summarizing: the processed state is the 'typical' formulation of the state (for translational dynamics: Cartesian states).
 
-         .. note:: The same information can be retrieved from the
-                   :py:attr:`SingleArcSimulationResults.processed_state_ids`
-                   attribute.
+         .. note::
 
-    py::class_< tp::SingleArcPropagatorProcessingSettings,
-                std::shared_ptr< tp::SingleArcPropagatorProcessingSettings >,
-                tp::PropagatorProcessingSettings >(
-            m, "SingleArcPropagatorProcessingSettings", get_docstring( "SingleArcPropagatorProcessingSettings" ).c_str( ) )
-            .def_property_readonly( "print_settings",
-                                    &tp::SingleArcPropagatorProcessingSettings::getPrintSettings,
-                                    get_docstring( "SingleArcPropagatorProcessingSettings.print_settings" ).c_str( ) )
-            .def_property( "results_save_frequency_in_steps",
-                           &tp::SingleArcPropagatorProcessingSettings::getResultsSaveFrequencyInSteps,
-                           &tp::SingleArcPropagatorProcessingSettings::setResultsSaveFrequencyInSteps,
-                           get_docstring( "SingleArcPropagatorProcessingSettings.results_save_frequency_in_steps" ).c_str( ) )
-            .def_property( "results_save_frequency_in_seconds",
-                           &tp::SingleArcPropagatorProcessingSettings::getResultsSaveFrequencyInSeconds,
-                           &tp::SingleArcPropagatorProcessingSettings::setResultsSaveFrequencyInSeconds,
-                           get_docstring( "SingleArcPropagatorProcessingSettings.results_save_frequency_in_seconds" ).c_str( ) );
-
-    py::class_< tp::MultiArcPropagatorProcessingSettings,
-                std::shared_ptr< tp::MultiArcPropagatorProcessingSettings >,
-                tp::PropagatorProcessingSettings >(
-            m, "MultiArcPropagatorProcessingSettings", get_docstring( "MultiArcPropagatorProcessingSettings" ).c_str( ) )
-            .def( "set_print_settings_for_all_arcs",
-                  &tp::MultiArcPropagatorProcessingSettings::resetAndApplyConsistentSingleArcPrintSettings,
-                  py::arg( "single_arc_print_settings" ),
-                  get_docstring( "MultiArcPropagatorProcessingSettings.set_print_settings_for_all_arcs" ).c_str( ) )
-            .def_property( "print_output_on_first_arc_only",
-                           &tp::MultiArcPropagatorProcessingSettings::getPrintFirstArcOnly,
-                           &tp::MultiArcPropagatorProcessingSettings::resetPrintFirstArcOnly,
-                           get_docstring( "MultiArcPropagatorProcessingSettings.print_output_on_first_arc_only" ).c_str( ) )
-            .def_property_readonly( "identical_settings_per_arc",
-                                    &tp::MultiArcPropagatorProcessingSettings::useIdenticalSettings,
-                                    get_docstring( "MultiArcPropagatorProcessingSettings.identical_settings_per_arc" ).c_str( ) )
-            .def_property_readonly( "single_arc_settings",
-                                    &tp::MultiArcPropagatorProcessingSettings::getSingleArcSettings,
-                                    get_docstring( "MultiArcPropagatorProcessingSettings.single_arc_settings" ).c_str( ) );
+             The same information can be retrieved from the :py:attr:`SingleArcSimulationResults.processed_state_ids` attribute.
 
          :type: bool
       )doc" )
@@ -709,14 +674,6 @@ Enumeration of available integrated state types.
          Functional base class to define settings for propagators.
 
          Base class to define settings for propagators. Derived classes are split into settings for single- and multi-arc dynamics.
-
-    py::class_< tp::TranslationalStatePropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE >,
-                std::shared_ptr< tp::TranslationalStatePropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE > >,
-                tp::SingleArcPropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE > >(
-            m, "TranslationalStatePropagatorSettings", get_docstring( "TranslationalStatePropagatorSettings" ).c_str( ) )
-
-
-
 
       )doc" )
             .def_property( "initial_states",
@@ -1398,12 +1355,6 @@ HybridArcPropagatorSettings
  This behaviour can be suppressed by providing the optional input argument
  ``terminate_exactly_on_final_condition=True``, in which case the final propagation step will be *exactly* on the
  specified time.
-
-    m.def( "non_sequential_termination",
-           &tp::nonSequentialPropagationTerminationSettings,
-           py::arg( "forward_termination_settings" ),
-           py::arg( "backward_termination_settings" ),
-           get_docstring( "non_sequential_termination" ).c_str( ) );
 
  Parameters
  ----------

--- a/src/tudatpy/numerical_simulation/propagation_setup/propagator/expose_propagator.cpp
+++ b/src/tudatpy/numerical_simulation/propagation_setup/propagator/expose_propagator.cpp
@@ -76,42 +76,42 @@ Propagation of Cartesian elements (state vector size 6), without any transformat
                     tp::TranslationalPropagatorType::encke,
                     R"doc(
 
-Propagation of the difference in Cartesian elements of the orbit w.r.t. an unperturbed reference orbit. The reference orbit is generated from the initial state/central body, and not updated during the propagation (see Wakker, 2015 [2]_)
+Propagation of the difference in Cartesian elements of the orbit w.r.t. an unperturbed reference orbit. The reference orbit is generated from the initial state/central body, and not updated during the propagation (see :cite:t:`wakker2015`)
 
 )doc" )
             .value( "gauss_keplerian",
                     tp::TranslationalPropagatorType::gauss_keplerian,
                     R"doc(
 
-Propagation of Keplerian elements (state vector size 6), with true anomaly as the 'fast' element  (see Vallado, 2001 [4]_)
+Propagation of Keplerian elements (state vector size 6), with true anomaly as the 'fast' element  (see :cite:t:`vallado2001`)
 
 )doc" )
             .value( "gauss_modified_equinoctial",
                     tp::TranslationalPropagatorType::gauss_modified_equinoctial,
                     R"doc(
 
-Propagation of Modified equinoctial elements (state vector size 6), with the element :math:`I` defining the location of the singularity based on the initial condition (see Hintz, 2008 [3]_)
+Propagation of Modified equinoctial elements (state vector size 6), with the element :math:`I` defining the location of the singularity based on the initial condition (see :cite:t:`hintz2008`)
 
 )doc" )
             .value( "unified_state_model_quaternions",
                     tp::TranslationalPropagatorType::unified_state_model_quaternions,
                     R"doc(
 
-Propagation of Unified state model using quaternions (state vector size 7, see Vittaldev et al., 2012 [1]_)
+Propagation of Unified state model using quaternions (state vector size 7, see :cite:t:`vittaldev2012`)
 
 )doc" )
             .value( "unified_state_model_modified_rodrigues_parameters",
                     tp::TranslationalPropagatorType::unified_state_model_modified_rodrigues_parameters,
                     R"doc(
 
-Propagation of Unified state model using modified Rodrigues parameters (state vector size 7, last element represents shadow parameter, see Vittaldev et al., 2012 [1]_)
+Propagation of Unified state model using modified Rodrigues parameters (state vector size 7, last element represents shadow parameter, see :cite:t:`vittaldev2012`)
 
 )doc" )
             .value( "unified_state_model_exponential_map",
                     tp::unified_state_model_exponential_map,
                     R"doc(
 
-Propagation of Unified state model using exponential map (state vector size 7, last element represents shadow parameter, see Vittaldev et al., 2012 [1]_)
+Propagation of Unified state model using exponential map (state vector size 7, last element represents shadow parameter, see :cite:t:`vittaldev2012`)
 
 )doc" )
             .export_values( );
@@ -121,8 +121,6 @@ Propagation of Unified state model using exponential map (state vector size 7, l
                                                R"doc(
 
 Enumeration of available rotational propagator types.
-
-
 
 
 

--- a/src/tudatpy/trajectory_design/transfer_trajectory/expose_transfer_trajectory.cpp
+++ b/src/tudatpy/trajectory_design/transfer_trajectory/expose_transfer_trajectory.cpp
@@ -98,9 +98,7 @@ void expose_transfer_trajectory( py::module &m )
 
          Class for defining low-thrust spherical-shaping leg.
 
-         `TransferLeg` derived class for defining a low-thrust leg described using spherical shaping [3]_.
-
-
+         `TransferLeg` derived class for defining a low-thrust leg described using spherical shaping :cite:p:`roegiers2014`.
 
 
 
@@ -114,7 +112,7 @@ void expose_transfer_trajectory( py::module &m )
 
          Class for defining low-thrust hodographic-shaping leg.
 
-         `TransferLeg` derived class for defining a low-thrust leg described using hodographic shaping [4]_.
+         `TransferLeg` derived class for defining a low-thrust leg described using hodographic shaping :cite:p:`gondelach2012`.
 
 
 
@@ -241,7 +239,7 @@ void expose_transfer_trajectory( py::module &m )
 
  minimum_pericenters : dict[str, float], default=DEFAULT_MINIMUM_PERICENTERS
      Minimum pericenter radii, where each body is specified as key and the respective minimum pericenter radius as
-     value. Default values from Izzo [1]_.
+     value. Default values from :cite:t:`izzo2007`.
 
  Returns
  -------
@@ -293,7 +291,7 @@ void expose_transfer_trajectory( py::module &m )
 
  minimum_pericenters : dict[str, float], default=DEFAULT_MINIMUM_PERICENTERS
      Minimum pericenter radii, where each body is specified as key and the respective minimum pericenter radius as
-     value. Default values from Izzo [1]_.
+     value. Default values from :cite:t:`izzo2007`.
 
  Returns
  -------
@@ -345,7 +343,7 @@ void expose_transfer_trajectory( py::module &m )
 
  minimum_pericenters : dict[str, float], default=DEFAULT_MINIMUM_PERICENTERS
      Minimum pericenter radii, where each body is specified as key and the respective minimum pericenter radius as
-     value. Default values from Izzo [1]_.
+     value. Default values from :cite:t:`izzo2007`.
 
  Returns
  -------
@@ -420,7 +418,7 @@ void expose_transfer_trajectory( py::module &m )
 
  minimum_pericenters : dict[str, float], default=DEFAULT_MINIMUM_PERICENTERS
      Minimum pericenter radii, where each body is specified as key and the respective minimum pericenter radius as
-     value. Default values from Izzo [1]_.
+     value. Default values from :cite:t:`izzo2007`.
 
  Returns
  -------
@@ -487,7 +485,7 @@ void expose_transfer_trajectory( py::module &m )
 
  minimum_pericenters : dict[str, float], default=DEFAULT_MINIMUM_PERICENTERS
      Minimum pericenter radii, where each body is specified as key and the respective minimum pericenter radius as
-     value. Default values from Izzo [1]_.
+     value. Default values from :cite:t:`izzo2007`.
 
  Returns
  -------
@@ -553,7 +551,7 @@ void expose_transfer_trajectory( py::module &m )
 
  minimum_pericenters : dict[str, float], default=DEFAULT_MINIMUM_PERICENTERS
      Minimum pericenter radii, where each body is specified as key and the respective minimum pericenter radius as
-     value. Default values from Izzo [1]_.
+     value. Default values from :cite:t:`izzo2007`.
 
  Returns
  -------
@@ -842,7 +840,7 @@ void expose_transfer_trajectory( py::module &m )
  Given the departure and arrival position, this leg computes the departure and arrival velocity using a Lambert
  targeter.
  The calculations performed in this leg do not involve any numerical integration, and are solved by
- (semi-)analytical models. For details see Musegaas, 2012 [2]_.
+ (semi-)analytical models. For details see :cite:t:`musegaas2012`.
 
  Returns
  -------
@@ -870,7 +868,7 @@ void expose_transfer_trajectory( py::module &m )
  a Lambert targeter to compute the velocity after the DSM and the arrival velocity. The Delta V applied in the
  DSM is computed using the velocity before and after the DSM.
  The calculations performed in this leg do not involve any numerical integration, and are solved by
- (semi-)analytical models. For details see Musegaas, 2012 [2]_.
+ (semi-)analytical models. For details see :cite:t:`musegaas2012`.
 
  Returns
  -------
@@ -898,7 +896,7 @@ void expose_transfer_trajectory( py::module &m )
  and the arrival position, it computes the velocity after the DSM
  (which is used to compute the Delta V applied in the DSM) and the arrival velocity using a Lambert targeter.
  The calculations performed in this leg do not involve any numerical integration, and are solved by
- (semi-)analytical models. For details see Musegaas, 2012 [2]_.
+ (semi-)analytical models. For details see :cite:t:`musegaas2012`.
 
  Returns
  -------
@@ -930,7 +928,7 @@ void expose_transfer_trajectory( py::module &m )
  transfer. The trajectory depends on a single parameter, which is selected using the root finder in order to meet
  a user-specified time of flight.
  The calculations performed in this leg do not involve any numerical integration, and are solved by
- (semi-)analytical models. For details see Roegiers, 2014 [3]_.
+ (semi-)analytical models. For details see :cite:t:`roegiers2014`.
 
 
  Parameters
@@ -983,7 +981,7 @@ void expose_transfer_trajectory( py::module &m )
  component (radial, normal and axial); this is required to obtain a trajectory that satisfies the boundary
  conditions.
  The calculations performed in this leg do not involve any numerical integration, and are solved by
- (semi-)analytical models. For details see Gondelach, 2012 [4]_.
+ (semi-)analytical models. For details see :cite:t:`gondelach2012`.
 
 
  Parameters
@@ -1029,7 +1027,7 @@ void expose_transfer_trajectory( py::module &m )
  gravity assist, possibly with a Delta V at the a periapsis. Given known incoming and outgoing velocities,
  the node computes the Delta V required to meet those.
  The calculations performed in this node do not involve any numerical integration, and are solved by
- (semi-)analytical models. For details see Musegaas, 2012 [2]_.
+ (semi-)analytical models. For details see :cite:t:`musegaas2012`.
 
 
  Parameters
@@ -1063,7 +1061,7 @@ void expose_transfer_trajectory( py::module &m )
  Given the initial orbit and the departure velocity, the node computes the Delta V that needs to be applied
  at the periapsis of the initial orbit to enter the escape trajectory.
  The calculations performed in this node do not involve any numerical integration, and are solved by
- (semi-)analytical models. For details see Musegaas, 2012 [2]_.
+ (semi-)analytical models. For details see :cite:t:`musegaas2012`.
 
 
  Parameters
@@ -1097,7 +1095,7 @@ void expose_transfer_trajectory( py::module &m )
  Given the the arrival velocity and the final orbit, the node computes the Delta V that needs to be applied
  at the periapsis of the final orbit to exit the capture trajectory.
  The calculations performed in this node do not involve any numerical integration, and are solved by
- (semi-)analytical models. For details see Musegaas, 2012 [2]_.
+ (semi-)analytical models. For details see :cite:t:`musegaas2012`.
 
 
  Parameters


### PR DESCRIPTION
As discussed in the last developer meeting, this PR adds a global bibliography to the API reference. At the moment the bibliography is added on the index page, which can of course be modified!
Additionally, the citations are now created using the `sphinxcontrib.bibtex` package for more flexibility and easier bibliography maintenance.

> [!IMPORTANT]
> This PR builds on #309, which should be reviewed and merged first. 