### PR TITLE
Fix exposure of body_occultation_viability_list

### DIFF
--- a/src/tudatpy/numerical_simulation/estimation_setup/observation/expose_observation.cpp
+++ b/src/tudatpy/numerical_simulation/estimation_setup/observation/expose_observation.cpp
@@ -3052,7 +3052,7 @@ Examples
     m.def( "body_occultation_viability_list",
            py::overload_cast< const std::vector< std::pair< std::string, std::string > >, const std::string >(
                    &tom::bodyOccultationViabilitySettings ),
-           py::arg( "link_end_id" ),
+           py::arg( "link_end_ids" ),
            py::arg( "occulting_body" ),
            R"doc(
 


### PR DESCRIPTION
Fix exposure of `body_occultation_viability_list` to map to the function definition that takes a list of link end IDs as input and returns a list of occultation viability settings