### PR TITLE
Python imports refactoring

### DIFF
--- a/src/tudatpy/data/processTrk234/converters/converter.py
+++ b/src/tudatpy/data/processTrk234/converters/converter.py
@@ -20,7 +20,7 @@ class Converter(ABC):
         """
         Process a merged DataFrame (from multiple files extract outputs) into Tudat structured format.
         For observable converters, this will be a list of
-        tudatpy.numerical_simulation.estimation_setup.observation.single_observation_sets;
+        tudatpy.estimation.observations.single_observation_sets;
         For the ramp converter, a merged ramp DataFrame.
 
         Parameters

--- a/src/tudatpy/data/processTrk234/converters/derivedDoppler.py
+++ b/src/tudatpy/data/processTrk234/converters/derivedDoppler.py
@@ -1,11 +1,7 @@
-from tudatpy.numerical_simulation.estimation_setup.observation import (
-    dsn_n_way_doppler_ancilliary_settings,
-    link_definition,
-    receiver,
-    reflector1,
-    dsn_n_way_averaged_doppler,
-)
-from tudatpy.numerical_simulation.estimation import single_observation_set
+from tudatpy.estimation.observations_setup.ancillary_settings import dsn_n_way_doppler_ancilliary_settings
+from tudatpy.estimation.observable_models_setup.links import link_definition, receiver, reflector1
+from tudatpy.estimation.observable_models_setup.model_settings import dsn_n_way_averaged_doppler
+from tudatpy.estimation.observations import single_observation_set
 from . import RadioBase
 from pandas import DataFrame
 

--- a/src/tudatpy/data/processTrk234/converters/derivedSraRange.py
+++ b/src/tudatpy/data/processTrk234/converters/derivedSraRange.py
@@ -1,10 +1,8 @@
-from tudatpy.numerical_simulation.estimation_setup.observation import (
-    dsn_n_way_range_ancilliary_settings,
-    link_definition,
-    receiver,
-    dsn_n_way_range,
-)
-from tudatpy.numerical_simulation.estimation import single_observation_set
+from tudatpy.estimation.observations_setup.ancillary_settings import dsn_n_way_range_ancilliary_settings
+from tudatpy.estimation.observable_models_setup.links import link_definition, receiver
+from tudatpy.estimation.observable_models_setup.model_settings import dsn_n_way_range
+
+from tudatpy.estimation.observations import single_observation_set
 
 from . import RadioBase
 from pandas import DataFrame

--- a/src/tudatpy/data/processTrk234/converters/radioBase.py
+++ b/src/tudatpy/data/processTrk234/converters/radioBase.py
@@ -6,7 +6,8 @@ from tudatpy.dynamics.environment_setup.ground_station import (
     # from tudatpy.dynamics.environment import (
     get_approximate_dsn_ground_station_positions,
 )
-from tudatpy.numerical_simulation.estimation_setup import observation  # type:ignore
+from tudatpy.estimation.observations_setup.ancillary_settings import FrequencyBands  # type:ignore
+from tudatpy.estimation.observable_models_setup import links
 from tudatpy.astro import time_conversion
 from . import Converter
 from trk234 import bands
@@ -24,10 +25,10 @@ class RadioBase(Converter):
     time_scale_converter = time_conversion.default_time_scale_converter()
 
     frequencyBandsDict = {
-        "S": observation.FrequencyBands.s_band,
-        "X": observation.FrequencyBands.x_band,
-        # "K": observation.FrequencyBands.ku_band,
-        "Ka": observation.FrequencyBands.ka_band,
+        "S": FrequencyBands.s_band,
+        "X": FrequencyBands.x_band,
+        # "K": FrequencyBands.ku_band,
+        "Ka": FrequencyBands.ka_band,
     }
 
     stationDict = get_approximate_dsn_ground_station_positions()
@@ -127,24 +128,24 @@ class RadioBase(Converter):
 
         # Set custom spacecraft name if provided
         if spacecraftName is not None:
-            spacecraft = observation.body_origin_link_end_id(spacecraftName)
+            spacecraft = links.body_origin_link_end_id(spacecraftName)
         else:
-            spacecraft = observation.body_origin_link_end_id(link_end_tuple[1])
+            spacecraft = links.body_origin_link_end_id(link_end_tuple[1])
 
         if link_end_tuple[0] == "nan" and len(link_end_tuple) == 2:
             return {
-                observation.transmitter: spacecraft,
-                observation.receiver: observation.body_reference_point_link_end_id(
+                links.transmitter: spacecraft,
+                links.receiver: links.body_reference_point_link_end_id(
                     "Earth", link_end_tuple[2]
                 ),
             }
         else:
             return {
-                observation.transmitter: observation.body_reference_point_link_end_id(
+                links.transmitter: links.body_reference_point_link_end_id(
                     "Earth", link_end_tuple[0]
                 ),
-                observation.reflector1: spacecraft,
-                observation.receiver: observation.body_reference_point_link_end_id(
+                links.reflector1: spacecraft,
+                links.receiver: links.body_reference_point_link_end_id(
                     "Earth", link_end_tuple[2]
                 ),
             }

--- a/src/tudatpy/data/processTrk234/converters/radioBase.py
+++ b/src/tudatpy/data/processTrk234/converters/radioBase.py
@@ -2,8 +2,8 @@
 Base class for radiometric converters sharing helper functions.
 """
 
