### PR TITLE
JD and MJD static methods to construct DateTime

### DIFF
--- a/docs/source/time_conversion.rst
+++ b/docs/source/time_conversion.rst
@@ -50,17 +50,11 @@ Functions
 
    iso_string_to_epoch
 
-   julian_day_to_python_datetime
-
    julian_day_to_seconds_since_epoch
 
    julian_day_to_modified_julian_day
 
    modified_julian_day_to_julian_day
-
-   python_datetime_to_julian_day
-
-   python_datetime_to_days_since_epoch
 
    seconds_since_epoch_to_julian_day
 
@@ -99,17 +93,11 @@ Functions
 
 .. autofunction:: tudatpy.astro.time_conversion.iso_string_to_epoch
 
-.. autofunction:: tudatpy.astro.time_conversion.julian_day_to_python_datetime
-
 .. autofunction:: tudatpy.astro.time_conversion.julian_day_to_seconds_since_epoch
 
 .. autofunction:: tudatpy.astro.time_conversion.julian_day_to_modified_julian_day
 
 .. autofunction:: tudatpy.astro.time_conversion.modified_julian_day_to_julian_day
-
-.. autofunction:: tudatpy.astro.time_conversion.python_datetime_to_julian_day
-
-.. autofunction:: tudatpy.astro.time_conversion.python_datetime_to_days_since_epoch
 
 .. autofunction:: tudatpy.astro.time_conversion.seconds_since_epoch_to_julian_day
 

