### PR TITLE
Make `build.py` compatible with star imports from submodules

### DIFF
--- a/build.py
+++ b/build.py
@@ -131,6 +131,40 @@ class BuildParser(argparse.ArgumentParser):
         return None
 
 
+def is_star_import(statement: ast.stmt) -> bool:
+    """Check if a statement is a star import
+
+    :param statement: The statement to be checked
+    :return: Whether the statement is a star import or not
+    """
+
+    # All star imports are of type: from X import *
+    if not isinstance(statement, ast.ImportFrom):
+        return False
+
+    # The number of imported elements must be equal to 1 (the star)
+    if len(statement.names) != 1:
+        return False
+
+    # The imported item must be *
+    if statement.names[0].name != "*":
+        return False
+
+    return True
+
+
+def module_has_init_stub(module_stubs_path: Path) -> bool:
+    """Checks if an __init__.pyi stub exists for a module
+
+    :param module_stubs_path: Path to the module directory in the stubs tree
+    :return: Whether __init__.pyi exists in the directory of the module in the stubs tree
+    """
+
+    # Path to __init__.pyi
+    init_stub_path = module_stubs_path / "__init__.pyi"
+    return init_stub_path.exists()
+
+
 class StubGenerator:
 
     # Default indentation length in pybind11-stubgen
@@ -697,34 +731,40 @@ class StubGenerator:
         )
         init = self.__parse_script(init_path)
 
+        # Initialize containers for the contents of the stub
         stub_body = []
         stub_all: list[str] = []
+
+        # Fill containers based on content of __init__.py
         for statement in init.body:
 
             # Regular import statements
+            # e.g. "import numpy as np" or "import subprocess"
             if isinstance(statement, ast.Import):
 
                 # Multiple items can be imported in a single statement
                 for alias in statement.names:
 
-                    # Star imports must be of ImportFrom type. Regular imports
-                    # from kernel are not allowed
+                    # Regular imports from kernel are not supported
                     if "kernel" in alias.name:
                         raise ValueError(
                             f"Failed to generate {stub_path}: "
-                            f"Only star imports from kernel are supported. "
+                            f"Regular imports from kernel are not supported. "
                             f"Requested: {ast.unparse(statement)}"
                         )
 
                     # External import
                     # TODO: Regular submodule imports should not be accepted
+                    # TODO: How to check if an import is external?
                     stub_body.append(statement)
                     continue
 
             # ImportFrom statements
+            # e.g. "from matplotlib import pyplot as plt", "from . import X"
             if isinstance(statement, ast.ImportFrom):
 
-                # Submodule import
+                # Submodule import from .
+                # e.g. "from . import <submodule>"
                 if statement.module is None:
 
                     # Check that statement follows rules
@@ -754,9 +794,10 @@ class StubGenerator:
                     continue
 
                 # Relative import
+                # e.g. "from .<submodule> import X"
                 if statement.level > 0:
 
-                    # Relative kernel imports are not allowed
+                    # Relative kernel imports are not supported
                     if "kernel" in statement.module:
                         raise ValueError(
                             f"Failed to generate {stub_path}: "
@@ -764,16 +805,37 @@ class StubGenerator:
                             f"Requested: {ast.unparse(statement)}"
                         )
 
-                    # Star imports from Python scripts are not allowed
-                    if (
-                        len(statement.names) == 1
-                        and statement.names[0].name == "*"
-                    ):
-                        raise ValueError(
-                            f"Failed to generate {stub_path}: "
-                            f"Star imports from Python scripts are not allowed."
-                            f"Requested: {ast.unparse(statement)}"
+                    # Check for star import from submodule
+                    if is_star_import(statement):
+
+                        # Get submodule stubs path from statement
+                        submodule_stubs_path = (
+                            module_path / statement.module.replace(".", "/")
                         )
+
+                        # Generate __init__.pyi if it does not exist
+                        if not module_has_init_stub(submodule_stubs_path):
+                            self.__generate_single_init_stub(
+                                submodule_stubs_path
+                            )
+
+                        # Get contents in __all__ statement from __init__.pyi
+                        submodule_all_statement = self.__find_all_statement(
+                            submodule_stubs_path / "__init__.pyi"
+                        )
+                        submodule_contents = self.__retrieve_items_in_all(
+                            submodule_all_statement
+                        )
+
+                        # If there is nothing to import, skip statement
+                        if len(submodule_contents) == 0:
+                            continue
+
+                        # Replace star with imported items
+                        __aliases = [
+                            ast.alias(item) for item in submodule_contents
+                        ]
+                        statement.names = __aliases
 
                     # Add all imported items, or their aliases, to __all__
                     for alias in statement.names:
@@ -838,7 +900,7 @@ class StubGenerator:
                     f"{ast.unparse(statement)}"
                 )
 
-            # Other statements
+            # Other statements (We add them without modification)
             stub_body.append(statement)
 
         # Add __all__ to the stub


### PR DESCRIPTION
The current version of the stub generator in `build.py` only allows star imports from the kernel. Trying to import everything from a python script or a submodule results in an error that prevents stub generation.

We allow kernel star imports because the function of the kernel is to expose public functionality in tudat, but we decided to forbid them on the python side to force developers to be conscious about what they put in the API and what they hide from users.  I still think this is a good idea, but the way in which I implemented it does not allow for star imports from submodules, which is undesirable.

For example: having `tudatpy.estimation.observation_setup` divided into `biases`, `links`, `light_time_corrections`, and `model_settings`, is useful because it keeps the code organized and makes it easier for developers to understand where to find something by following the source tree of the library; but I think a user should be able to find anything related to the setup of observations in the top-level module. A solution would be to have this type of `__init__.py` file in `tudatpy/estimation/observation_setup`:
```python
from tudatpy.kernel.estimation.observation_setup import *    # Exposes top-level C++ functionality
from .biases import *
from .links import *
from .light_time_corrections import *
from .model_settings import *
```
This allows us to keep the low-level subdivision, but hide it from users.

This PR modifies the `build.py` script to make these types of imports technically possible, so that they can be implemented right away if we decide to.