-from tudatpy.numerical_simulation.environment_setup.ground_station import (
-    # from tudatpy.numerical_simulation.environment import (
+from tudatpy.dynamics.environment_setup.ground_station import (
+    # from tudatpy.dynamics.environment import (
     get_approximate_dsn_ground_station_positions,
 )
 from tudatpy.numerical_simulation.estimation_setup import observation  # type:ignore

--- a/src/tudatpy/data/processTrk234/converters/radioBase.py
+++ b/src/tudatpy/data/processTrk234/converters/radioBase.py
@@ -8,7 +8,7 @@ from tudatpy.dynamics.environment_setup.ground_station import (
 )
 from tudatpy.estimation.observations_setup.ancillary_settings import FrequencyBands  # type:ignore
 from tudatpy.estimation.observable_models_setup import links
-from tudatpy.astro import time_conversion
+from tudatpy.astro import time_representation
 from . import Converter
 from trk234 import bands
 
@@ -22,7 +22,7 @@ class RadioBase(Converter):
         3: "3W",
     }
 
-    time_scale_converter = time_conversion.default_time_scale_converter()
+    time_scale_converter = time_representation.default_time_scale_converter()
 
     frequencyBandsDict = {
         "S": FrequencyBands.s_band,
@@ -172,10 +172,10 @@ class RadioBase(Converter):
                 )
             )
 
-        epoch_utc = time_conversion.datetime_to_tudat(epoch).epoch()
+        epoch_utc = time_representation.datetime_to_tudat(epoch).epoch()
         epoch_tdb = self.time_scale_converter.convert_time(
-            input_scale=time_conversion.utc_scale,
-            output_scale=time_conversion.tdb_scale,
+            input_scale=time_representation.utc_scale,
+            output_scale=time_representation.tdb_scale,
             input_value=epoch_utc,
             earth_fixed_position=self.stationDict[station],
         )

--- a/src/tudatpy/data/processTrk234/processor.py
+++ b/src/tudatpy/data/processTrk234/processor.py
@@ -2,8 +2,8 @@ import trk234
 from . import converters as cnv
 from pandas import concat as pd_concat
 from tudatpy.numerical_simulation.estimation import ObservationCollection
