### PR TITLE
Fix propagated RSW covariances containing NaN entries

### DIFF
--- a/src/tudatpy/estimation/estimation_analysis/expose_estimation_analysis.cpp
+++ b/src/tudatpy/estimation/estimation_analysis/expose_estimation_analysis.cpp
@@ -160,7 +160,6 @@ std::pair< std::vector< double >, std::vector< Eigen::VectorXd > > propagateForm
 {
     std::map< double, Eigen::VectorXd > propagatedFormalErrors = propagateFormalErrorsRsw(
             estimationOutput, orbitDeterminationManager, evaluationTimes );
-    tp::propagateFormalErrorsRsw( estimationOutput, orbitDeterminationManager, evaluationTimes );
     return std::make_pair( utilities::createVectorFromMapKeys( propagatedFormalErrors ),
                            utilities::createVectorFromMapValues( propagatedFormalErrors ) );
 }


### PR DESCRIPTION
When propagating a covariance/formal errors in RSW, the output erroneously contains NaN entries. For a reproducible example, see https://github.com/orgs/tudat-team/discussions/48.

This seems to be caused by not fully initialized inertial to RSW rotation matrices.
Adding the following lines

```c++
        std::cout << "Propagating covariance at time: " << currentTime << std::endl;
        std::cout << "Inertial to RSW:" << std::endl;
        std::cout << currentFullInertialToRswState << std::endl;
```

after https://github.com/tudat-team/tudatpy/blob/204d79dd1f7474a74cabbf14380982ff918d6932/src/tudatpy/numerical_simulation/estimation/expose_estimation_propagated_covariance.cpp#L117

prints (at an arbitrary epoch)

```
Propagating covariance at time: 9.8412e+08
Inertial to RSW:
   -0.976909    -0.194102    0.0892951 6.74472e-310            0 6.95303e-310
    0.195985    -0.980524    0.0127432 5.40994e-310            0         -nan
   0.0850825    0.0299495     0.995924 6.95303e-310            0 1.97626e-322
6.74481e-310 6.74469e-310  8.42229e-44    -0.976909    -0.194102    0.0892951
6.95303e-310 6.74472e-310 7.35305e-314     0.195985    -0.980524    0.0127432
6.95303e-310 6.74472e-310 1.97626e-322    0.0850825    0.0299495     0.995924
```
i.e. the inertial to RSW rotation matrix contains NaN entries in the off-diagonal blocks.

This can be resolved by explicitly initializing the matrix as zero matrix, see PR modifications.

After the changes, the matrices are correctly initialized as 0, and the RSW covariances/formal errors no longer contain NaN entries:

```
Propagating covariance at time: 9.8412e+08
Inertial to RSW:
-0.976909 -0.194102 0.0892951         0         0         0
 0.195985 -0.980524 0.0127432         0         0         0
0.0850825 0.0299495  0.995924         0         0         0
        0         0         0 -0.976909 -0.194102 0.0892951
        0         0         0  0.195985 -0.980524 0.0127432
        0         0         0 0.0850825 0.0299495  0.995924
```