--- a/src/tudatpy/astro/time_conversion/expose_time_conversion.cpp
+++ b/src/tudatpy/astro/time_conversion/expose_time_conversion.cpp
@@ -65,6 +65,8 @@ std::chrono::system_clock::time_point dateTimeToTimePoint( const tba::DateTime& 
 // returned is a time_point (Python datetime).
 std::chrono::system_clock::time_point convertJulianDayToCalendarDatePy( const double julianDay )
 {
+    tutil::printDeprecationWarning( "julian_day_to_calendar_date", "DateTime.from_julian_day(...).to_python_datetime()" );
+
     tba::DateTime dateTime = tba::DateTime::fromTime< double >( tudat::timeFromJulianDay< double >( julianDay ) );
 
     return dateTime.timePoint( );
@@ -75,6 +77,8 @@ std::chrono::system_clock::time_point convertJulianDayToCalendarDatePy( const do
 template< typename TimeScalarType = double >
 TimeScalarType convertCalendarDateToJulianDayPy( const std::chrono::system_clock::time_point calendarDate )
 {
+    tutil::printDeprecationWarning( "calendar_date_to_julian_day", "DateTime.from_python_datetime(...).to_julian_day()" );
+
     tba::DateTime dateTime = tba::DateTime::fromTimePoint( calendarDate );
     return dateTime.julianDay< TimeScalarType >( );
 }
@@ -84,6 +88,8 @@ TimeScalarType convertCalendarDateToJulianDaySinceEpochPy(
         const std::chrono::system_clock::time_point calendarDate,
         const TimeScalarType epochSinceJulianDayZero = tba::getJulianDayOnJ2000< TimeScalarType >( ) )
 {
+    tutil::printDeprecationWarning( "calendar_date_to_days_since_epoch",
+                                    "DateTime.from_python_datetime(...).to_days_since_reference_julian_day()" );
     tba::DateTime dateTime = tba::DateTime::fromTimePoint( calendarDate );
     return dateTime.julianDay< TimeScalarType >( ) - epochSinceJulianDayZero;
 }
@@ -555,6 +561,68 @@ In this example, the calendar date corresponding to when 122 days have passed in
      print(dt) # prints 2025-01-01 00:00:00.000000000000000
                          
                          )doc" )
+            .def_static( "from_julian_day",
+                         &tba::DateTime::fromJulianDay,
+                         py::arg( "julian_day" ),
+                         R"doc(
+
+ Creates a Tudat-native :class:`DateTime` object from a Julian day.
+
+ Parameters
+ ----------
+ julian_day : float
+     Date in Julian days since January 1st 4713 BC.
+
+ Returns
+ -------
+ DateTime
+     Tudat ``DateTime`` object.
+
+ Examples
+ --------
+ In this example, the DateTime is constructed from a Julian day since January 1st 4713 BC.
+ 
+ .. code-block:: python
+ 
+     from tudatpy.astro.time_conversion import DateTime
+
+     julian_day = 2451545.0 
+
+     dt = DateTime.from_julian_day(julian_day)
+     print(dt) # prints 2000-01-01 12:00:00.000000000000000
+                         
+                         )doc" )
+            .def_static( "from_modified_julian_day",
+                         &tba::DateTime::fromModifiedJulianDay,
+                         py::arg( "modified_julian_day" ),
+                         R"doc(
+
+ Creates a Tudat-native :class:`DateTime` object from a modified Julian day.
+
+ Parameters
+ ----------
+ modified_julian_day : float
+     Date in modified Julian days (number of days since November 17th 1858).
+
+ Returns
+ -------
+ DateTime
+     Tudat ``DateTime`` object.
+
+ Examples
+ --------
+ In this example, the DateTime is constructed from a modified Julian day since November 17th 1858.
+ 
+ .. code-block:: python
+ 
+     from tudatpy.astro.time_conversion import DateTime
+
+     modified_julian_day = 51544.5
+
+     dt = DateTime.from_modified_julian_day(modified_julian_day)
+     print(dt) # prints 2000-01-01 12:00:00.000000000000000
+                         
+                         )doc" )
             .def( "to_python_datetime", &tba::DateTime::timePoint, R"doc(
                 
 Method to convert retrieve a Python datetime.datetime object from the Tudat :class:`DateTime` object. This is the inverse of the :meth:`~tudatpy.astro.time_conversion.DateTime.from_python_datetime` method.
@@ -571,6 +639,40 @@ datetime.datetime
     Datetime object, using the Python datetime library
 
     )doc" )
+            .def( "to_days_since_reference_julian_day",
+                  &tba::DateTime::daySinceReferenceJulianDay< double >,
+                  py::arg( "reference_julian_day" ) = tba::JULIAN_DAY_ON_J2000,
+                  R"doc(
+
+ Convert a DateTime to Julian days since a given reference Julian date.
+
+
+ Parameters
+ ----------
+ reference_julian_day : float, default = constants.JULIAN_DAY_ON_J2000
+     Reference epoch (in days) since when the Julian days have to be counted. By default, set to `constants.JULIAN_DAY_ON_J2000` (2451545.0) corresponding to the 1st of January 2000.
+ Returns
+ -------
+ float
+     Date in Julian days since the given reference epoch.
+
+ Examples
+ --------
+ In this example, the calendar date of the 21st of May 2022 at 13:52 and 41 seconds is converted to Julian days since J2000 (the 1st of January 2000).
+
+ .. code-block:: python
+
+   from tudatpy.astro.time_conversion import DateTime
+
+   # Define the calendar date using datetime
+   dt = DateTime(2022, 5, 21, 13, 52, 41)
+   # Convert the calendar date to Julian days since J2000
+   julian_date = dt.to_days_since_reference_julian_day()
+   # Print the converted output
+   print(julian_date)  # prints 8176.07825231459
+
+
+     )doc" )
             .def( "add_seconds", &tba::DateTime::addSecondsToDateTime< TIME_TYPE >, py::arg( "seconds_to_add" ), R"doc(
             
  Function to create a new Tudat :class:`DateTime` object by adding a number of seconds to an existing Tudat :class:`DateTime` object.
@@ -638,383 +740,6 @@ datetime.datetime
      # dt with days added: 2025-01-02 00:00:00.000000000000000   
 
             )doc" );
-
-    m.def( "datetime_to_tudat",
-           &tba::DateTime::fromTimePoint,
-           py::arg( "datetime" ),
-           R"doc(
-
- .. warning::
-
-    This function is deprecated and will be removed in a future version of Tudat. Use :func:`DateTime.from_python_datetime` instead.
-
- Function to convert a Python datetime.datetime object to a Tudat :class:`DateTime` object. The Tudat-native alternative has the advantage of providing sub-femtosecond resolution, as opposed to the microsecond resolution of the Python version
-
-
- Parameters
- ----------
- datetime : datetime.datetime
-     Datetime object, using the Python datetime library. Both the date and the time (hour, minutes, and seconds), can be specified, up to millisecond resolution.
- Returns
- -------
- DateTime
-     DateTime object defined in Tudat
-
-    )doc" );
-
-    m.def( "year_and_days_in_year_to_calendar_date",
-           &tba::DateTime::fromYearAndDaysInYear,
-           py::arg( "year" ),
-           py::arg( "days_in_year" ),
-           R"doc(
-        
-.. warning::
-
-    This function is deprecated and will be removed in a future version of Tudat. Use :func:`DateTime.from_year_and_day_of_year` instead.
-
-Create the Tudat :class:`DateTime` from the year and the number of days in the year.
-
-Parameters
-----------
-year : int
-    Calendar year.
-days_in_year : int
-    Number of days that have passed in the year.
-Returns
--------
-DateTime
-    Corresponding calendar date as a :class:`DateTime` object. Note: the hours, minutes and seconds in the object are set to 0 when calling this function.
-
-Examples
---------
-In this example, the calendar date corresponding to when 122 days have passed in 2020 is computed.
-
-.. code-block:: python
-
-    # Compute the calendar date when 122 days have passed in 2020
-    currentDate = time_conversion.year_and_days_in_year_to_calendar_date(2020, 122)
-    # Print the converted output
-    print(currentDate)  # prints (2020, 5, 2, 0, 0)
-
-     )doc" );
-
-    m.def( "datetime_to_python",
-           &dateTimeToTimePoint,
-           py::arg( "datetime" ),
-           R"doc(
-
- .. warning::
-
-    This function is deprecated and will be removed in a future version of Tudat. Use :func:`DateTime.to_python_datetime` instead.
-
-
- Function to convert a Tudat :class:`DateTime` object to a Python datetime.datetime object. This is the inverse of the :func:`datetime_to_tudat` function
-
- Parameters
- ----------
- datetime : DateTime
-     Tudat-native Datetime object. Both the date and the time (hour, minutes, and seconds), can be specified, up to sub-femtosecond resolution.
- Returns
- -------
- datetime.datetime
-     Datetime object, using the Python datetime library
-     )doc" );
-
-    m.def( "add_seconds_to_datetime",
-           &tba::addSecondsToDateTime< TIME_TYPE >,
-           py::arg( "datetime" ),
-           py::arg( "seconds_to_add" ),
-           R"doc(
-
- Function to create a new Tudat :class:`DateTime` object by adding a number of seconds to an existing Tudat :class:`DateTime` object
-
-
- Parameters
- ----------
- datetime : DateTime
-     Tudat-native Datetime object to which a number of seconds are to be added
- seconds_to_add : float
-     Number of seconds to add
- Returns
- -------
- DateTime
-     Tudat-native Datetime object created by adding the given number of seconds to the original DateTime
-
-
-
-
-
-
-     )doc" );
-
-    m.def( "add_days_to_datetime",
-           &tba::addDaysToDateTime< TIME_TYPE >,
-           py::arg( "datetime" ),
-           py::arg( "days_to_add" ),
-           R"doc(
-
- Function to create a new Tudat :class:`DateTime` object by adding a number of days (86400 seconds) to an existing Tudat :class:`DateTime` object
-
-
- Parameters
- ----------
- datetime : DateTime
-     Tudat-native Datetime object to which a number of days are to be added
- days_to_add : float
-     Number of days to add
- Returns
- -------
- DateTime
-     Tudat-native Datetime object created by adding the given number of days to the original DateTime
-
-
-
-
-
-
-     )doc" );
-
-    m.def( "calendar_date_to_julian_day",
-           &convertCalendarDateToJulianDayPy< double >,
-           py::arg( "calendar_date" ),
-           R"doc(
-
- .. warning::
-
-    This function is deprecated and will be removed in a future version of Tudat. Use :func:`python_datetime_to_julian_day` instead.
-
- Convert a calendar date to Julian days.
-
-
- Parameters
- ----------
- calendar_date : datetime.datetime
-     Datetime object, using the Python datetime library. Both the date and the time (hour, minutes, and seconds), can be specified, up to millisecond resolution.
- Returns
- -------
- float
-     Julian day number (days since noon January 1st 4713 BC.)
-
-
-
-
-
- Examples
- --------
- In this example, the calendar date of the 21st of May 2022 at 13:52 and 41 seconds is converted to Julian days.
-
- .. code-block:: python
-
-   # Define the calendar date using datetime
-   calendar_date = datetime.datetime(2022, 5, 21, 13, 52, 41)
-   # Convert the calendar date to Julian days since January 1st 4713 BC
-   julian_date = time_conversion.calendar_date_to_julian_day(calendar_date)
-   # Print the converted output
-   print(julian_date)  # prints 2459721.0782523146
-
-
-     )doc" );
-
-    m.def( "python_datetime_to_julian_day",
-           &convertCalendarDateToJulianDayPy< double >,
-           py::arg( "datetime" ),
-           R"doc(
-
- Convert a calendar date to Julian days.
-
-
- Parameters
- ----------
- datetime : datetime.datetime
-     Datetime object, using the Python datetime library. Both the date and the time (hour, minutes, and seconds), can be specified, up to millisecond resolution.
- Returns
- -------
- float
-     Julian day number (days since noon January 1st 4713 BC.)
-
-
-
-
-
- Examples
- --------
- In this example, the calendar date of the 21st of May 2022 at 13:52 and 41 seconds is converted to Julian days.
-
- .. code-block:: python
-
-   # Define the calendar date using datetime
-   calendar_date = datetime.datetime(2022, 5, 21, 13, 52, 41)
-   # Convert the calendar date to Julian days since January 1st 4713 BC
-   julian_date = time_conversion.python_datetime_to_julian_day(calendar_date)
-   # Print the converted output
-   print(julian_date)  # prints 2459721.0782523146
-
-
-     )doc" );
-
-    m.def( "julian_day_to_calendar_date",
-           &convertJulianDayToCalendarDatePy,
-           py::arg( "julian_day" ),
-           R"doc(
-
- .. warning::
-
-    This function is deprecated and will be removed in a future version of Tudat. Use :func:`julian_day_to_python_datetime` instead.
-
- Convert Julian days to a calendar date.
-
- Inverse function of :func:`calendar_date_to_julian_day`.
-
- Parameters
- ----------
- julian_day : float
-     Date in Julian days since January 1st 4713 BC.
- Returns
- -------
- datetime.datetime
-     Datetime object, using the Python datetime library, containing the date and time corresponding to the Julian date input.
-
-
-
-
-
- Examples
- --------
- In this example, the Julian date `2459721.0783` (in days since January 1st 4713 BC), is converted to a calendar date.
-
- .. code-block:: python
-
-   # Define the Julian date in days since January 1st 4713 BC
-   julian_date = 2459721.0783
-   # Convert the Julian date to a calendar date
-   calendar_date = time_conversion.julian_day_to_calendar_date(julian_date)
-   # Print the converted output
-   print(calendar_date)  # prints datetime.datetime(2022, 5, 21, 13, 52, 45)
-
-
-     )doc" );
-
-    m.def( "julian_day_to_python_datetime",
-           &convertJulianDayToCalendarDatePy,
-           py::arg( "julian_day" ),
-           R"doc(
-
- Convert Julian days to a calendar date.
-
- Inverse function of :func:`python_datetime_to_julian_day`.
-
- Parameters
- ----------
- julian_day : float
-     Date in Julian days since January 1st 4713 BC.
- Returns
- -------
- datetime.datetime
-     Datetime object, using the Python datetime library, containing the date and time corresponding to the Julian date input.
-
-
-
-
-
- Examples
- --------
- In this example, the Julian date `2459721.0783` (in days since January 1st 4713 BC), is converted to a calendar date.
-
- .. code-block:: python
-
-   # Define the Julian date in days since January 1st 4713 BC
-   julian_date = 2459721.0783
-   # Convert the Julian date to a calendar date
-   calendar_date = time_conversion.julian_day_to_python_datetime(julian_date)
-   # Print the converted output
-   print(calendar_date)  # prints datetime.datetime(2022, 5, 21, 13, 52, 45)
-
-
-     )doc" );
-
-    m.def( "calendar_date_to_days_since_epoch",
-           &convertCalendarDateToJulianDaySinceEpochPy< double >,
-           py::arg( "calendar_date" ),
-           py::arg( "days_since_julian_day_zero" ) = tba::JULIAN_DAY_ON_J2000,
-           R"doc(
-
- .. warning::
-
-    This function is deprecated and will be removed in a future version of Tudat. Use :func:`python_datetime_to_days_since_epoch` instead.
-
- Convert a calendar date to Julian days since a given epoch.
-
-
- Parameters
- ----------
- calendar_date : datetime.datetime
-     Datetime object, using the Python datetime library. Both the date and the time (hour, minutes, and seconds), can be specified. Milliseconds are ignored.
- days_since_julian_day_zero : float, default = constants.JULIAN_DAY_ON_J2000
-     Reference epoch (in days) since when the Julian days have to be counted. By default, set to `constants.JULIAN_DAY_ON_J2000` (2451545.0) corresponding to the 1st of January 2000.
- Returns
- -------
- float
-     Date in Julian days since the given epoch.
-
-
-
-
-
- Examples
- --------
- In this example, the calendar date of the 21st of May 2022 at 13:52 and 41 seconds is converted to Julian days since J2000 (the 1st of January 2000).
-
- .. code-block:: python
-
-   # Define the calendar date using datetime
-   calendar_date = datetime.datetime(2022, 5, 21, 13, 52, 41)
-   # Convert the calendar date to Julian days since J2000
-   julian_date = time_conversion.calendar_date_to_days_since_epoch(calendar_date)
-   # Print the converted output
-   print(julian_date)  # prints 8176.07825231459
-
-
-     )doc" );
-
-    m.def( "python_datetime_to_days_since_epoch",
-           &convertCalendarDateToJulianDaySinceEpochPy< double >,
-           py::arg( "datetime" ),
-           py::arg( "days_since_julian_day_zero" ) = tba::JULIAN_DAY_ON_J2000,
-           R"doc(
-
- Convert a calendar date to Julian days since a given epoch.
-
-
- Parameters
- ----------
- datetime : datetime.datetime
-     Datetime object, using the Python datetime library. Both the date and the time (hour, minutes, and seconds), can be specified. Milliseconds are ignored.
- days_since_julian_day_zero : float, default = constants.JULIAN_DAY_ON_J2000
-     Reference epoch (in days) since when the Julian days have to be counted. By default, set to `constants.JULIAN_DAY_ON_J2000` (2451545.0) corresponding to the 1st of January 2000.
- Returns
- -------
- float
-     Date in Julian days since the given epoch.
-
-
-
-
-
- Examples
- --------
- In this example, the calendar date of the 21st of May 2022 at 13:52 and 41 seconds is converted to Julian days since J2000 (the 1st of January 2000).
-
- .. code-block:: python
-
-   # Define the calendar date using datetime
-   calendar_date = datetime.datetime(2022, 5, 21, 13, 52, 41)
-   # Convert the calendar date to Julian days since J2000
-   julian_date = time_conversion.python_datetime_to_days_since_epoch(calendar_date)
-   # Print the converted output
-   print(julian_date)  # prints 8176.07825231459
-
-
-     )doc" );
 
     m.def( "julian_day_to_seconds_since_epoch",
            &tba::convertJulianDayToSecondsSinceEpoch< double >,
@@ -1661,7 +1386,7 @@ In this example, the calendar date corresponding to when 122 days have passed in
 
      )doc" );
 
-    m.def( "epoch_from_date_time_components",
+    m.def( "date_time_components_to_epoch",
            &tba::timeFromDecomposedDateTime< TIME_TYPE >,
            py::arg( "year" ),
            py::arg( "month" ),
@@ -1671,13 +1396,9 @@ In this example, the calendar date corresponding to when 122 days have passed in
            py::arg( "seconds" ),
            R"doc(
 
- .. warning::
-
-    This function is deprecated and will be removed in a future version of Tudat. Use :func:`date_time_components_to_epoch` instead.
-
  Computes the epoch as seconds since J2000 from the entries of the current date and time.
 
- Computes the epoch as seconds since J2000. This function is added for convenience, and creates a :class:`DateTime` object, and subsequently calls its ``epoch`` function
+ Computes the epoch as seconds since J2000. This function is added for convenience, and is equivalent to ``DateTime(...).to_epoch()``.
 
  Parameters
  ----------
@@ -1711,7 +1432,508 @@ In this example, the calendar date corresponding to when 122 days have passed in
 
      )doc" );
 
-    m.def( "date_time_components_to_epoch",
+    m.def( "iso_string_to_epoch",
+           &tba::timeFromIsoString< TIME_TYPE >,
+           py::arg( "iso_datetime" ),
+           R"doc(
+
+ Computes the epoch as seconds since J2000 from an ISO datetime string.
+
+ Computes the epoch as seconds since J2000. This function is added for convenience and is equivalent to ``DateTime.from_iso_string(...).to_epoch()``.
+
+ Parameters
+ ----------
+ iso_datetime : str
+     Date and time as ISO compatible string ("YYYY-MM-DDTHH:MM:SS.SSSSS..", where the T may be replaced with a space)
+
+ Returns
+ -------
+ float
+     Time in seconds since J2000.
+
+
+
+
+
+
+     )doc" );
+
+    //    m.def("epoch_from_julian_day",
+    //          &tudat::timeFromJulianDay< TIME_TYPE >,
+    //          py::arg("julian_day"),
+    //          get_docstring("epoch_from_julian_day").c_str() );
+
+    //    m.def("epoch_from_modified_julian_day",
+    //          &tudat::timeFromModifiedJulianDay< TIME_TYPE >,
+    //          py::arg("modified_julian_day"),
+    //          get_docstring("epoch_from_modified_julian_day").c_str()
+    //          );
+
+    /////////////// DEPRECATED
+
+    m.def( "date_time_from_epoch",
+           &tba::DateTime::fromTime< TIME_TYPE >,
+           py::arg( "epoch" ),
+           R"doc(
+
+ .. warning::
+
+    This function is deprecated and will be removed in a future version of Tudat. Use :func:`DateTime.from_epoch` instead.
+
+
+ Creates a Tudat-native :class:`DateTime` object from the seconds since J2000.
+
+
+ Parameters
+ ----------
+ epoch : float
+     Seconds since J2000
+
+ Returns
+ -------
+ DateTime
+     Tudat ``DateTime`` object.
+
+
+
+
+
+
+     )doc" );
+
+    m.def( "date_time_from_iso_string",
+           &tba::DateTime::fromIsoString,
+           py::arg( "iso_string" ),
+           R"doc(
+
+ .. warning::
+
+    This function is deprecated and will be removed in a future version of Tudat. Use :func:`DateTime.from_iso_string` instead.
+
+ Creates a Tudat-native :class:`DateTime` object from an ISO datetime string.
+
+
+ Parameters
+ ----------
+ iso_datetime : str
+     Date and time as ISO compatible string ("YYYY-MM-DDTHH:MM:SS.SSSSS..", where the T may be replaced with a space)
+
+ Returns
+ -------
+ DateTime
+     Tudat ``DateTime`` object.
+
+
+
+
+
+
+     )doc" );
+
+    m.def( "calendar_date_to_julian_day_since_epoch",
+           &convertCalendarDateToJulianDaySinceEpochPy< double >,
+           py::arg( "calendar_date" ),
+           py::arg( "days_since_julian_day_zero" ) = tba::JULIAN_DAY_ON_J2000 );
+
+    m.def( "calendar_date_to_days_since_epoch",
+           &convertCalendarDateToJulianDaySinceEpochPy< double >,
+           py::arg( "calendar_date" ),
+           py::arg( "days_since_julian_day_zero" ) = tba::JULIAN_DAY_ON_J2000,
+           R"doc(
+
+ .. warning::
+
+    This function is deprecated and will be removed in a future version of Tudat. Use `DateTime.from_python_datetime(...).to_days_since_reference_julian_day()` instead.
+
+ Convert a calendar date to Julian days since a given epoch.
+
+
+ Parameters
+ ----------
+ calendar_date : datetime.datetime
+     Datetime object, using the Python datetime library. Both the date and the time (hour, minutes, and seconds), can be specified. Milliseconds are ignored.
+ days_since_julian_day_zero : float, default = constants.JULIAN_DAY_ON_J2000
+     Reference epoch (in days) since when the Julian days have to be counted. By default, set to `constants.JULIAN_DAY_ON_J2000` (2451545.0) corresponding to the 1st of January 2000.
+ Returns
+ -------
+ float
+     Date in Julian days since the given epoch.
+
+
+
+
+
+ Examples
+ --------
+ In this example, the calendar date of the 21st of May 2022 at 13:52 and 41 seconds is converted to Julian days since J2000 (the 1st of January 2000).
+
+ .. code-block:: python
+
+   # Define the calendar date using datetime
+   calendar_date = datetime.datetime(2022, 5, 21, 13, 52, 41)
+   # Convert the calendar date to Julian days since J2000
+   julian_date = time_conversion.calendar_date_to_days_since_epoch(calendar_date)
+   # Print the converted output
+   print(julian_date)  # prints 8176.07825231459
+
+
+     )doc" );
+
+    m.def( "python_datetime_to_days_since_epoch",
+           &convertCalendarDateToJulianDaySinceEpochPy< double >,
+           py::arg( "datetime" ),
+           py::arg( "days_since_julian_day_zero" ) = tba::JULIAN_DAY_ON_J2000,
+           R"doc(
+
+ .. warning::
+
+    This function is deprecated and will be removed in a future version of Tudat. Use `DateTime.from_python_datetime(...).to_days_since_reference_julian_day()` instead.
+
+
+ Convert a calendar date to Julian days since a given epoch.
+
+
+ Parameters
+ ----------
+ datetime : datetime.datetime
+     Datetime object, using the Python datetime library. Both the date and the time (hour, minutes, and seconds), can be specified. Milliseconds are ignored.
+ days_since_julian_day_zero : float, default = constants.JULIAN_DAY_ON_J2000
+     Reference epoch (in days) since when the Julian days have to be counted. By default, set to `constants.JULIAN_DAY_ON_J2000` (2451545.0) corresponding to the 1st of January 2000.
+ Returns
+ -------
+ float
+     Date in Julian days since the given epoch.
+
+
+
+
+
+ Examples
+ --------
+ In this example, the calendar date of the 21st of May 2022 at 13:52 and 41 seconds is converted to Julian days since J2000 (the 1st of January 2000).
+
+ .. code-block:: python
+
+   # Define the calendar date using datetime
+   calendar_date = datetime.datetime(2022, 5, 21, 13, 52, 41)
+   # Convert the calendar date to Julian days since J2000
+   julian_date = time_conversion.python_datetime_to_days_since_epoch(calendar_date)
+   # Print the converted output
+   print(julian_date)  # prints 8176.07825231459
+
+
+     )doc" );
+
+    m.def( "julian_day_to_calendar_date",
+           &convertJulianDayToCalendarDatePy,
+           py::arg( "julian_day" ),
+           R"doc(
+
+ .. warning::
+
+    This function is deprecated and will be removed in a future version of Tudat. Use `DateTime.from_julian_day(...).to_python_datetime()` instead.
+
+ Convert Julian days to a calendar date.
+
+ Inverse function of :func:`calendar_date_to_julian_day`.
+
+ Parameters
+ ----------
+ julian_day : float
+     Date in Julian days since January 1st 4713 BC.
+ Returns
+ -------
+ datetime.datetime
+     Datetime object, using the Python datetime library, containing the date and time corresponding to the Julian date input.
+
+
+
+
+
+ Examples
+ --------
+ In this example, the Julian date `2459721.0783` (in days since January 1st 4713 BC), is converted to a calendar date.
+
+ .. code-block:: python
+
+   # Define the Julian date in days since January 1st 4713 BC
+   julian_date = 2459721.0783
+   # Convert the Julian date to a calendar date
+   calendar_date = time_conversion.julian_day_to_calendar_date(julian_date)
+   # Print the converted output
+   print(calendar_date)  # prints datetime.datetime(2022, 5, 21, 13, 52, 45)
+
+
+     )doc" );
+
+    m.def( "julian_day_to_python_datetime",
+           &convertJulianDayToCalendarDatePy,
+           py::arg( "julian_day" ),
+           R"doc(
+
+ .. warning::
+
+    This function is deprecated and will be removed in a future version of Tudat. Use `DateTime.from_julian_day(...).to_python_datetime()` instead.
+
+
+ Convert Julian days to a calendar date.
+
+ Inverse function of :func:`python_datetime_to_julian_day`.
+
+ Parameters
+ ----------
+ julian_day : float
+     Date in Julian days since January 1st 4713 BC.
+ Returns
+ -------
+ datetime.datetime
+     Datetime object, using the Python datetime library, containing the date and time corresponding to the Julian date input.
+
+
+
+
+
+ Examples
+ --------
+ In this example, the Julian date `2459721.0783` (in days since January 1st 4713 BC), is converted to a calendar date.
+
+ .. code-block:: python
+
+   # Define the Julian date in days since January 1st 4713 BC
+   julian_date = 2459721.0783
+   # Convert the Julian date to a calendar date
+   calendar_date = time_conversion.julian_day_to_python_datetime(julian_date)
+   # Print the converted output
+   print(calendar_date)  # prints datetime.datetime(2022, 5, 21, 13, 52, 45)
+
+
+     )doc" );
+
+    m.def( "calendar_date_to_julian_day",
+           &convertCalendarDateToJulianDayPy< double >,
+           py::arg( "calendar_date" ),
+           R"doc(
+
+ .. warning::
+
+    This function is deprecated and will be removed in a future version of Tudat. Use `DateTime.from_python_datetime(...).to_julian_day()` instead.
+
+ Convert a calendar date to Julian days.
+
+
+ Parameters
+ ----------
+ calendar_date : datetime.datetime
+     Datetime object, using the Python datetime library. Both the date and the time (hour, minutes, and seconds), can be specified, up to millisecond resolution.
+ Returns
+ -------
+ float
+     Julian day number (days since noon January 1st 4713 BC.)
+
+
+
+
+
+ Examples
+ --------
+ In this example, the calendar date of the 21st of May 2022 at 13:52 and 41 seconds is converted to Julian days.
+
+ .. code-block:: python
+
+   # Define the calendar date using datetime
+   calendar_date = datetime.datetime(2022, 5, 21, 13, 52, 41)
+   # Convert the calendar date to Julian days since January 1st 4713 BC
+   julian_date = time_conversion.calendar_date_to_julian_day(calendar_date)
+   # Print the converted output
+   print(julian_date)  # prints 2459721.0782523146
+
+
+     )doc" );
+
+    m.def( "python_datetime_to_julian_day",
+           &convertCalendarDateToJulianDayPy< double >,
+           py::arg( "datetime" ),
+           R"doc(
+
+ .. warning::
+
+    This function is deprecated and will be removed in a future version of Tudat. Use `DateTime.from_python_datetime(...).to_julian_day()` instead.
+
+ Convert a calendar date to Julian days.
+
+
+ Parameters
+ ----------
+ datetime : datetime.datetime
+     Datetime object, using the Python datetime library. Both the date and the time (hour, minutes, and seconds), can be specified, up to millisecond resolution.
+ Returns
+ -------
+ float
+     Julian day number (days since noon January 1st 4713 BC.)
+
+
+
+
+
+ Examples
+ --------
+ In this example, the calendar date of the 21st of May 2022 at 13:52 and 41 seconds is converted to Julian days.
+
+ .. code-block:: python
+
+   # Define the calendar date using datetime
+   calendar_date = datetime.datetime(2022, 5, 21, 13, 52, 41)
+   # Convert the calendar date to Julian days since January 1st 4713 BC
+   julian_date = time_conversion.python_datetime_to_julian_day(calendar_date)
+   # Print the converted output
+   print(julian_date)  # prints 2459721.0782523146
+
+
+     )doc" );
+    m.def( "datetime_to_tudat",
+           &tba::DateTime::fromTimePoint,
+           py::arg( "datetime" ),
+           R"doc(
+
+ .. warning::
+
+    This function is deprecated and will be removed in a future version of Tudat. Use :func:`DateTime.from_python_datetime` instead.
+
+ Function to convert a Python datetime.datetime object to a Tudat :class:`DateTime` object. The Tudat-native alternative has the advantage of providing sub-femtosecond resolution, as opposed to the microsecond resolution of the Python version
+
+
+ Parameters
+ ----------
+ datetime : datetime.datetime
+     Datetime object, using the Python datetime library. Both the date and the time (hour, minutes, and seconds), can be specified, up to millisecond resolution.
+ Returns
+ -------
+ DateTime
+     DateTime object defined in Tudat
+
+    )doc" );
+
+    m.def( "year_and_days_in_year_to_calendar_date",
+           &tba::DateTime::fromYearAndDaysInYear,
+           py::arg( "year" ),
+           py::arg( "days_in_year" ),
+           R"doc(
+        
+.. warning::
+
+    This function is deprecated and will be removed in a future version of Tudat. Use :func:`DateTime.from_year_and_day_of_year` instead.
+
+Create the Tudat :class:`DateTime` from the year and the number of days in the year.
+
+Parameters
+----------
+year : int
+    Calendar year.
+days_in_year : int
+    Number of days that have passed in the year.
+Returns
+-------
+DateTime
+    Corresponding calendar date as a :class:`DateTime` object. Note: the hours, minutes and seconds in the object are set to 0 when calling this function.
+
+Examples
+--------
+In this example, the calendar date corresponding to when 122 days have passed in 2020 is computed.
+
+.. code-block:: python
+
+    # Compute the calendar date when 122 days have passed in 2020
+    currentDate = time_conversion.year_and_days_in_year_to_calendar_date(2020, 122)
+    # Print the converted output
+    print(currentDate)  # prints (2020, 5, 2, 0, 0)
+
+     )doc" );
+
+    m.def( "datetime_to_python",
+           &dateTimeToTimePoint,
+           py::arg( "datetime" ),
+           R"doc(
+
+ .. warning::
+
+    This function is deprecated and will be removed in a future version of Tudat. Use :func:`DateTime.to_python_datetime` instead.
+
+
+ Function to convert a Tudat :class:`DateTime` object to a Python datetime.datetime object. This is the inverse of the :func:`datetime_to_tudat` function
+
+ Parameters
+ ----------
+ datetime : DateTime
+     Tudat-native Datetime object. Both the date and the time (hour, minutes, and seconds), can be specified, up to sub-femtosecond resolution.
+ Returns
+ -------
+ datetime.datetime
+     Datetime object, using the Python datetime library
+     )doc" );
+
+    m.def( "add_seconds_to_datetime",
+           &tba::addSecondsToDateTime< TIME_TYPE >,
+           py::arg( "datetime" ),
+           py::arg( "seconds_to_add" ),
+           R"doc(
+
+ .. warning::
+
+    This function is deprecated and will be removed in a future version of Tudat. Use :func:`DateTime.add_seconds()` instead.
+
+ Function to create a new Tudat :class:`DateTime` object by adding a number of seconds to an existing Tudat :class:`DateTime` object
+
+
+ Parameters
+ ----------
+ datetime : DateTime
+     Tudat-native Datetime object to which a number of seconds are to be added
+ seconds_to_add : float
+     Number of seconds to add
+ Returns
+ -------
+ DateTime
+     Tudat-native Datetime object created by adding the given number of seconds to the original DateTime
+
+
+
+
+
+
+     )doc" );
+
+    m.def( "add_days_to_datetime",
+           &tba::addDaysToDateTime< TIME_TYPE >,
+           py::arg( "datetime" ),
+           py::arg( "days_to_add" ),
+           R"doc(
+
+ .. warning::
+
+    This function is deprecated and will be removed in a future version of Tudat. Use :func:`DateTime.add_days()` instead.
+
+ Function to create a new Tudat :class:`DateTime` object by adding a number of days (86400 seconds) to an existing Tudat :class:`DateTime` object
+
+
+ Parameters
+ ----------
+ datetime : DateTime
+     Tudat-native Datetime object to which a number of days are to be added
+ days_to_add : float
+     Number of days to add
+ Returns
+ -------
+ DateTime
+     Tudat-native Datetime object created by adding the given number of days to the original DateTime
+
+
+
+
+
+
+     )doc" );
+
+    m.def( "epoch_from_date_time_components",
            &tba::timeFromDecomposedDateTime< TIME_TYPE >,
            py::arg( "year" ),
            py::arg( "month" ),
@@ -1720,6 +1942,10 @@ In this example, the calendar date corresponding to when 122 days have passed in
            py::arg( "minute" ),
            py::arg( "seconds" ),
            R"doc(
+
+ .. warning::
+
+    This function is deprecated and will be removed in a future version of Tudat. Use :func:`date_time_components_to_epoch` instead.
 
  Computes the epoch as seconds since J2000 from the entries of the current date and time.
 
@@ -1781,109 +2007,6 @@ In this example, the calendar date corresponding to when 122 days have passed in
      Time in seconds since J2000.
 
      )doc" );
-
-    m.def( "iso_string_to_epoch",
-           &tba::timeFromIsoString< TIME_TYPE >,
-           py::arg( "iso_datetime" ),
-           R"doc(
-
- Computes the epoch as seconds since J2000 from an ISO datetime string.
-
- Computes the epoch as seconds since J2000. This function is added for convenience, and creates a :class:`DateTime` object, and subsequently calls its ``epoch`` function
-
- Parameters
- ----------
- iso_datetime : str
-     Date and time as ISO compatible string ("YYYY-MM-DDTHH:MM:SS.SSSSS..", where the T may be replaced with a space)
-
- Returns
- -------
- float
-     Time in seconds since J2000.
-
-
-
-
-
-
-     )doc" );
-
-    //    m.def("epoch_from_julian_day",
-    //          &tudat::timeFromJulianDay< TIME_TYPE >,
-    //          py::arg("julian_day"),
-    //          get_docstring("epoch_from_julian_day").c_str() );
-
-    //    m.def("epoch_from_modified_julian_day",
-    //          &tudat::timeFromModifiedJulianDay< TIME_TYPE >,
-    //          py::arg("modified_julian_day"),
-    //          get_docstring("epoch_from_modified_julian_day").c_str()
-    //          );
-
-    m.def( "date_time_from_epoch",
-           &tba::DateTime::fromTime< TIME_TYPE >,
-           py::arg( "epoch" ),
-           R"doc(
-
- .. warning::
-
-    This function is deprecated and will be removed in a future version of Tudat. Use :func:`DateTime.from_epoch` instead.
-
-
- Creates a Tudat-native :class:`DateTime` object from the seconds since J2000.
-
-
- Parameters
- ----------
- epoch : float
-     Seconds since J2000
-
- Returns
- -------
- DateTime
-     Tudat ``DateTime`` object.
-
-
-
-
-
-
-     )doc" );
-
-    m.def( "date_time_from_iso_string",
-           &tba::DateTime::fromIsoString,
-           py::arg( "iso_string" ),
-           R"doc(
-
- .. warning::
-
-    This function is deprecated and will be removed in a future version of Tudat. Use :func:`DateTime.from_iso_string` instead.
-
- Creates a Tudat-native :class:`DateTime` object from an ISO datetime string.
-
-
- Parameters
- ----------
- iso_datetime : str
-     Date and time as ISO compatible string ("YYYY-MM-DDTHH:MM:SS.SSSSS..", where the T may be replaced with a space)
-
- Returns
- -------
- DateTime
-     Tudat ``DateTime`` object.
-
-
-
-
-
-
-     )doc" );
-
-    /////////////// DEPRECATED
-
-    m.def( "calendar_date_to_julian_day_since_epoch",
-           &convertCalendarDateToJulianDaySinceEpochPy< double >,
-           py::arg( "calendar_date" ),
-           py::arg( "days_since_julian_day_zero" ) = tba::JULIAN_DAY_ON_J2000 );
 }
 }  // namespace time_conversion
 }  // namespace astro


### PR DESCRIPTION
Expose `from_julian_day`, `from_modified_julian_day` and `to_days_since_reference_julian_day` methods implemented in https://github.com/tudat-team/tudat/pull/342, deprecate `julian_day_to_python_datetime`, `python_datetime_to_julian_day` and `python_datetime_to_days_since_epoch` functions.
Move all deprecated functions in `// deprecated` section.