-from tudatpy.astro import time_conversion
-from tudatpy.numerical_simulation.environment import (
+from tudatpy.astro import time_representation
+from tudatpy.dynamics.environment import (
     PiecewiseLinearFrequencyInterpolator,
 )
 
@@ -140,10 +140,10 @@ class Trk234Processor:
         ramp_df = self.ramp_converter.process(all_ramps)
 
         ramp_df["start_time_seconds"] = ramp_df["start_time"].apply(
-            lambda x: time_conversion.datetime_to_tudat(x).epoch()
+            lambda x: time_representation.datetime_to_tudat(x).epoch()
         )
         ramp_df["end_time_seconds"] = ramp_df["end_time"].apply(
-            lambda x: time_conversion.datetime_to_tudat(x).epoch()
+            lambda x: time_representation.datetime_to_tudat(x).epoch()
         )
         earth = bodies.get("Earth")
         for station in ramp_df["station"].unique():

--- a/src/tudatpy/data/processTrk234/processor.py
+++ b/src/tudatpy/data/processTrk234/processor.py
@@ -35,7 +35,7 @@ class Trk234Processor:
     >>> # Process observations
     >>> observations = tnf_processor.process()
     >>>
-    >>> # Set frequency information in the bodies assuming you have a bodies object tudatpy.numerical_simulation.environment.SystemOfBodies
+    >>> # Set frequency information in the bodies assuming you have a bodies object tudatpy.dynamics.environment.SystemOfBodies
     >>> tnf_processor.set_tnf_information_in_bodies(bodies)
     """
 

--- a/src/tudatpy/data/processTrk234/processor.py
+++ b/src/tudatpy/data/processTrk234/processor.py
@@ -1,7 +1,7 @@
 import trk234
 from . import converters as cnv
 from pandas import concat as pd_concat
-from tudatpy.numerical_simulation.estimation import ObservationCollection
+from tudatpy.estimation.observations import ObservationCollection
 from tudatpy.astro import time_representation
 from tudatpy.dynamics.environment import (
     PiecewiseLinearFrequencyInterpolator,

--- a/src/tudatpy/dynamics/environment_setup/ephemeris/horizons_wrapper.py
+++ b/src/tudatpy/dynamics/environment_setup/ephemeris/horizons_wrapper.py
@@ -15,7 +15,7 @@ from typing import Union, List, Any
 import datetime
 
 from tudatpy import constants
-from tudatpy.kernel.dynamics.environment_setup import (
+from tudatpy.dynamics.environment_setup import (
     ephemeris,
     BodySettings,
 )

--- a/src/tudatpy/dynamics/propagation/dependent_variable_dictionary.py
+++ b/src/tudatpy/dynamics/propagation/dependent_variable_dictionary.py
@@ -15,9 +15,9 @@ from inspect import getmro
 from typing import Any
 
 # Tudat imports
-from ...util import result2array
-from ...dynamics.simulator import SingleArcSimulator
-from ...dynamics.propagation_setup.dependent_variable import (
+from tudatpy.util import result2array
+from tudatpy.dynamics.simulator import SingleArcSimulator
+from tudatpy.dynamics.propagation_setup.dependent_variable import (
     VariableSettings,
     get_dependent_variable_id,
     get_dependent_variable_shape,
@@ -50,7 +50,7 @@ class DependentVariableDictionary(dict):
     .. code-block:: python
 
         # Create simulation object and propagate the dynamics
-        dynamics_simulator = numerical_simulation.create_dynamics_simulator(
+        dynamics_simulator = dynamics.simulator.create_dynamics_simulator(
             bodies, propagator_settings
         )
 
@@ -122,7 +122,7 @@ class DependentVariableDictionary(dict):
         elif not isinstance(key, str):
             raise TypeError(
                 "DependentVariableDictionary keys must be either instances of `VariableSettings`-derived classes, "
-                "or dependent variable string IDs (see `numerical_simulation.propagation_setup.dependent_variable.get_dependent_variable_id`)."
+                "or dependent variable string IDs (see `dynamics.propagation_setup.dependent_variable.get_dependent_variable_id`)."
             )
 
         return key

--- a/src/tudatpy/numerical_simulation/estimation/__init__.py
+++ b/src/tudatpy/numerical_simulation/estimation/__init__.py
@@ -1,8 +1,6 @@
 import warnings
 warnings.warn(
-    "tudatpy.numerical_simulation.estimation is deprecated. " \
-    "Use tudatpy.estimation.observations, tudatpy.estimation.observations_setup and/or " \
-    "tudatpy.estimation.estimation_analysis instead.",
+    "tudatpy.numerical_simulation.estimation is deprecated. Use tudatpy.estimation.observations, tudatpy.estimation.observations_setup and/or tudatpy.estimation.estimation_analysis instead.",
     FutureWarning,
     stacklevel=1
 )

--- a/src/tudatpy/numerical_simulation/estimation_setup/__init__.py
+++ b/src/tudatpy/numerical_simulation/estimation_setup/__init__.py
@@ -1,12 +1,12 @@
 import warnings
 warnings.warn(
-    "tudatpy.numerical_simulation.estimation_setup is deprecated. " \
-    "Features got distributed over tudatpy.estimation.observable_models_setup, " \
-    " tudatpy.estimation.observable_models, "
-    " tudatpy.estimation.observations_setup, " \
-    " tudatpy.estimation.observations, " \
-    " tudatpy.dynamics.parameters_setup, " \
-    " tudatpy.dynamics.parameters, " \
+    "tudatpy.numerical_simulation.estimation_setup is deprecated.\nFeatures got distributed over:\n"
+    " tudatpy.estimation.observable_models_setup, \n" +
+    " tudatpy.estimation.observable_models, \n" +
+    " tudatpy.estimation.observations_setup, \n" +
+    " tudatpy.estimation.observations, \n" +
+    " tudatpy.dynamics.parameters_setup, \n" +
+    " tudatpy.dynamics.parameters, \n" +
     " and tudatpy.estimation.estimation_analysis instead.",
     FutureWarning,
     stacklevel=1

--- a/src/tudatpy/numerical_simulation/estimation_setup/observation/__init__.py
+++ b/src/tudatpy/numerical_simulation/estimation_setup/observation/__init__.py
@@ -1,7 +1,6 @@
 import warnings
 warnings.warn(
-    "tudatpy.numerical_simulation.estimation_setup.observation is deprecated. " \
-    "Use tudatpy.estimation.observable_models_setup and/or tudatpy.estimation.observations_setup instead.",
+    "tudatpy.numerical_simulation.estimation_setup.observation is deprecated. Use tudatpy.estimation.observable_models_setup and/or tudatpy.estimation.observations_setup instead.",
     FutureWarning,
     stacklevel=1
 )

--- a/src/tudatpy/numerical_simulation/estimation_setup/parameter/__init__.py
+++ b/src/tudatpy/numerical_simulation/estimation_setup/parameter/__init__.py
@@ -1,7 +1,6 @@
 import warnings
 warnings.warn(
-    "tudatpy.numerical_simulation.estimation_setup.parameter is deprecated. " \
-    "Use tudatpy.dynamics.parameters_setup instead.",
+    "tudatpy.numerical_simulation.estimation_setup.parameter is deprecated. Use tudatpy.dynamics.parameters_setup instead.",
     stacklevel=1
 )
 

--- a/src/tudatpy/plotting/_helpers.py
+++ b/src/tudatpy/plotting/_helpers.py
@@ -184,7 +184,7 @@ def trajectory_3d(
 
     """
     # Import SPICE
-    from ..kernel.interface import spice
+    from tudatpy.interface import spice
 
     # Save color and linestyle index
     i_c, i_ls = 0, 0

--- a/src/tudatpy/trajectory_design/porkchop/_lambert.py
+++ b/src/tudatpy/trajectory_design/porkchop/_lambert.py
@@ -14,7 +14,7 @@ import numpy as np
 
 # Tudat imports
 from tudatpy.astro import two_body_dynamics
-from tudatpy.numerical_simulation import environment
+from tudatpy.dynamics import environment
 
 
 def calculate_lambert_arc_impulsive_delta_v(

--- a/src/tudatpy/trajectory_design/porkchop/_plot_porkchop.py
+++ b/src/tudatpy/trajectory_design/porkchop/_plot_porkchop.py
@@ -21,7 +21,7 @@ from matplotlib.ticker import AutoMinorLocator, FuncFormatter
 
 # Tudat imports
 from tudatpy import constants
-from tudatpy.astro import time_conversion
+from tudatpy.astro import time_representation
 
 
 def plot_porkchop_of_single_field(
@@ -309,7 +309,7 @@ def plot_porkchop_of_single_field(
 
     # Tick labels
     dt = 40
-    tick_formatter = lambda epoch: time_conversion.date_time_from_epoch(
+    tick_formatter = lambda epoch: time_representation.date_time_from_epoch(
         epoch
     ).iso_string()[:10]
     # X axis

--- a/src/tudatpy/trajectory_design/porkchop/porkchop.py
+++ b/src/tudatpy/trajectory_design/porkchop/porkchop.py
@@ -16,8 +16,8 @@ from numbers import Number
 
 # Tudat imports
 from tudatpy import constants
-from tudatpy.astro import time_conversion
-from tudatpy.numerical_simulation import environment
+from tudatpy.astro import time_representation
+from tudatpy.dynamics import environment
 from tudatpy.trajectory_design.porkchop._plot_porkchop import plot_porkchop
 from tudatpy.trajectory_design.porkchop._lambert import (
     calculate_lambert_arc_impulsive_delta_v,
@@ -91,10 +91,10 @@ def calculate_delta_v_time_map(
     bodies: environment.SystemOfBodies,
     departure_body: str,
     target_body: str,
-    earliest_departure_time: time_conversion.DateTime,
-    latest_departure_time: time_conversion.DateTime,
-    earliest_arrival_time: time_conversion.DateTime,
-    latest_arrival_time: time_conversion.DateTime,
+    earliest_departure_time: time_representation.DateTime,
+    latest_departure_time: time_representation.DateTime,
+    earliest_arrival_time: time_representation.DateTime,
+    latest_arrival_time: time_representation.DateTime,
     time_resolution: float,
     function_to_calculate_delta_v: callable = calculate_lambert_arc_impulsive_delta_v,
 ):
@@ -181,10 +181,10 @@ def porkchop(
     bodies: environment.SystemOfBodies,
     departure_body: str,
     target_body: str,
-    earliest_departure_time: time_conversion.DateTime,
-    latest_departure_time: time_conversion.DateTime,
-    earliest_arrival_time: time_conversion.DateTime,
-    latest_arrival_time: time_conversion.DateTime,
+    earliest_departure_time: time_representation.DateTime,
+    latest_departure_time: time_representation.DateTime,
+    earliest_arrival_time: time_representation.DateTime,
+    latest_arrival_time: time_representation.DateTime,
     time_resolution: float,
     function_to_calculate_delta_v: callable = calculate_lambert_arc_impulsive_delta_v,
     # Plot arguments

--- a/src/tudatpy/trajectory_design/porkchop/porkchop.py
+++ b/src/tudatpy/trajectory_design/porkchop/porkchop.py
@@ -109,13 +109,13 @@ def calculate_delta_v_time_map(
         The name of the body from which the transfer is to be computed
     target_body: str
         The name of the body to which the transfer is to be computed
-    earliest_departure_time: time_conversion.DateTime
+    earliest_departure_time: time_representation.DateTime
         Earliest epoch of the departure window
-    latest_departure_time: time_conversion.DateTime
+    latest_departure_time: time_representation.DateTime
         Latest epoch of the departure window
-    earliest_arrival_time: time_conversion.DateTime
+    earliest_arrival_time: time_representation.DateTime
         Earliest epoch of the arrival window
-    latest_arrival_time: time_conversion.DateTime
+    latest_arrival_time: time_representation.DateTime
         Latest epoch of the arrival window
     time_resolution: float
         Resolution used to discretize the departure/arrival time windows
@@ -211,13 +211,13 @@ def porkchop(
         The name of the body from which the transfer is to be computed
     target_body: str
         The name of the body to which the transfer is to be computed
-    earliest_departure_time: time_conversion.DateTime
+    earliest_departure_time: time_representation.DateTime
         Earliest epoch of the departure window
-    latest_departure_time: time_conversion.DateTime
+    latest_departure_time: time_representation.DateTime
         Latest epoch of the departure window
-    earliest_arrival_time: time_conversion.DateTime
+    earliest_arrival_time: time_representation.DateTime
         Earliest epoch of the arrival window
-    latest_arrival_time: time_conversion.DateTime
+    latest_arrival_time: time_representation.DateTime
         Latest epoch of the arrival window
     time_resolution: float
         Resolution used to discretize the departure/arrival time windows

--- a/src/tudatpy/util/_support.py
+++ b/src/tudatpy/util/_support.py
@@ -1,18 +1,19 @@
 import numpy as np
 from tudatpy.math import interpolators
-from tudatpy import numerical_simulation
+from tudatpy.dynamics import propagation
+from tudatpy.dynamics.propagation_setup import propagator
 import os
 from typing import Union, TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
-    from ..numerical_simulation.propagation_setup import propagator
+    from ..dynamics.propagation_setup import propagator
 
 
 def result2array(result: dict[float, np.ndarray]):
     """Initial prototype function to convert dict result from DynamicsSimulator
 
     The `state_history` and `dependent_history` retrieved from classes
-    deriving from the :class:`~tudatpy.numerical_simulation.SingleArcSimulator`
+    deriving from the :class:`~tudatpy.dynamics.simulator.SingleArcSimulator`
     return these time series as a mapping illustrated by:
 
     .. code-block:: python
@@ -290,7 +291,7 @@ def split_history(
         Dictionary mapping the simulation time steps to the propagated
         state time series.
 
-    propagator_settings : tudatpy.kernel.numerical_simulation.propagation_setup.propagator.PropagatorSettings
+    propagator_settings : tudatpy.dynamics.propagation_setup.propagator.PropagatorSettings
         Settings used for the propagation.
 
     Returns
@@ -300,7 +301,7 @@ def split_history(
     """
     # Get the propagated state types and names of the propagated bodies from the integrator settings.
     integrated_type_and_body_list = (
-        numerical_simulation.get_integrated_type_and_body_list(
+        propagator.get_integrated_type_and_body_list(
             propagator_settings
         )
     )
@@ -317,7 +318,7 @@ def split_history(
             n_bodies = len(body_list)
             body_names = [body_list[i][0] for i in range(n_bodies)]
         # Get the state size for the current state type.
-        state_size = numerical_simulation.get_single_integration_size(
+        state_size = propagation.get_single_integration_size(
             state_type
         )
         propagated_states_sizes.append(state_size)
@@ -350,7 +351,7 @@ def vector2matrix(flat_matrix: np.ndarray):
 
     Following Tudat standards, a rotation matrix is returned as a nine-entry vector in the dependent variable output,
     where entry (i,j) of the matrix is stored in entry (3i+j) of the vector with i,j = 0,1,2.
-    This is detailled in the :func:`~tudatpy.numerical_simulation.propagation_setup.dependent_variable.inertial_to_body_fixed_rotation_frame` docs.
+    This is detailled in the :func:`~tudatpy.dynamics.propagation_setup.dependent_variable.inertial_to_body_fixed_rotation_frame` docs.
 
     Parameters
     -----------

--- a/tests/test_tudatpy/test_data_horizons.py
+++ b/tests/test_tudatpy/test_data_horizons.py
@@ -1,6 +1,6 @@
 from tudatpy.data.horizons import HorizonsQuery, HorizonsBatch
-from tudatpy.numerical_simulation.environment_setup.ephemeris import jpl_horizons
-from tudatpy.numerical_simulation import environment_setup
+from tudatpy.dynamics.environment_setup.ephemeris import jpl_horizons
+from tudatpy.dynamics import environment_setup
 
 
 from tudatpy.interface import spice

--- a/tests/test_tudatpy/test_data_mpc.py
+++ b/tests/test_tudatpy/test_data_mpc.py
@@ -2,7 +2,7 @@
 from tudatpy.data.mpc import BatchMPC
 from tudatpy.data.horizons import HorizonsQuery
 
-from tudatpy.numerical_simulation import environment_setup
+from tudatpy.dynamics import environment_setup
 from tudatpy.interface import spice
 
 import numpy as np

--- a/tests/test_tudatpy/test_data_weights.py
+++ b/tests/test_tudatpy/test_data_weights.py
@@ -1,6 +1,6 @@
 
 # tests for data weights functionality
-from tudatpy.numerical_simulation import environment_setup
+from tudatpy.dynamics import environment_setup
 from tudatpy.numerical_simulation import estimation
 from tudatpy.data.mpc import BatchMPC
 from tudatpy.interface import spice

--- a/tests/test_tudatpy/test_data_weights.py
+++ b/tests/test_tudatpy/test_data_weights.py
@@ -1,7 +1,7 @@
 
 # tests for data weights functionality
 from tudatpy.dynamics import environment_setup
-from tudatpy.numerical_simulation import estimation
+from tudatpy.estimation import estimation_analysis
 from tudatpy.data.mpc import BatchMPC
 from tudatpy.interface import spice
 
@@ -92,9 +92,9 @@ def test_MPC_weights_to_ObsCol(
 
     # test pod_input
     # provide the observation collection as input, and limit number of iterations for estimation.
-    pod_input = estimation.EstimationInput(
+    pod_input = estimation_analysis.EstimationInput(
         observations_and_times=observation_collection,
-        convergence_checker=estimation.estimation_convergence_checker(
+        convergence_checker=estimation_analysis.estimation_convergence_checker(
             maximum_iterations=1,
         ),
     )

--- a/tests/test_tudatpy/test_dependent_variable_dictionary.py
+++ b/tests/test_tudatpy/test_dependent_variable_dictionary.py
@@ -5,8 +5,7 @@ from matplotlib import pyplot as plt
 
 # Load tudatpy modules
 from tudatpy.interface import spice
-from tudatpy import numerical_simulation
-from tudatpy.dynamics import environment_setup, propagation_setup
+from tudatpy.dynamics import environment_setup, propagation_setup, simulator
 from tudatpy.astro import element_conversion
 from tudatpy import constants
 from tudatpy.util import result2array
@@ -170,7 +169,7 @@ def test_dependent_variable_dictionary():
     )
 
     # Create simulation object and propagate the dynamics
-    dynamics_simulator = numerical_simulation.create_dynamics_simulator(
+    dynamics_simulator = simulator.create_dynamics_simulator(
         bodies, propagator_settings
     )
 

--- a/tests/test_tudatpy/test_dependent_variable_dictionary.py
+++ b/tests/test_tudatpy/test_dependent_variable_dictionary.py
@@ -6,14 +6,14 @@ from matplotlib import pyplot as plt
 # Load tudatpy modules
 from tudatpy.interface import spice
 from tudatpy import numerical_simulation
-from tudatpy.numerical_simulation import environment_setup, propagation_setup
+from tudatpy.dynamics import environment_setup, propagation_setup
 from tudatpy.astro import element_conversion
 from tudatpy import constants
 from tudatpy.util import result2array
 
 # Semantic variable history stuff
 import pickle
-from tudatpy.numerical_simulation.propagation import create_dependent_variable_dictionary
+from tudatpy.dynamics.propagation import create_dependent_variable_dictionary
 
 
 def test_dependent_variable_dictionary():

--- a/tests/test_tudatpy/test_interface_spice.py
+++ b/tests/test_tudatpy/test_interface_spice.py
@@ -1,4 +1,4 @@
-import tudatpy.kernel.interface.spice as spice_interface
+import tudatpy.interface.spice as spice_interface
 # from tudatpy import load_standard_spice_kernels
 # import pytest
 # from pytest_bdd import scenario, given, when, then

--- a/tests/test_tudatpy/test_nrlmsise00.py
+++ b/tests/test_tudatpy/test_nrlmsise00.py
@@ -4,10 +4,10 @@ import pickle
 import numpy as np
 
 # Load Tudatpy modules
-from tudatpy.kernel import numerical_simulation
+from tudatpy.dynamics import environment_setup
 from tudatpy.data import read_solar_activity_data, get_space_weather_path
-from tudatpy.kernel.astro.time_conversion import epoch_from_date_time_iso_string
-from tudatpy.kernel.astro.element_conversion import convert_geographic_to_geodetic_latitude
+from tudatpy.astro.time_representation import iso_string_to_epoch
+from tudatpy.astro.element_conversion import convert_geographic_to_geodetic_latitude
 
 
 def test_nrlmsise00():
@@ -21,13 +21,13 @@ def test_nrlmsise00():
 
     # Initialise Tudat NRLMSISE00 model
     solar_weather_data = read_solar_activity_data(get_space_weather_path() + '/sw19571001.txt')
-    NRLMSISE00 = numerical_simulation.environment_setup.atmosphere.NRLMSISE00Atmosphere(solar_weather_data,True,False,True)
+    NRLMSISE00 = environment_setup.atmosphere.NRLMSISE00Atmosphere(solar_weather_data,True,False,True)
 
     # Extract input data and expected densities from the list of dictionaries
     altitudes = np.array([data["altitude"] for data in validation_data])
     longitudes = np.array([data["longitude"] for data in validation_data])
     latitudes = np.array([data["latitude"] for data in validation_data])
-    epochs = np.array([epoch_from_date_time_iso_string(data["date"]) for data in validation_data])
+    epochs = np.array([iso_string_to_epoch(data["date"]) for data in validation_data])
     expected_densities = np.array([data["density"] for data in validation_data])
 
     # Convert geographic latitudes to geodetic latitudes as the validation data was obtained by passing geodetic latitudes to pymsis

--- a/tests/test_tudatpy/test_processTrk234.py
+++ b/tests/test_tudatpy/test_processTrk234.py
@@ -9,7 +9,8 @@ from tudatpy.dynamics.environment_setup import (
     ground_station,
     create_system_of_bodies,
 )
-from tudatpy.numerical_simulation.estimation_setup import observation
+from tudatpy.estimation.observations_setup import ancillary_settings
+from tudatpy.estimation.observable_models_setup import links
 from tudatpy.data.processTrk234.processor import Trk234Processor
 from tudatpy.data.processTrk234 import converters as cnv
 
@@ -286,7 +287,7 @@ def test_reader():
 
     # Check doppler integration time.
     dopplerCount = obs_set.ancilliary_settings.get_float_settings(
-        observation.doppler_integration_time
+        ancillary_settings.doppler_integration_time
     )
     assert (
         dopplerCount == 1.0
@@ -294,7 +295,7 @@ def test_reader():
 
     # Check link end delays.
     linkEndDelays = obs_set.ancilliary_settings.get_float_list_settings(
-        observation.link_ends_delays
+        ancillary_settings.link_ends_delays
     )
     expected_delays = [4.915100149105456e-08, 0.0, -1.8370300836068054e-07]
     assert linkEndDelays == pytest.approx(
@@ -303,9 +304,9 @@ def test_reader():
 
     # Check link definition.
     linkEndType = obs_set.link_definition
-    transmitter = linkEndType.link_end_id(observation.transmitter).reference_point
-    sc = linkEndType.link_end_id(observation.reflector1).body_name
-    rcv = linkEndType.link_end_id(observation.receiver).reference_point
+    transmitter = linkEndType.link_end_id(links.transmitter).reference_point
+    sc = linkEndType.link_end_id(links.reflector1).body_name
+    rcv = linkEndType.link_end_id(links.receiver).reference_point
     assert transmitter == "DSS-65", f"Expected transmitter 'DSS-65', got {transmitter}"
     assert sc == "-202", f"Expected spacecraft '-202', got {sc}"
     assert rcv == "DSS-65", f"Expected receiver 'DSS-65', got {rcv}"

--- a/tests/test_tudatpy/test_processTrk234.py
+++ b/tests/test_tudatpy/test_processTrk234.py
@@ -4,7 +4,7 @@ import requests
 import os
 import pytest
 from tudatpy.interface import spice
-from tudatpy.numerical_simulation.environment_setup import (
+from tudatpy.dynamics.environment_setup import (
     get_default_body_settings,
     ground_station,
     create_system_of_bodies,

--- a/tests/test_tudatpy/test_time_conversions.py
+++ b/tests/test_tudatpy/test_time_conversions.py
@@ -1,14 +1,14 @@
 import math
 from datetime import datetime
-from tudatpy.kernel.astro import time_conversion
+from tudatpy.astro import time_representation
 
 
 def test_datetime_conversions():
 
     python_datetime = datetime.fromisoformat('2023-06-20T00:05:23.281765')
-    tudat_datetime = time_conversion.datetime_to_tudat( python_datetime )
+    tudat_datetime = time_representation.datetime_to_tudat( python_datetime )
     tudat_datetime_string = tudat_datetime.iso_string( False, 12 )
-    python_datetime_reconstructed = time_conversion.datetime_to_python( tudat_datetime )
+    python_datetime_reconstructed = time_representation.datetime_to_python( tudat_datetime )
 
     while (tudat_datetime_string[-1] == '0'):
         tudat_datetime_string = tudat_datetime_string[:-1]
@@ -20,7 +20,7 @@ def test_datetime_conversions():
     assert '2023-06-20 00:05:23.281765' == str(python_datetime)
 
     julian_day = 2443494.5
-    tudat_datettime = time_conversion.datetime_to_tudat(time_conversion.julian_day_to_calendar_date(julian_day))
+    tudat_datettime = time_representation.datetime_to_tudat(time_representation.julian_day_to_calendar_date(julian_day))
     assert julian_day == tudat_datettime.julian_day( )
 
     # pre_1970_date = datetime(1960,1,1,13,7,23,891234)


### PR DESCRIPTION
Update all imports in Python files for new module structure of former `numerical_simulation` and `time_conversion` modules.
Fixes #356 

Note: This builds on top of #355, so #355 should be reviewed and merged first.