### PR TITLE
Make COV/FE RSW propagation input consistent, minor exposure/docs updates

### DIFF
--- a/docs/tudatpy/source/estimation/estimation_analysis.rst
+++ b/docs/tudatpy/source/estimation/estimation_analysis.rst
@@ -23,9 +23,15 @@ Functions
 
    propagate_covariance
 
+   propagate_covariance_split_output
+
+   propagate_covariance_rsw_split_output
+
    propagate_formal_errors
 
    propagate_formal_errors_split_output
+
+   propagate_formal_errors_rsw_split_output
 
    estimation_convergence_checker
 
@@ -35,9 +41,15 @@ Functions
 
 .. autofunction:: tudatpy.estimation.estimation_analysis.propagate_covariance
 
+.. autofunction:: tudatpy.estimation.estimation_analysis.propagate_covariance_split_output
+
+.. autofunction:: tudatpy.estimation.estimation_analysis.propagate_covariance_rsw_split_output
+
 .. autofunction:: tudatpy.estimation.estimation_analysis.propagate_formal_errors
 
 .. autofunction:: tudatpy.estimation.estimation_analysis.propagate_formal_errors_split_output
+
+.. autofunction:: tudatpy.estimation.estimation_analysis.propagate_formal_errors_rsw_split_output
 
 .. autofunction:: tudatpy.estimation.estimation_analysis.estimation_convergence_checker
 

--- a/src/tudatpy/dynamics/parameters_setup/expose_parameters_setup.cpp
+++ b/src/tudatpy/dynamics/parameters_setup/expose_parameters_setup.cpp
@@ -162,7 +162,20 @@ void expose_parameters_setup( py::module& m )
 
       )doc" )
             .def_readwrite( "custom_partial_settings",
-                            &tep::EstimatableParameterSettings::customPartialSettings_ );
+                            &tep::EstimatableParameterSettings::customPartialSettings_ )
+            .def_readwrite( "parameter_identifier",
+                            &tep::EstimatableParameterSettings::parameterType_, 
+                            R"doc(
+                            
+Type and associated body of the parameter.
+
+The identifier contains the type of the parameter, defined by the :class:`~tudatpy.dynamics.parameters_setup.EstimatableParameterTypes` enumeration, the body and (if applicable) the reference point to which the parameter is associated.
+The identifier is represented by a tuple of the form ``(parameter_type, (body_name, reference_point_name))``.
+
+:type: tuple[ :class:`~tudatpy.dynamics.parameters_setup.EstimatableParameterTypes`, tuple[str, str] ]
+                            
+                            )doc");
+            
 
 
     // # EstimatableParameterSettings --> EstimatableParameterSet #


### PR DESCRIPTION
This PR changes:

- The input to the `propagate_covariance_rsw_split_output` and `propagate_formal_errors_rsw_split_output` functions is made consistent with the other Cov/FE propagation functions, to take the initial covariance as an input instead of a `CovarianceAnalysisOutput` object. This allows to also propagate a consider covariance matrix, which before would throw an error due to a size mismatch of the STM/Sensitivity Matrix interface (which includes the consider parameters) and the covariance matrix requested from the `CovarianceAnalysisOutput` object (which did not include the consider parameter portion)
- The RSW Cov/FE propagation functions are documented and added to the API docs
- The parameter identifier attribute of the `EstimatableParameterSettings` class is exposed