### PR TITLE
Fix deprecation warnings strings to avoid invalid characters

### DIFF
--- a/src/tudatpy/numerical_simulation/estimation/__init__.py
+++ b/src/tudatpy/numerical_simulation/estimation/__init__.py
@@ -1,8 +1,6 @@
 import warnings
 warnings.warn(
-    "tudatpy.numerical_simulation.estimation is deprecated. " \
-    "Use tudatpy.estimation.observations, tudatpy.estimation.observations_setup and/or " \
-    "tudatpy.estimation.estimation_analysis instead.",
+    "tudatpy.numerical_simulation.estimation is deprecated. Use tudatpy.estimation.observations, tudatpy.estimation.observations_setup and/or tudatpy.estimation.estimation_analysis instead.",
     FutureWarning,
     stacklevel=1
 )

--- a/src/tudatpy/numerical_simulation/estimation_setup/__init__.py
+++ b/src/tudatpy/numerical_simulation/estimation_setup/__init__.py
@@ -1,12 +1,12 @@
 import warnings
 warnings.warn(
-    "tudatpy.numerical_simulation.estimation_setup is deprecated. " \
-    "Features got distributed over tudatpy.estimation.observable_models_setup, " \
-    " tudatpy.estimation.observable_models, "
-    " tudatpy.estimation.observations_setup, " \
-    " tudatpy.estimation.observations, " \
-    " tudatpy.dynamics.parameters_setup, " \
-    " tudatpy.dynamics.parameters, " \
+    "tudatpy.numerical_simulation.estimation_setup is deprecated.\nFeatures got distributed over:\n"
+    " tudatpy.estimation.observable_models_setup, \n" +
+    " tudatpy.estimation.observable_models, \n" +
+    " tudatpy.estimation.observations_setup, \n" +
+    " tudatpy.estimation.observations, \n" +
+    " tudatpy.dynamics.parameters_setup, \n" +
+    " tudatpy.dynamics.parameters, \n" +
     " and tudatpy.estimation.estimation_analysis instead.",
     FutureWarning,
     stacklevel=1

--- a/src/tudatpy/numerical_simulation/estimation_setup/observation/__init__.py
+++ b/src/tudatpy/numerical_simulation/estimation_setup/observation/__init__.py
@@ -1,7 +1,6 @@
 import warnings
 warnings.warn(
-    "tudatpy.numerical_simulation.estimation_setup.observation is deprecated. " \
-    "Use tudatpy.estimation.observable_models_setup and/or tudatpy.estimation.observations_setup instead.",
+    "tudatpy.numerical_simulation.estimation_setup.observation is deprecated. Use tudatpy.estimation.observable_models_setup and/or tudatpy.estimation.observations_setup instead.",
     FutureWarning,
     stacklevel=1
 )

--- a/src/tudatpy/numerical_simulation/estimation_setup/parameter/__init__.py
+++ b/src/tudatpy/numerical_simulation/estimation_setup/parameter/__init__.py
@@ -1,7 +1,6 @@
 import warnings
 warnings.warn(
-    "tudatpy.numerical_simulation.estimation_setup.parameter is deprecated. " \
-    "Use tudatpy.dynamics.parameters_setup instead.",
+    "tudatpy.numerical_simulation.estimation_setup.parameter is deprecated. Use tudatpy.dynamics.parameters_setup instead.",
     stacklevel=1
 )
 


### PR DESCRIPTION
When building the merged tudatpy repository, the stub generation fails due to invalid characters in the deprecation warnings:

```
[100%] Linking CXX shared module kernel.so
[100%] Built target kernel
Generating stubs for tudatpy.kernel...
pybind11_stubgen - [  ERROR] In tudatpy.kernel.astro.element_conversion.convert_position_elements : Invalid expression 'tudat::basic_astrodynamics::BodyShapeModel'

< omitting invalid expression errors>

pybind11_stubgen - [  ERROR] In tudatpy.kernel.trajectory_design.transfer_trajectory.set_low_thrust_acceleration : Invalid expression 'tudat::simulation_setup::SystemOfBodies'
pybind11_stubgen - [WARNING] Enum-like str representations were found with no matching mapping to the enum class location.
Use `--enum-class-locations` to specify full path to the following enum(s):
 - LightTimeFailureHandling
 - RotationalPropagatorType
 - IntegratedObservationPropertyHandling
 - MinimumIntegrationTimeStepHandling
 - TranslationalPropagatorType
 - MaximumIterationHandling
 - BoundaryInterpolationType
 - TimeScales
 - ThrustFrames
 - TroposphericMappingModel
 - LagrangeInterpolatorBoundaryHandling
 - IAUConventions
 - AerodynamicsReferenceFrames
 - LinkEndType
 - AerodynamicCoefficientFrames
 - AvailableLookupScheme
 - WaterVaporPartialPressureModel
 - PositionElementTypes
 - RadiationPressureTargetModelType
 - OrderToIntegrate
pybind11_stubgen - [WARNING] Raw C++ types/values were found in signatures extracted from docstrings.
Please check the corresponding sections of pybind11 documentation to avoid common mistakes in binding code:
 - https://pybind11.readthedocs.io/en/latest/advanced/misc.html#avoiding-cpp-types-in-docstrings
 - https://pybind11.readthedocs.io/en/latest/advanced/functions.html#default-arguments-revisited
Generating stubs for Python source code...
Traceback (most recent call last):
  File "/home/lars/repos/tudatpy/build.py", line 1186, in <module>
    builder.generate_stubs(mock_env)
  File "/home/lars/repos/tudatpy/build.py", line 1168, in generate_stubs
    StubGenerator(self.build_dir, mock_env).generate_stubs()
  File "/home/lars/repos/tudatpy/build.py", line 945, in generate_stubs
    self.__generate_init_stubs()
  File "/home/lars/repos/tudatpy/build.py", line 918, in __generate_init_stubs
    self.__generate_single_init_stub(item)
  File "/home/lars/repos/tudatpy/build.py", line 698, in __generate_single_init_stub
    init = self.__parse_script(init_path)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lars/repos/tudatpy/build.py", line 199, in __parse_script
    return ast.parse(normalized_text)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lars/miniconda3/envs/tudatpy10/lib/python3.11/ast.py", line 50, in parse
    return compile(source, filename, mode, flags,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<unknown>", line 3
    "tudatpy.numerical_simulation.estimation is deprecated. " ¿
                                                              ^
SyntaxError: invalid character '¿' (U+00BF)
```

This can be fixed by using single-line strings in the deprecation warnings or concatenating the strings using the + operator.

Tagging @SamFayolle @minervino96 @alfonsoSR FYI.