### PR TITLE
Minor docstring updates

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - develop_10
 
 jobs:
   format-check:

--- a/build.py
+++ b/build.py
@@ -953,6 +953,8 @@ class StubGenerator:
         # Missing: Fix __init__.pyi stubs to expand star imports
         self.__generate_init_stubs()
 
+        print("Stubs generated successfully")
+
         return None
 
 

--- a/include/tudat/astro/observation_models/corrections/atmosphereCorrection.h
+++ b/include/tudat/astro/observation_models/corrections/atmosphereCorrection.h
@@ -304,7 +304,7 @@ private:
 };
 
 // Enum listing the available tropospheric mapping models.
-enum TroposphericMappingModel { simplified_chao, niell, vmf3 };
+enum class TroposphericMappingModel { simplified_chao, niell, vmf3 };
 
 // Base class defining a tropospheric elevation mapping function (used to map a zenith tropospheric correction
 // to the desired elevation)

--- a/include/tudat/io/readOdfFile.h
+++ b/include/tudat/io/readOdfFile.h
@@ -7,8 +7,8 @@
  *    a copy of the license with this file. If not, please or visit:
  *    http://tudat.tudelft.nl/LICENSE.
  *
- *    References: 820-013, TRK-2-18 Tracking System Interfaces Orbit Data File Interface, Revision
- * E, 2008, JPL/DSN
+ *    References: 820-013, TRK-2-18 Tracking System Interfaces Orbit Data File
+ * Interface, Revision E, 2008, JPL/DSN
  *
  */
 
@@ -33,27 +33,57 @@ namespace tudat
 namespace input_output
 {
 
+// Enumeration of data types in ODF files
+// From LBL file of an ODF
+// (http://archives.esac.esa.int/psa/repo/ftp-public/MARS-EXPRESS/MRS/MEX-X-MRS-1-2-3-EXT4-3649-V1.0/DATA/LEVEL1A/CLOSED_LOOP/DSN/ODF/M00ODF0L1A_ODF_133631130_00.LBL)
+enum class OdfDataType {
+    narrowband_spacecraft_vlbi_doppler_mode = 1,
+    narrowband_spacecraft_vlbi_phase_mode = 2,
+    narrowband_quasar_vlbi_doppler_mode = 3,
+    narrowband_quasar_vlbi_phase_mode = 4,
+    wideband_spacecraft_vlbi = 5,
+    wideband_quasar_vlbi = 6,
+    one_way_doppler = 11,
+    two_way_doppler = 12,
+    three_way_doppler = 13,
+    one_way_total_count_phase = 21,
+    two_way_total_count_phase = 22,
+    three_way_total_count_phase = 23,
+    pra_planetary_operational_discrete_spectrum_range = 36,
+    sra_planetary_operational_discrete_spectrum_range = 37,
+    re_range = 41,
+    azimuth_angle = 51,
+    elevation_angle = 52,
+    hour_angle = 53,
+    declination_angle = 54,
+    x_angle_east = 55,
+    y_angle_east = 56,
+    x_angle_south = 57,
+    y_angle_south = 58,
+};
+
 // TODO: test
 //! ODF file clock offset block
 class OdfClockOffsetBlock
 {
 public:
     /*!
-     * Constructor. Parses an ODF clock offset block, according to table 3-6 of TRK-2-18 (2018).
+     * Constructor. Parses an ODF clock offset block, according to table
+     * 3-6 of TRK-2-18 (2018).
      *
      * @param dataBits Data block of ODF file.
      */
     OdfClockOffsetBlock( const std::bitset< 288 > dataBits );
 
-    // Returns the start time of the clock offset validity in UTC seconds since the reference time
-    // specified in the header.
+    // Returns the start time of the clock offset validity in UTC
+    // seconds since the reference time specified in the header.
     double getStartTime( )
     {
         return static_cast< double >( integerStartTime_ ) + static_cast< double >( fractionalStartTime_ ) * 1.0E-9;
     }
 
-    // Returns the end time of the clock offset validity in UTC seconds since the reference time
-    // specified in the header.
+    // Returns the end time of the clock offset validity in UTC seconds
+    // since the reference time specified in the header.
     double getEndTime( )
     {
         return static_cast< double >( integerEndTime_ ) + static_cast< double >( fractionalEndTime_ ) * 1.0E-9;
@@ -98,7 +128,8 @@ class OdfRampBlock
 {
 public:
     /*!
-     * Constructor. Parses an ODF ramp block, according to table 3-5 of TRK-2-18 (2018).
+     * Constructor. Parses an ODF ramp block, according to table 3-5 of
+     * TRK-2-18 (2018).
      *
      * @param dataBits Data block of ODF file.
      */
@@ -117,20 +148,22 @@ public:
         return static_cast< double >( integerRampRate_ ) + static_cast< double >( fractionalRampRate_ ) * 1.0E-9;
     }
 
-    // Returns the ramp start time in UTC seconds since the reference time specified in the header.
+    // Returns the ramp start time in UTC seconds since the reference
+    // time specified in the header.
     Time getRampStartTime( )
     {
         return Time( static_cast< double >( integerRampStartTime_ ) ) + Time( static_cast< double >( fractionalRampStartTime_ ) * 1.0E-9 );
     }
 
-    // Returns the ramp end time in UTC seconds since the reference time specified in the header.
+    // Returns the ramp end time in UTC seconds since the reference time
+    // specified in the header.
     Time getRampEndTime( )
     {
         return Time( static_cast< double >( integerRampEndTime_ ) ) + Time( static_cast< double >( fractionalRampEndTime_ ) * 1.0E-9 );
     }
 
-    // ID of the DSN station to which the ramp block applies, specified according to TRK-2-18
-    // (2018).
+    // ID of the DSN station to which the ramp block applies, specified
+    // according to TRK-2-18 (2018).
     int getTransmittingStationId( )
     {
         return transmittingStationId_;
@@ -141,7 +174,7 @@ public:
      *
      * @param outFile File name on which to write data.
      */
-    void printDataBlock( std::ofstream &outFile );
+    void printDataBlock( std::ofstream& outFile );
 
 private:
     unsigned int integerRampStartTime_;     // sec
@@ -162,47 +195,55 @@ private:
     unsigned int fractionalRampEndTime_;  // nsec
 };
 
-// Base class defining the observable specific portion of an ODF data block.
+// Base class defining the observable specific portion of an ODF data
+// block.
 class OdfDataSpecificBlock
 {
 public:
     /*!
      * Constructor.
-     * @param dataType_ Data type, specified according to section 3.2.4 of TRK-2-18 (2018).
+     * @param dataType_ Data type, specified according to section 3.2.4
+     * of TRK-2-18 (2018).
      */
-    OdfDataSpecificBlock( int dataType_ ): dataType_( dataType_ ) { }
+    OdfDataSpecificBlock( OdfDataType dataType ): dataType_( dataType ) { }
 
     // Destructor
     virtual ~OdfDataSpecificBlock( ) { }
 
     /*!
-     * Virtual function printing the observable specific data block to the specified output file.
-     * Should be implemented in the derived classes.
+     * Virtual function printing the observable specific data block to
+     * the specified output file. Should be implemented in the derived
+     * classes.
      *
      * @param outFile File name on which to write data.
      */
-    virtual void printDataBlock( std::ofstream &outFile )
+    virtual void printDataBlock( std::ofstream& outFile )
     {
         outFile << "Printing not implemented for current type";
     }
 
-    // Observable type, according to table 3-4a, item 10, of TRK-2-18 (2018).
-    int dataType_;
+    // Observable type, according to table 3-4a, item 10, of TRK-2-18
+    // (2018).
+    OdfDataType dataType_;
 };
 
 // TODO: test
-// Derived class defining a Delta differential one-way Doppler data block
+// Derived class defining a Delta differential one-way Doppler data
+// block
 class OdfDDodDataBlock : public OdfDataSpecificBlock
 {
 public:
     /*!
-     * Constructor. Parses a the observable specific portion of a Delta differential one-way Doppler
-     * block, according to table 3-4b of TRK-2-18 (2018).
+     * Constructor. Parses a the observable specific portion of a Delta
+     * differential one-way Doppler block, according to table 3-4b of
+     * TRK-2-18 (2018).
      *
-     * @param specificDataBits Observable specific portion of the data block.
-     * @param dDodDataType Data type, specified according to section 3.2.4 of TRK-2-18 (2018). Can take values 1, 2, 3, 4.
+     * @param specificDataBits Observable specific portion of the data
+     * block.
+     * @param dDodDataType Data type, specified according to
+     * section 3.2.4 of TRK-2-18 (2018). Can take values 1, 2, 3, 4.
      */
-    OdfDDodDataBlock( const std::bitset< 128 > specificDataBits, const int dDodDataType );
+    OdfDDodDataBlock( const std::bitset< 128 > specificDataBits, const OdfDataType dDodDataType );
 
     // Destructor
     ~OdfDDodDataBlock( ) { }
@@ -239,7 +280,8 @@ public:
         return compressionTime_ * 1.0e-2;
     }
 
-    // Returns the downlink delay at the second receiving station in seconds.
+    // Returns the downlink delay at the second receiving station in
+    // seconds.
     double getSecondReceivingStationDownlinkDelay( )
     {
         return secondReceivingStationDownlinkDelay_ * 1.0e-9;
@@ -257,18 +299,22 @@ private:
 };
 
 // TODO: test
-// Derived class defining a Delta differential one-way ranging data block
+// Derived class defining a Delta differential one-way ranging data
+// block
 class OdfDDorDataBlock : public OdfDataSpecificBlock
 {
 public:
     /*!
-     * Constructor. Parses a the observable specific portion of a Delta differential one-way ranging
-     * block, according to table 3-4c of TRK-2-18 (2018).
+     * Constructor. Parses a the observable specific portion of a Delta
+     * differential one-way ranging block, according to table 3-4c of
+     * TRK-2-18 (2018).
      *
-     * @param specificDataBits Observable specific portion of the data block.
-     * @param dDorDataType Data type, specified according to section 3.2.4 of TRK-2-18 (2018). Can take values 5, 6.
+     * @param specificDataBits Observable specific portion of the data
+     * block.
+     * @param dDorDataType Data type, specified according to
+     * section 3.2.4 of TRK-2-18 (2018). Can take values 5, 6.
      */
-    OdfDDorDataBlock( const std::bitset< 128 > specificDataBits, const int dDorDataType );
+    OdfDDorDataBlock( const std::bitset< 128 > specificDataBits, const OdfDataType dDorDataType );
 
     // Destructor
     ~OdfDDorDataBlock( ) { }
@@ -299,7 +345,8 @@ public:
         return composite1_;
     }
 
-    // Returns the downlink delay at the second receiving station in seconds.
+    // Returns the downlink delay at the second receiving station in
+    // seconds.
     double getSecondReceivingStationDownlinkDelay( )
     {
         return secondReceivingStationDownlinkDelay_ * 1.0e-9;
@@ -321,14 +368,16 @@ class OdfDopplerDataBlock : public OdfDataSpecificBlock
 {
 public:
     /*!
-     * Constructor. Parses a the observable specific portion of an n-way Doppler block, according to
-     * table 3-4d of TRK-2-18 (2018).
+     * Constructor. Parses a the observable specific portion of an n-way
+     * Doppler block, according to table 3-4d of TRK-2-18 (2018).
      *
-     * @param specificDataBits Observable specific portion of the data block.
-     * @param dopplerDataType Data type, specified according to section 3.2.4 of TRK-2-18 (2018). Can take values 11 (1-way),
-     *      12 (2-way), 13 (3-way).
+     * @param specificDataBits Observable specific portion of the data
+     * block.
+     * @param dopplerDataType Data type, specified according to
+     * section 3.2.4 of TRK-2-18 (2018). Can take values 11 (1-way), 12
+     * (2-way), 13 (3-way).
      */
-    OdfDopplerDataBlock( const std::bitset< 128 > specificDataBits, const int dopplerDataType );
+    OdfDopplerDataBlock( const std::bitset< 128 > specificDataBits, const OdfDataType dopplerDataType );
 
     // Destructor
     ~OdfDopplerDataBlock( ) { }
@@ -371,7 +420,7 @@ public:
      *
      * @param outFile File name on which to write data.
      */
-    void printDataBlock( std::ofstream &outFile );
+    void printDataBlock( std::ofstream& outFile );
 
 private:
     int receiverChannel_;
@@ -391,8 +440,9 @@ class OdfSequentialRangeDataBlock : public OdfDataSpecificBlock
 {
 public:
     /*!
-     * Constructor. Parses a the observable specific portion of an sequential range data block,
-     * according to table 3-4e of TRK-2-18 (2018).
+     * Constructor. Parses a the observable specific portion of an
+     * sequential range data block, according to table 3-4e of TRK-2-18
+     * (2018).
      *
      * @param dataBits Observable specific portion of the data block.
      */
@@ -457,10 +507,11 @@ class OdfToneRangeDataBlock : public OdfDataSpecificBlock
 {
 public:
     /*!
-     * Constructor. Parses a the observable specific portion of a tone range data block, according
-     * to table 3-4f of TRK-2-18 (2018).
+     * Constructor. Parses a the observable specific portion of a tone
+     * range data block, according to table 3-4f of TRK-2-18 (2018).
      *
-     * @param specificDataBits Observable specific portion of the data block.
+     * @param specificDataBits Observable specific portion of the data
+     * block.
      */
     OdfToneRangeDataBlock( const std::bitset< 128 > specificDataBits );
 
@@ -504,13 +555,15 @@ class OdfAngleDataBlock : public OdfDataSpecificBlock
 {
 public:
     /*!
-     * Constructor. Parses the observable specific portion of a angular data block, according to
-     * table 3-4g of TRK-2-18 (2018).
+     * Constructor. Parses the observable specific portion of a angular
+     * data block, according to table 3-4g of TRK-2-18 (2018).
      *
-     * @param specificDataBits Observable specific portion of the data block.
-     * @param angleDataType Data type, specified according to section 3.2.4 of TRK-2-18 (2018). Can take values in [51, 58].
+     * @param specificDataBits Observable specific portion of the data
+     * block.
+     * @param angleDataType Data type, specified according to
+     * section 3.2.4 of TRK-2-18 (2018). Can take values in [51, 58].
      */
-    OdfAngleDataBlock( const std::bitset< 128 > specificDataBits, const int angleDataType );
+    OdfAngleDataBlock( const std::bitset< 128 > specificDataBits, const OdfDataType angleDataType );
 
     // Destructor
     ~OdfAngleDataBlock( ) { }
@@ -531,20 +584,21 @@ private:
     int reservedBlock7_;
 };
 
-// Class defining the common data data block of an ODF file, according to table 3-4a of TRK-2-18
-// (2018).
+// Class defining the common data data block of an ODF file, according
+// to table 3-4a of TRK-2-18 (2018).
 class OdfCommonDataBlock
 {
 public:
     /*!
-     * Constructor. Parses the common portion of an ODF data block, according to table 3-4a of
-     * TRK-2-18 (2018).
+     * Constructor. Parses the common portion of an ODF data block,
+     * according to table 3-4a of TRK-2-18 (2018).
      *
      * @param commonDataBits Common portion of the data block.
      */
     OdfCommonDataBlock( const std::bitset< 160 > commonDataBits );
 
-    // Returns the observable time in UTC seconds since the reference time specified in the header.
+    // Returns the observable time in UTC seconds since the reference
+    // time specified in the header.
     Time getObservableTime( )
     {
         return Time( static_cast< double >( integerTimeTag_ ) ) + Time( static_cast< double >( fractionalTimeTag_ ) / 1000.0 );
@@ -566,7 +620,7 @@ public:
     int receivingStationId_;
     int transmittingStationId_;
     int transmittingStationNetworkId_;
-    int dataType_;
+    OdfDataType dataType_;
     int downlinkBandId_;
     int uplinkBandId_;
     int referenceBandId_;
@@ -577,7 +631,7 @@ public:
      *
      * @param outFile File name on which to write data.
      */
-    void printDataBlock( std::ofstream &outFile );
+    void printDataBlock( std::ofstream& outFile );
 
 private:
     uint32_t integerTimeTag_;            // sec
@@ -593,8 +647,9 @@ class OdfDataBlock
 {
 public:
     /*!
-     * Constructor. Parses an ODF data block, dividing the data into a common data block and an
-     * observable specific data block. According to section 3.2.4 of TRK-2-18 (2018).
+     * Constructor. Parses an ODF data block, dividing the data into a
+     * common data block and an observable specific data block.
+     * According to section 3.2.4 of TRK-2-18 (2018).
      *
      * @param dataBits Data block of ODF file.
      */
@@ -617,7 +672,7 @@ public:
      *
      * @param outFile File name on which to write data.
      */
-    void printDataBlock( std::ofstream &outFile )
+    void printDataBlock( std::ofstream& outFile )
     {
         commonDataBlock_->printDataBlock( outFile );
         observableSpecificDataBlock_->printDataBlock( outFile );
@@ -632,7 +687,8 @@ private:
     std::shared_ptr< OdfCommonDataBlock > commonDataBlock_;
 };
 
-// Class containing the raw data from an ODF file, according to TRK-2-18 (2018).
+// Class containing the raw data from an ODF file, according to TRK-2-18
+// (2018).
 class OdfRawFileContents
 {
 public:
@@ -641,14 +697,15 @@ public:
      *
      * @param odfFile File name/location of ODF file that is to be read
      */
-    OdfRawFileContents( const std::string &odfFile );
+    OdfRawFileContents( const std::string& odfFile );
 
     // File label group, table 3.2 of TRK-2-18 (2018)
     std::string systemId_;
     std::string programId_;
     uint32_t spacecraftId_;
 
-    uint32_t fileCreationDate_;  // year, month, day (YYYMMDD): year from 1900
+    uint32_t fileCreationDate_;  // year, month, day (YYYMMDD): year
+                                 // from 1900
     uint32_t fileCreationTime_;  // hour, minute, second (HHMMSS)
 
     uint32_t fileReferenceDate_;  // year, month, day (YYYYMMDD)
@@ -662,8 +719,8 @@ public:
     std::string identifierGroupStringB_;
     std::string identifierGroupStringC_;
 
-    // Boolean indicating whether the EOF header was found (header should be present in all ODF
-    // files)
+    // Boolean indicating whether the EOF header was found (header
+    // should be present in all ODF files)
     bool eofHeaderFound_;
 
     //! Function to retrieve the orbit data blocsk
@@ -689,7 +746,7 @@ public:
      *
      * @param odfTextFile Name of the output file.
      */
-    void writeOdfToTextFile( const std::string &odfTextFile );
+    void writeOdfToTextFile( const std::string& odfTextFile );
 
 private:
     //! Vector of data blocks
@@ -698,34 +755,41 @@ private:
     //! Vector of ramp blocks indexed by transmitting station ID
     std::map< int, std::vector< std::shared_ptr< OdfRampBlock > > > rampBlocks_;
 
-    //! Clock offset blocks indexed by pair of (primary station ID, secondary station ID)
+    //! Clock offset blocks indexed by pair of (primary station ID,
+    //! secondary station ID)
     std::map< std::pair< int, int >, std::shared_ptr< OdfClockOffsetBlock > > clockOffsetBlocks_;
 
     /*!
-     * Function to parse the contents of an ODF file label block, according to table 3.2 of TRK-2-18
-     * (2018). The data contained in the block is returned by  reference.
+     * Function to parse the contents of an ODF file label block,
+     * according to table 3.2 of TRK-2-18 (2018). The data contained in
+     * the block is returned by  reference.
      *
      * @param dataBits Data block (input).
      * @param systemId System ID (output).
      * @param programId Program ID (output)
      * @param spacecraftId Spacecraft ID (output)
-     * @param fileCreationDate File creation date (output). Format: year, month, day (YYYMMDD): year from 1900
-     * @param fileCreationTime File creation time (output). Format: hour, minute, second (HHMMSS)
-     * @param fileReferenceDate File reference date (output). Format: year, month, day (YYYYMMDD)
-     * @param fileReferenceTime File reference time (output). Format: hour, minute, second (HHMMSS)
+     * @param fileCreationDate File creation date (output). Format:
+     * year, month, day (YYYMMDD): year from 1900
+     * @param fileCreationTime File creation time (output). Format:
+     * hour, minute, second (HHMMSS)
+     * @param fileReferenceDate File reference date (output). Format:
+     * year, month, day (YYYYMMDD)
+     * @param fileReferenceTime File reference time (output). Format:
+     * hour, minute, second (HHMMSS)
      */
     void parseFileLabelData( std::bitset< 288 > dataBits,
-                             std::string &systemId,
-                             std::string &programId,
-                             uint32_t &spacecraftId,
-                             uint32_t &fileCreationDate,
-                             uint32_t &fileCreationTime,
-                             uint32_t &fileReferenceDate,
-                             uint32_t &fileReferenceTime );
+                             std::string& systemId,
+                             std::string& programId,
+                             uint32_t& spacecraftId,
+                             uint32_t& fileCreationDate,
+                             uint32_t& fileCreationTime,
+                             uint32_t& fileReferenceDate,
+                             uint32_t& fileReferenceTime );
 
     /*!
-     * Function to parse the contents of an ODF identifier block, according to table 3.3 of TRK-2-18
-     * (2018). The data contained in the block is returned by  reference.
+     * Function to parse the contents of an ODF identifier block,
+     * according to table 3.3 of TRK-2-18 (2018). The data contained in
+     * the block is returned by  reference.
      *
      * @param dataBits Data block (input).
      * @param identifierGroupStringA identifierGroupStringA (output)
@@ -733,14 +797,16 @@ private:
      * @param identifierGroupStringC identifierGroupStringC (output)
      */
     void parseIdentifierData( std::bitset< 288 > dataBits,
-                              std::string &identifierGroupStringA,
-                              std::string &identifierGroupStringB,
-                              std::string &identifierGroupStringC );
+                              std::string& identifierGroupStringA,
+                              std::string& identifierGroupStringB,
+                              std::string& identifierGroupStringC );
 
     /*!
-     * Function to parse the contents of an ODF file header block, according to table 3.1 of
-     * TRK-2-18 (2018). The data contained in the header is returned by  reference. If the provided
-     * dataBits block is not consistent with the format of a header, an error is thrown.
+     * Function to parse the contents of an ODF file header block,
+     * according to table 3.1 of TRK-2-18 (2018). The data contained in
+     * the header is returned by  reference. If the provided dataBits
+     * block is not consistent with the format of a header, an error is
+     * thrown.
      *
      * @param dataBits Single header block of ODF file (input).
      * @param primaryKey Header primary key (output)
@@ -749,15 +815,16 @@ private:
      * @param groupStartPacketNumber Group start packet number (output)
      */
     void parseHeader( std::bitset< 288 > dataBits,
-                      int32_t &primaryKey,
-                      uint32_t &secondaryKey,
-                      uint32_t &logicalRecordLength,
-                      uint32_t &groupStartPacketNumber );
+                      int32_t& primaryKey,
+                      uint32_t& secondaryKey,
+                      uint32_t& logicalRecordLength,
+                      uint32_t& groupStartPacketNumber );
 
     /*!
-     * Function to check if the current ODF data block is a header. Returns the primary key,
-     * secondary key, logical record length, and group start packet number by reference if the group
-     * IS a header.
+     * Function to check if the current ODF data block is a header.
+     * Returns the primary key, secondary key, logical record length,
+     * and group start packet number by reference if the group IS a
+     * header.
      *
      * @param dataBits Single block of ODF file (input).
      * @param primaryKey Header primary key (output)
@@ -767,18 +834,19 @@ private:
      * @return Boolean indicating whether group is header or not.
      */
     bool currentBlockIsHeader( std::bitset< 288 > dataBits,
-                               int &primaryKey,
-                               unsigned int &secondaryKey,
-                               unsigned int &logicalRecordLength,
-                               unsigned int &groupStartPacketNumber );
+                               int& primaryKey,
+                               unsigned int& secondaryKey,
+                               unsigned int& logicalRecordLength,
+                               unsigned int& groupStartPacketNumber );
 
     /*!
-     * Function reads a single 36 byte block from ODF file. The block is returned by reference.
+     * Function reads a single 36 byte block from ODF file. The block is
+     * returned by reference.
      *
      * @param file ODF file (input)
      * @param dataBits Read byte block (output).
      */
-    void readOdfFileBlock( std::istream &file, std::bitset< 36 * 8 > &dataBits );
+    void readOdfFileBlock( std::istream& file, std::bitset< 36 * 8 >& dataBits );
 };
 
 inline std::shared_ptr< OdfRawFileContents > readOdfFile( std::string fileName )

--- a/include/tudat/simulation/estimation_setup/createLightTimeCorrection.h
+++ b/include/tudat/simulation/estimation_setup/createLightTimeCorrection.h
@@ -30,7 +30,7 @@ namespace observation_models
 {
 
 //! Typedef for function calculating light-time correction in light-time calculation loop.
-typedef std::function< double( const Eigen::Vector6d &, const Eigen::Vector6d &, const double, const double ) > LightTimeCorrectionFunction;
+typedef std::function< double( const Eigen::Vector6d&, const Eigen::Vector6d&, const double, const double ) > LightTimeCorrectionFunction;
 
 //! Base class for light-time correction settings.
 /*!
@@ -80,7 +80,7 @@ public:
      * \param perturbingBodies List of bodies for which the point masses are used to compute the light-time correction.
      * \param useBending Boolean flag to determine if light bending should be included, default is true.
      */
-    FirstOrderRelativisticLightTimeCorrectionSettings( const std::vector< std::string > &perturbingBodies, const bool useBending = false ):
+    FirstOrderRelativisticLightTimeCorrectionSettings( const std::vector< std::string >& perturbingBodies, const bool useBending = false ):
         LightTimeCorrectionSettings( first_order_relativistic ), perturbingBodies_( perturbingBodies ), useBending_( useBending )
     { }
 
@@ -120,12 +120,12 @@ class TabulatedTroposphericCorrectionSettings : public LightTimeCorrectionSettin
 {
 public:
     TabulatedTroposphericCorrectionSettings(
-            const AtmosphericCorrectionPerStationAndSpacecraftType &troposphericDryCorrectionAdjustment,
-            const AtmosphericCorrectionPerStationAndSpacecraftType &troposphericWetCorrectionAdjustment,
-            const std::string &bodyWithAtmosphere = "Earth",
-            const TroposphericMappingModel troposphericMappingModel = niell,
-            const AtmosphericCorrectionPerStationAndSpacecraftType &troposphericDryCorrection = extractDefaultTroposphericDryCorrection( ),
-            const AtmosphericCorrectionPerStationAndSpacecraftType &troposphericWetCorrection =
+            const AtmosphericCorrectionPerStationAndSpacecraftType& troposphericDryCorrectionAdjustment,
+            const AtmosphericCorrectionPerStationAndSpacecraftType& troposphericWetCorrectionAdjustment,
+            const std::string& bodyWithAtmosphere = "Earth",
+            const TroposphericMappingModel troposphericMappingModel = TroposphericMappingModel::niell,
+            const AtmosphericCorrectionPerStationAndSpacecraftType& troposphericDryCorrection = extractDefaultTroposphericDryCorrection( ),
+            const AtmosphericCorrectionPerStationAndSpacecraftType& troposphericWetCorrection =
                     extractDefaultTroposphericWetCorrection( ) ):
         LightTimeCorrectionSettings( tabulated_tropospheric ), troposphericDryCorrectionAdjustment_( troposphericDryCorrectionAdjustment ),
         troposphericWetCorrectionAdjustment_( troposphericWetCorrectionAdjustment ),
@@ -180,8 +180,8 @@ private:
 class SaastamoinenTroposphericCorrectionSettings : public LightTimeCorrectionSettings
 {
 public:
-    SaastamoinenTroposphericCorrectionSettings( const std::string &bodyWithAtmosphere = "Earth",
-                                                const TroposphericMappingModel troposphericMappingModel = niell,
+    SaastamoinenTroposphericCorrectionSettings( const std::string& bodyWithAtmosphere = "Earth",
+                                                const TroposphericMappingModel troposphericMappingModel = TroposphericMappingModel::niell,
                                                 const WaterVaporPartialPressureModel waterVaporPartialPressureModel = tabulated ):
         LightTimeCorrectionSettings( saastamoinen_tropospheric ), bodyWithAtmosphere_( bodyWithAtmosphere ),
         troposphericMappingModelType_( troposphericMappingModel ), waterVaporPartialPressureModelType_( waterVaporPartialPressureModel )
@@ -219,9 +219,9 @@ public:
      * \param useGradientCorrection Whether gradient terms are present in the VMF3 data
      * \param troposphericMappingModel Placeholder mapping model type (ignored, handled externally)
      */
-    VMF3TroposphericCorrectionSettings( const std::string &bodyWithAtmosphere = "Earth",
+    VMF3TroposphericCorrectionSettings( const std::string& bodyWithAtmosphere = "Earth",
                                         const bool useGradientCorrection = true,
-                                        const TroposphericMappingModel troposphericMappingModel = vmf3 ):
+                                        const TroposphericMappingModel troposphericMappingModel = TroposphericMappingModel::vmf3 ):
         LightTimeCorrectionSettings( vmf3_tropospheric ), bodyWithAtmosphere_( bodyWithAtmosphere ),
         useGradientCorrection_( useGradientCorrection ), troposphericMappingModelType_( troposphericMappingModel )
     { }
@@ -254,9 +254,9 @@ private:
 class TabulatedIonosphericCorrectionSettings : public LightTimeCorrectionSettings
 {
 public:
-    TabulatedIonosphericCorrectionSettings( const AtmosphericCorrectionPerStationAndSpacecraftType &referenceRangeCorrection,
+    TabulatedIonosphericCorrectionSettings( const AtmosphericCorrectionPerStationAndSpacecraftType& referenceRangeCorrection,
                                             const double referenceFrequency = 2295e6,
-                                            const std::string &bodyWithAtmosphere = "Earth" ):
+                                            const std::string& bodyWithAtmosphere = "Earth" ):
         LightTimeCorrectionSettings( tabulated_ionospheric ), referenceRangeCorrection_( referenceRangeCorrection ),
         referenceFrequency_( referenceFrequency ), bodyWithAtmosphere_( bodyWithAtmosphere )
     { }
@@ -294,7 +294,7 @@ public:
                                            const double geomagneticPoleLatitude = unit_conversions::convertDegreesToRadians( 80.9 ),
                                            const double geomagneticPoleLongitude = unit_conversions::convertDegreesToRadians( -72.6 ),
                                            const bool useUtcTimeForLocalTimeComputation = false,
-                                           const std::string &bodyWithAtmosphere = "Earth" ):
+                                           const std::string& bodyWithAtmosphere = "Earth" ):
         LightTimeCorrectionSettings( jakowski_vtec_ionospheric ), ionosphereHeight_( ionosphereHeight ),
         firstOrderDelayCoefficient_( firstOrderDelayCoefficient ),
         solarActivityData_( input_output::solar_activity::readSolarActivityData( solarActivityDataPath ) ),
@@ -358,7 +358,7 @@ class IonexIonosphericCorrectionSettings : public LightTimeCorrectionSettings
 {
 public:
     //! Constructor
-    IonexIonosphericCorrectionSettings( const std::string &bodyWithIonosphere,
+    IonexIonosphericCorrectionSettings( const std::string& bodyWithIonosphere,
                                         const double ionosphereHeight,
                                         const double firstOrderDelayCoefficient = 40.3 ):
         LightTimeCorrectionSettings( ionex_vtec_ionospheric ), bodyWithIonosphere_( bodyWithIonosphere ),
@@ -398,10 +398,10 @@ private:
 class InversePowerSeriesSolarCoronaCorrectionSettings : public LightTimeCorrectionSettings
 {
 public:
-    InversePowerSeriesSolarCoronaCorrectionSettings( const std::vector< double > &coefficients = { 1.31 * 5.97e-6 },
-                                                     const std::vector< double > &positiveExponents = { 2.0 },
+    InversePowerSeriesSolarCoronaCorrectionSettings( const std::vector< double >& coefficients = { 1.31 * 5.97e-6 },
+                                                     const std::vector< double >& positiveExponents = { 2.0 },
                                                      const double criticalPlasmaDensityDelayCoefficient = 40.3,
-                                                     const std::string &sunBodyName = "Sun" ):
+                                                     const std::string& sunBodyName = "Sun" ):
         LightTimeCorrectionSettings( inverse_power_series_solar_corona ), coefficients_( coefficients ),
         positiveExponents_( positiveExponents ), criticalPlasmaDensityDelayCoefficient_( criticalPlasmaDensityDelayCoefficient ),
         sunBodyName_( sunBodyName )
@@ -434,23 +434,23 @@ private:
 
     const double criticalPlasmaDensityDelayCoefficient_;
 
-    const std::string &sunBodyName_;
+    const std::string& sunBodyName_;
 };
 
 inline std::shared_ptr< LightTimeCorrectionSettings > firstOrderRelativisticLightTimeCorrectionSettings(
-        const std::vector< std::string > &perturbingBodies,
+        const std::vector< std::string >& perturbingBodies,
         const bool useBending = false )
 {
     return std::make_shared< FirstOrderRelativisticLightTimeCorrectionSettings >( perturbingBodies, useBending );
 }
 
 inline std::shared_ptr< LightTimeCorrectionSettings > tabulatedTroposphericCorrectionSettings(
-        const std::vector< std::string > &troposphericCorrectionFileNames,
-        const std::string &bodyWithAtmosphere = "Earth",
-        const TroposphericMappingModel troposphericMappingModel = niell )
+        const std::vector< std::string >& troposphericCorrectionFileNames,
+        const std::string& bodyWithAtmosphere = "Earth",
+        const TroposphericMappingModel troposphericMappingModel = TroposphericMappingModel::niell )
 {
     std::vector< std::shared_ptr< input_output::CspRawFile > > troposphericCspFiles;
-    for( const std::string &cspFile: troposphericCorrectionFileNames )
+    for( const std::string& cspFile: troposphericCorrectionFileNames )
     {
         troposphericCspFiles.push_back( std::make_shared< input_output::CspRawFile >( cspFile ) );
     }
@@ -462,8 +462,8 @@ inline std::shared_ptr< LightTimeCorrectionSettings > tabulatedTroposphericCorre
 }
 
 inline std::shared_ptr< LightTimeCorrectionSettings > saastamoinenTroposphericCorrectionSettings(
-        const std::string &bodyWithAtmosphere = "Earth",
-        const TroposphericMappingModel troposphericMappingModel = niell,
+        const std::string& bodyWithAtmosphere = "Earth",
+        const TroposphericMappingModel troposphericMappingModel = TroposphericMappingModel::niell,
         const WaterVaporPartialPressureModel waterVaporPartialPressureModel = tabulated )
 {
     return std::make_shared< SaastamoinenTroposphericCorrectionSettings >(
@@ -471,14 +471,14 @@ inline std::shared_ptr< LightTimeCorrectionSettings > saastamoinenTroposphericCo
 }
 
 inline std::shared_ptr< LightTimeCorrectionSettings > tabulatedIonosphericCorrectionSettings(
-        const std::vector< std::string > &ionosphericCorrectionFileNames,
-        const std::map< int, std::string > &spacecraftNamePerSpacecraftId = std::map< int, std::string >( ),
-        const std::map< int, std::string > &quasarNamePerQuasarId = std::map< int, std::string >( ),
+        const std::vector< std::string >& ionosphericCorrectionFileNames,
+        const std::map< int, std::string >& spacecraftNamePerSpacecraftId = std::map< int, std::string >( ),
+        const std::map< int, std::string >& quasarNamePerQuasarId = std::map< int, std::string >( ),
         const double referenceFrequency = 2295e6,
-        const std::string &bodyWithAtmosphere = "Earth" )
+        const std::string& bodyWithAtmosphere = "Earth" )
 {
     std::vector< std::shared_ptr< input_output::CspRawFile > > ionosphericCspFiles;
-    for( const std::string &cspFile: ionosphericCorrectionFileNames )
+    for( const std::string& cspFile: ionosphericCorrectionFileNames )
     {
         ionosphericCspFiles.push_back( std::make_shared< input_output::CspRawFile >( cspFile ) );
     }
@@ -496,7 +496,7 @@ inline std::shared_ptr< LightTimeCorrectionSettings > jakowskiIonosphericCorrect
         const double geomagneticPoleLatitude = unit_conversions::convertDegreesToRadians( 80.9 ),
         const double geomagneticPoleLongitude = unit_conversions::convertDegreesToRadians( -72.6 ),
         const bool useUtcTimeForLocalTimeComputation = false,
-        const std::string &bodyWithAtmosphere = "Earth" )
+        const std::string& bodyWithAtmosphere = "Earth" )
 {
     return std::make_shared< JakowskiIonosphericCorrectionSettings >( ionosphereHeight,
                                                                       firstOrderDelayCoefficient,
@@ -507,7 +507,7 @@ inline std::shared_ptr< LightTimeCorrectionSettings > jakowskiIonosphericCorrect
                                                                       bodyWithAtmosphere );
 }
 
-inline std::shared_ptr< LightTimeCorrectionSettings > ionexIonosphericCorrectionSettings( const std::string &bodyWithIonosphere,
+inline std::shared_ptr< LightTimeCorrectionSettings > ionexIonosphericCorrectionSettings( const std::string& bodyWithIonosphere,
                                                                                           const double ionosphereHeight,
                                                                                           const double firstOrderDelayCoefficient = 40.3 )
 {
@@ -515,18 +515,18 @@ inline std::shared_ptr< LightTimeCorrectionSettings > ionexIonosphericCorrection
 }
 
 inline std::shared_ptr< LightTimeCorrectionSettings > vmf3TroposphericCorrectionSettings(
-        const std::string &bodyWithAtmosphere = "Earth",
+        const std::string& bodyWithAtmosphere = "Earth",
         const bool useGradientCorrection = true,
-        const TroposphericMappingModel troposphericMappingModel = vmf3 )
+        const TroposphericMappingModel troposphericMappingModel = TroposphericMappingModel::vmf3 )
 {
     return std::make_shared< VMF3TroposphericCorrectionSettings >( bodyWithAtmosphere, useGradientCorrection, troposphericMappingModel );
 }
 
 inline std::shared_ptr< LightTimeCorrectionSettings > inversePowerSeriesSolarCoronaCorrectionSettings(
-        const std::vector< double > &coefficients = { 1.31 * 5.97e-6 },
-        const std::vector< double > &positiveExponents = { 2.0 },
+        const std::vector< double >& coefficients = { 1.31 * 5.97e-6 },
+        const std::vector< double >& positiveExponents = { 2.0 },
         const double criticalPlasmaDensityDelayCoefficient = 40.3,
-        const std::string &sunBodyName = "Sun" )
+        const std::string& sunBodyName = "Sun" )
 {
     return std::make_shared< InversePowerSeriesSolarCoronaCorrectionSettings >(
             coefficients, positiveExponents, criticalPlasmaDensityDelayCoefficient, sunBodyName );
@@ -543,10 +543,10 @@ inline std::shared_ptr< LightTimeCorrectionSettings > inversePowerSeriesSolarCor
  * \return Object for computing required light-time correction
  */
 std::shared_ptr< LightTimeCorrection > createLightTimeCorrections( const std::shared_ptr< LightTimeCorrectionSettings > correctionSettings,
-                                                                   const simulation_setup::SystemOfBodies &bodies,
-                                                                   const LinkEnds &linkEnds,
-                                                                   const LinkEndType &transmittingLinkEndType,
-                                                                   const LinkEndType &receivingLinkEndType,
+                                                                   const simulation_setup::SystemOfBodies& bodies,
+                                                                   const LinkEnds& linkEnds,
+                                                                   const LinkEndType& transmittingLinkEndType,
+                                                                   const LinkEndType& receivingLinkEndType,
                                                                    const ObservableType observableType = undefined_observation_model );
 
 /*!
@@ -562,22 +562,22 @@ std::shared_ptr< LightTimeCorrection > createLightTimeCorrections( const std::sh
  */
 std::shared_ptr< TroposhericElevationMapping > createTroposphericElevationMapping(
         const TroposphericMappingModel troposphericMappingModelType,
-        const simulation_setup::SystemOfBodies &bodies,
-        const LinkEndId &transmitter,
-        const LinkEndId &receiver,
+        const simulation_setup::SystemOfBodies& bodies,
+        const LinkEndId& transmitter,
+        const LinkEndId& receiver,
         const bool isUplinkCorrection );
 
 void setVmfTroposphereCorrections(
-        const std::vector< std::string > &dataFiles,
+        const std::vector< std::string >& dataFiles,
         const bool fileHasMeteo,
         const bool fileHasGradient,
-        const simulation_setup::SystemOfBodies &bodies,
+        const simulation_setup::SystemOfBodies& bodies,
         const bool setTropospherData = true,
         const bool setMeteoData = true,
         const std::shared_ptr< interpolators::InterpolatorSettings > interpolatorSettings = interpolators::cubicSplineInterpolation( ) );
 
-void setIonosphereModelFromIonex( const std::vector< std::string > &dataFiles,
-                                  const simulation_setup::SystemOfBodies &bodies,
+void setIonosphereModelFromIonex( const std::vector< std::string >& dataFiles,
+                                  const simulation_setup::SystemOfBodies& bodies,
                                   std::shared_ptr< interpolators::InterpolatorSettings > interpolatorSettings = nullptr );
 
 /*!
@@ -591,10 +591,10 @@ void setIonosphereModelFromIonex( const std::vector< std::string > &dataFiles,
  * @return Function that returns the frequency at the selected link.
  */
 std::function< double( std::vector< FrequencyBands > frequencyBands, double transmissionTime ) > createLinkFrequencyFunction(
-        const simulation_setup::SystemOfBodies &bodies,
-        const LinkEnds &linkEnds,
-        const LinkEndType &transmittingLinkEndType,
-        const LinkEndType &receivingLinkEndType );
+        const simulation_setup::SystemOfBodies& bodies,
+        const LinkEnds& linkEnds,
+        const LinkEndType& transmittingLinkEndType,
+        const LinkEndType& receivingLinkEndType );
 
 }  // namespace observation_models
 

--- a/include/tudat/simulation/estimation_setup/processOdfFile.h
+++ b/include/tudat/simulation/estimation_setup/processOdfFile.h
@@ -38,7 +38,7 @@ namespace observation_models
  * @param odfId ODF data ID
  * @return Observable type
  */
-observation_models::ObservableType getObservableTypeForOdfId( const int odfId );
+observation_models::ObservableType getObservableTypeForOdfId( const input_output::OdfDataType observable_type_id );
 
 /*! Get the frequency band associated with a given ODF frequency band ID.
  *
@@ -299,7 +299,7 @@ public:
     ProcessedOdfFileContents( const std::shared_ptr< input_output::OdfRawFileContents > rawOdfData,
                               const std::string spacecraftName,
                               bool verbose = true,
-                              const std::map< std::string, Eigen::Vector3d > &earthFixedGroundStationPositions =
+                              const std::map< std::string, Eigen::Vector3d >& earthFixedGroundStationPositions =
                                       simulation_setup::getApproximateDsnGroundStationPositions( ) ):
         ProcessedOdfFileContents( std::vector< std::shared_ptr< input_output::OdfRawFileContents > >{ rawOdfData },
                                   spacecraftName,
@@ -320,7 +320,7 @@ public:
     ProcessedOdfFileContents( std::vector< std::shared_ptr< input_output::OdfRawFileContents > > rawOdfDataVector,
                               const std::string spacecraftName,
                               const bool verbose = true,
-                              const std::map< std::string, Eigen::Vector3d > &earthFixedGroundStationPositions =
+                              const std::map< std::string, Eigen::Vector3d >& earthFixedGroundStationPositions =
                                       simulation_setup::getApproximateDsnGroundStationPositions( ) ):
         rawOdfData_( rawOdfDataVector ), spacecraftName_( spacecraftName ),
         approximateEarthFixedGroundStationPositions_( earthFixedGroundStationPositions ), verbose_( verbose )
@@ -437,7 +437,7 @@ public:
 
     // Return ODF observable types IDs (as per TRK-2-18) that were not included in the processed
     // data
-    std::vector< int > getIgnoredRawOdfObservableTypes( )
+    std::vector< input_output::OdfDataType > getIgnoredRawOdfObservableTypes( )
     {
         return ignoredRawOdfObservableTypes_;
     }
@@ -450,14 +450,14 @@ public:
     }
 
     // Return the ramp interpolators per ground station
-    const std::map< std::string, std::shared_ptr< ground_stations::PiecewiseLinearFrequencyInterpolator > > &getRampInterpolators( )
+    const std::map< std::string, std::shared_ptr< ground_stations::PiecewiseLinearFrequencyInterpolator > >& getRampInterpolators( )
     {
         return rampInterpolators_;
     }
 
     // Return processed data
     const std::map< observation_models::ObservableType,
-                    std::map< observation_models::LinkEnds, std::shared_ptr< ProcessedOdfFileSingleLinkData< TimeType > > > > &
+                    std::map< observation_models::LinkEnds, std::shared_ptr< ProcessedOdfFileSingleLinkData< TimeType > > > >&
     getProcessedDataBlocks( )
     {
         return processedDataBlocks_;
@@ -469,7 +469,7 @@ public:
         return rawOdfData_;
     }
 
-    void defineSpacecraftAntennaId( const std::string &spacecraft, const std::string &antennaName )
+    void defineSpacecraftAntennaId( const std::string& spacecraft, const std::string& antennaName )
     {
         std::map< observation_models::ObservableType,
                   std::map< observation_models::LinkEnds, std::shared_ptr< ProcessedOdfFileSingleLinkData< TimeType > > > >
@@ -494,9 +494,9 @@ public:
         processedDataBlocks_ = reprocessedDataBlocks;
     }
 
-    void defineSpacecraftAntennaId( const std::string &spacecraft,
-                                    const std::string &antennaName,
-                                    const std::map< double, double > &timeIntervals )
+    void defineSpacecraftAntennaId( const std::string& spacecraft,
+                                    const std::string& antennaName,
+                                    const std::map< double, double >& timeIntervals )
     {
         // Create lookup scheme to find closest time interval
         std::vector< double > timeIntervalStarts = utilities::createVectorFromMapKeys( timeIntervals );
@@ -562,7 +562,7 @@ private:
      *
      * @param rawOdfDataVector Vector of raw ODF objects.
      */
-    void sortAndValidateOdfDataVector( std::vector< std::shared_ptr< input_output::OdfRawFileContents > > &rawOdfDataVector )
+    void sortAndValidateOdfDataVector( std::vector< std::shared_ptr< input_output::OdfRawFileContents > >& rawOdfDataVector )
     {
         unsigned int spacecraftId = rawOdfDataVector.front( )->spacecraftId_;
 
@@ -595,7 +595,7 @@ private:
                              observation_models::LinkEnds linkEnds,
                              observation_models::ObservableType currentObservableType )
     {
-        int currentObservableId = rawDataBlock->getObservableSpecificDataBlock( )->dataType_;
+        input_output::OdfDataType currentObservableId = rawDataBlock->getObservableSpecificDataBlock( )->dataType_;
 
         std::string transmittingStation, receivingStation;
 
@@ -625,8 +625,8 @@ private:
             {
                 if( verbose_ )
                 {
-                    std::cerr << "Warning: observation of ODF type " << currentObservableId << " not covered by ramp table of station "
-                              << transmittingStation << ", ignoring it." << std::endl;
+                    std::cerr << "Warning: observation of ODF type " << static_cast< int >( currentObservableId )
+                              << " not covered by ramp table of station " << transmittingStation << ", ignoring it." << std::endl;
                 }
                 ignoredOdfRawDataBlocks_.push_back( rawDataBlock );
                 return false;
@@ -644,8 +644,8 @@ private:
                     ignoredGroundStations_.push_back( receivingStation );
                     if( verbose_ )
                     {
-                        std::cerr << "Warning: observation of ODF type " << currentObservableId << " not covered by ramp table of station "
-                                  << receivingStation << ", ignoring it." << std::endl;
+                        std::cerr << "Warning: observation of ODF type " << static_cast< int >( currentObservableId )
+                                  << " not covered by ramp table of station " << receivingStation << ", ignoring it." << std::endl;
                     }
                 }
                 ignoredOdfRawDataBlocks_.push_back( rawDataBlock );
@@ -660,7 +660,8 @@ private:
             {
                 if( verbose_ )
                 {
-                    std::cerr << "Warning: observation of ODF type " << currentObservableId << " not covered by ramp tables,"
+                    std::cerr << "Warning: observation of ODF type " << static_cast< int >( currentObservableId )
+                              << " not covered by ramp tables,"
                               << " ignoring it." << std::endl;
                 }
                 ignoredOdfRawDataBlocks_.push_back( rawDataBlock );
@@ -685,7 +686,7 @@ private:
         for( unsigned int i = 0; i < rawDataBlocks.size( ); i++ )
         {
             // Retrieve observable type and link ends
-            int currentObservableId = rawDataBlocks.at( i )->getObservableSpecificDataBlock( )->dataType_;
+            input_output::OdfDataType currentObservableId = rawDataBlocks.at( i )->getObservableSpecificDataBlock( )->dataType_;
 
             // Get current observable type and throw warning if not implemented
             observation_models::ObservableType currentObservableType;
@@ -693,7 +694,7 @@ private:
             {
                 currentObservableType = getObservableTypeForOdfId( currentObservableId );
             }
-            catch( const std::runtime_error & )
+            catch( const std::runtime_error& )
             {
                 if( std::find( ignoredRawOdfObservableTypes_.begin( ), ignoredRawOdfObservableTypes_.end( ), currentObservableId ) ==
                     ignoredRawOdfObservableTypes_.end( ) )
@@ -701,7 +702,7 @@ private:
                     ignoredRawOdfObservableTypes_.push_back( currentObservableId );
                     if( verbose_ )
                     {
-                        std::cerr << "Warning: processing of ODF data type " << currentObservableId
+                        std::cerr << "Warning: processing of ODF data type " << static_cast< int >( currentObservableId )
                                   << " is not implemented, ignoring the corresponding data." << std::endl;
                     }
                 }
@@ -912,7 +913,7 @@ private:
      * @return UTC times from J2000
      */
     template< typename InputTimeType >
-    std::vector< Time > computeObservationTimesUtcFromJ2000( const std::vector< InputTimeType > &observationTimesUtcFromEME1950 )
+    std::vector< Time > computeObservationTimesUtcFromJ2000( const std::vector< InputTimeType >& observationTimesUtcFromEME1950 )
     {
         std::vector< Time > observationTimesUtcFromJ2000;
 
@@ -936,7 +937,7 @@ private:
      * @return TDB times from J2000
      */
     std::vector< TimeType > computeObservationTimesTdbFromJ2000( const std::string groundStation,
-                                                                 const std::vector< TimeType > &observationTimesUtcFromEME1950 )
+                                                                 const std::vector< TimeType >& observationTimesUtcFromEME1950 )
     {
         earth_orientation::TerrestrialTimeScaleConverter timeScaleConverter = earth_orientation::TerrestrialTimeScaleConverter( );
 
@@ -995,7 +996,7 @@ private:
     // the required data to simulate the corresponding observable is not available in the ODF files
     // (e.g. ramp tables located in some other ODF file that was not provided). Vector keeping the
     // invalid observable types that were found in the raw ODF data
-    std::vector< int > ignoredRawOdfObservableTypes_;
+    std::vector< input_output::OdfDataType > ignoredRawOdfObservableTypes_;
     // Vector keeping the invalid ground stations that were found in the raw ODF data
     std::vector< std::string > ignoredGroundStations_;
     // Vector keeping the invalid data blocks that were found in the raw ODF data
@@ -1026,10 +1027,10 @@ private:
 
 template< typename TimeType = Time >
 inline std::shared_ptr< ProcessedOdfFileContents< TimeType > > processOdfData(
-        const std::vector< std::string > &odfFileNames,
-        const std::string &spacecraftName,
+        const std::vector< std::string >& odfFileNames,
+        const std::string& spacecraftName,
         const bool verbose = true,
-        const std::map< std::string, Eigen::Vector3d > &earthFixedGroundStationPositions =
+        const std::map< std::string, Eigen::Vector3d >& earthFixedGroundStationPositions =
                 simulation_setup::getApproximateDsnGroundStationPositions( ) )
 {
     std::vector< std::shared_ptr< input_output::OdfRawFileContents > > rawOdfDataVector;
@@ -1044,10 +1045,10 @@ inline std::shared_ptr< ProcessedOdfFileContents< TimeType > > processOdfData(
 
 template< typename TimeType = Time >
 inline std::shared_ptr< ProcessedOdfFileContents< TimeType > > processOdfData(
-        const std::string &odfFileName,
-        const std::string &spacecraftName,
+        const std::string& odfFileName,
+        const std::string& spacecraftName,
         const bool verbose = true,
-        const std::map< std::string, Eigen::Vector3d > &earthFixedGroundStationPositions =
+        const std::map< std::string, Eigen::Vector3d >& earthFixedGroundStationPositions =
                 simulation_setup::getApproximateDsnGroundStationPositions( ) )
 {
     return processOdfData< TimeType >(
@@ -1056,10 +1057,10 @@ inline std::shared_ptr< ProcessedOdfFileContents< TimeType > > processOdfData(
 
 template< typename TimeType = Time >
 inline std::shared_ptr< ProcessedOdfFileContents< TimeType > > processOdfData(
-        const std::vector< std::shared_ptr< input_output::OdfRawFileContents > > &odfFiles,
-        const std::string &spacecraftName,
+        const std::vector< std::shared_ptr< input_output::OdfRawFileContents > >& odfFiles,
+        const std::string& spacecraftName,
         const bool verbose = true,
-        const std::map< std::string, Eigen::Vector3d > &earthFixedGroundStationPositions =
+        const std::map< std::string, Eigen::Vector3d >& earthFixedGroundStationPositions =
                 simulation_setup::getApproximateDsnGroundStationPositions( ) )
 {
     return std::make_shared< ProcessedOdfFileContents< TimeType > >( odfFiles, spacecraftName, verbose, earthFixedGroundStationPositions );
@@ -1068,9 +1069,9 @@ inline std::shared_ptr< ProcessedOdfFileContents< TimeType > > processOdfData(
 template< typename TimeType = Time >
 inline std::shared_ptr< ProcessedOdfFileContents< TimeType > > processOdfData(
         const std::shared_ptr< input_output::OdfRawFileContents > odfFile,
-        const std::string &spacecraftName,
+        const std::string& spacecraftName,
         const bool verbose = true,
-        const std::map< std::string, Eigen::Vector3d > &earthFixedGroundStationPositions =
+        const std::map< std::string, Eigen::Vector3d >& earthFixedGroundStationPositions =
                 simulation_setup::getApproximateDsnGroundStationPositions( ) )
 {
     return processOdfData< TimeType >( std::vector< std::shared_ptr< input_output::OdfRawFileContents > >{ odfFile },
@@ -1180,9 +1181,9 @@ observation_models::ObservationAncilliarySimulationSettings createOdfAncillarySe
 template< typename ObservationScalarType = double, typename TimeType = double >
 void separateSingleLinkOdfData( observation_models::ObservableType currentObservableType,
                                 std::shared_ptr< ProcessedOdfFileSingleLinkData< TimeType > > odfSingleLinkData,
-                                std::vector< std::vector< TimeType > > &observationTimes,
-                                std::vector< std::vector< Eigen::Matrix< ObservationScalarType, Eigen::Dynamic, 1 > > > &observables,
-                                std::vector< observation_models::ObservationAncilliarySimulationSettings > &ancillarySettings )
+                                std::vector< std::vector< TimeType > >& observationTimes,
+                                std::vector< std::vector< Eigen::Matrix< ObservationScalarType, Eigen::Dynamic, 1 > > >& observables,
+                                std::vector< observation_models::ObservationAncilliarySimulationSettings >& ancillarySettings )
 {
     // Initialize vectors
     observationTimes.clear( );
@@ -1475,8 +1476,8 @@ std::shared_ptr< observation_models::ObservationCollection< ObservationScalarTyp
  */
 template< typename ObservationScalarType = double, typename TimeType = double >
 void changeObservableTypesOfObservationSimulationSettings(
-        std::vector< std::shared_ptr< simulation_setup::ObservationSimulationSettings< TimeType > > > &observationSimulationSettings,
-        const std::map< ObservableType, ObservableType > &replacementObservableTypes = {
+        std::vector< std::shared_ptr< simulation_setup::ObservationSimulationSettings< TimeType > > >& observationSimulationSettings,
+        const std::map< ObservableType, ObservableType >& replacementObservableTypes = {
                 { dsn_n_way_averaged_doppler, n_way_differenced_range },
                 { dsn_one_way_averaged_doppler, one_way_differenced_range } } )
 {
@@ -1526,8 +1527,8 @@ inline void setTransmittingFrequenciesInGroundStations( std::shared_ptr< Process
  */
 template< typename TimeType = Time >
 void setOdfInformationInBodies( const std::shared_ptr< ProcessedOdfFileContents< TimeType > > processedOdfFileContents,
-                                simulation_setup::SystemOfBodies &bodies,
-                                const std::string &bodyWithGroundStations = "Earth",
+                                simulation_setup::SystemOfBodies& bodies,
+                                const std::string& bodyWithGroundStations = "Earth",
                                 const std::function< double( FrequencyBands uplinkBand, FrequencyBands downlinkBand ) > getTurnaroundRatio =
                                         &getDsnDefaultTurnaroundRatios )
 {
@@ -1542,11 +1543,11 @@ void setOdfInformationInBodies( const std::shared_ptr< ProcessedOdfFileContents<
 
 template< typename ObservationScalarType = double, typename TimeType = Time >
 std::shared_ptr< observation_models::ObservationCollection< ObservationScalarType, TimeType > >
-createOdfObservedObservationCollectionFromFile( simulation_setup::SystemOfBodies &bodies,
-                                                const std::vector< std::string > &odfFileNames,
-                                                const std::string &targetName,
+createOdfObservedObservationCollectionFromFile( simulation_setup::SystemOfBodies& bodies,
+                                                const std::vector< std::string >& odfFileNames,
+                                                const std::string& targetName,
                                                 const bool verboseOutput = true,
-                                                const std::map< std::string, Eigen::Vector3d > &earthFixedGroundStationPositions =
+                                                const std::map< std::string, Eigen::Vector3d >& earthFixedGroundStationPositions =
                                                         simulation_setup::getApproximateDsnGroundStationPositions( ) )
 {
     std::vector< std::shared_ptr< input_output::OdfRawFileContents > > rawOdfDataVector;

--- a/src/tudat/simulation/estimation_setup/createLightTimeCorrection.cpp
+++ b/src/tudat/simulation/estimation_setup/createLightTimeCorrection.cpp
@@ -705,7 +705,7 @@ std::shared_ptr< TroposhericElevationMapping > createTroposphericElevationMappin
 
     switch( troposphericMappingModelType )
     {
-        case simplified_chao: {
+        case TroposphericMappingModel::simplified_chao: {
             std::function< double( Eigen::Vector3d, double ) > elevationFunction =
                     std::bind( &ground_stations::PointingAnglesCalculator::calculateElevationAngleFromInertialVector,
                                bodies.getBody( groundStation.bodyName_ )
@@ -718,7 +718,7 @@ std::shared_ptr< TroposhericElevationMapping > createTroposphericElevationMappin
 
             break;
         }
-        case niell: {
+        case TroposphericMappingModel::niell: {
             std::function< double( Eigen::Vector3d, double ) > elevationFunction =
                     std::bind( &ground_stations::PointingAnglesCalculator::calculateElevationAngleFromInertialVector,
                                bodies.getBody( groundStation.bodyName_ )
@@ -737,7 +737,7 @@ std::shared_ptr< TroposhericElevationMapping > createTroposphericElevationMappin
 
             break;
         }
-        case vmf3: {
+        case TroposphericMappingModel::vmf3: {
             std::function< double( Eigen::Vector3d, double ) > elevationFunction =
                     std::bind( &ground_stations::PointingAnglesCalculator::calculateElevationAngleFromInertialVector,
                                bodies.getBody( groundStation.bodyName_ )
@@ -765,7 +765,7 @@ std::shared_ptr< TroposhericElevationMapping > createTroposphericElevationMappin
         }
         default:
             throw std::runtime_error( "Error when creating tropospheric elevation mapping model: model type " +
-                                      std::to_string( troposphericMappingModelType ) + " not recognized." );
+                                      std::to_string( static_cast< int >( troposphericMappingModelType ) ) + " not recognized." );
 
             break;
     }

--- a/src/tudatpy/astro/time_conversion/__init__.py
+++ b/src/tudatpy/astro/time_conversion/__init__.py
@@ -1,6 +1,6 @@
 import warnings
 warnings.warn(
-    "tudatpy.astro.time_conversion is deprecated. Use tudatpy.astro.time_representation instead.",
+    "tudatpy.astro.time_conversion is deprecated as of v1.0 (see https://docs.tudat.space/en/latest/user-guide/project-updates/migration-guide.html). Use tudatpy.astro.time_representation instead.",
     FutureWarning,
     stacklevel=1
 )

--- a/src/tudatpy/astro/time_representation/expose_time_representation.cpp
+++ b/src/tudatpy/astro/time_representation/expose_time_representation.cpp
@@ -161,7 +161,7 @@ void expose_time_representation( py::module& m )
         
     Class for defining time with a resolution that is sub-femtosecond for very long periods of time.
     
-    Using double or long double precision as a representation of time, the issue of reduced precision will 
+    Using double or long double precision as a representation of time, the issue of reduced precision will
     occur over long time periods. For instance, over a period of 10^8 seconds (about 3 years), double and 
     long double representations have resolution of about 10^-8 and 10^-11 s respectively, which is 
     insufficient for various applications. 
@@ -195,6 +195,9 @@ void expose_time_representation( py::module& m )
      >>> from tudatpy.kernel import Time
      >>> t = Time(3600.0)  # 1 hour after J2000
      )doc" )
+
+            .def( py::init< const int >( ),
+                  py::arg( "seconds_since_j2000" ) )
 
             // Add docstring for the second constructor
             .def( py::init< const int, const long double >( ),
@@ -300,6 +303,8 @@ void expose_time_representation( py::module& m )
 
     // Register implicit conversion from float/double -> Time
     py::implicitly_convertible< double, tudat::Time >( );
+    py::implicitly_convertible< int, tudat::Time >( );
+
     py::enum_< tba::TimeScales >( m,
                                   "TimeScales",
                                   R"doc(

--- a/src/tudatpy/data/expose_data.cpp
+++ b/src/tudatpy/data/expose_data.cpp
@@ -36,7 +36,10 @@ namespace data
 
 void expose_data( py::module &m )
 {
-    // py::module_::import( "tudatpy.math.interpolators" );
+    py::module_::import( "tudatpy.math.interpolators" ).attr( "InterpolatorSettings" );
+    // py::module_::import( "tudatpy.math.interpolators" ).attr( "cubic_spline_interpolation" );
+    // py::object cubic_spline_interpolation =
+    //         (py::object)py::module_::import( "tudatpy.math.interpolators" ).attr( "cubic_spline_interpolation" );
 
     m.def( "get_resource_path",
            &tudat::paths::get_resource_path,
@@ -380,7 +383,7 @@ void expose_data( py::module &m )
 
         .def("get_solar_activity_data_map", &tio::solar_activity::SolarActivityContainer::getSolarActivityDataMap,
                 R"doc(Returns the full map of SolarActivityData.)doc");
-                        
+
     py::class_< tio::OdfRawFileContents, std::shared_ptr< tio::OdfRawFileContents > >(
             m, "OdfRawFileContents", R"doc(No documentation available.)doc" )
             .def( "write_to_text_file",
@@ -469,7 +472,6 @@ void expose_data( py::module &m )
            py::arg( "file_name" ),
            py::arg( "data_level" ) = "1b",
            R"doc(No documentation available.)doc" );
-
 };
 
 }  // namespace data

--- a/src/tudatpy/data/expose_data.cpp
+++ b/src/tudatpy/data/expose_data.cpp
@@ -235,120 +235,90 @@ void expose_data( py::module &m )
 
      )doc" );
 
-    py::enum_< tudat::input_output::TrackingDataType >(
-        m, "TrackingDataType", R"doc(No documentation available.)doc" )
-        .value( "year",
-                tudat::input_output::TrackingDataType::year,
-                R"doc(No documentation available.)doc" )
-        .value( "month",
-                tudat::input_output::TrackingDataType::month,
-                R"doc(No documentation available.)doc" )
-        .value( "day",
-                tudat::input_output::TrackingDataType::day,
-                R"doc(No documentation available.)doc" )
-        .value( "hour",
-                tudat::input_output::TrackingDataType::hour,
-                R"doc(No documentation available.)doc" )
-        .value( "minute",
-                tudat::input_output::TrackingDataType::minute,
-                R"doc(No documentation available.)doc" )
-        .value( "second",
-                tudat::input_output::TrackingDataType::second,
-                R"doc(No documentation available.)doc" )
-        .value( "time_tag_delay",
-                tudat::input_output::TrackingDataType::time_tag_delay,
-                R"doc(No documentation available.)doc" )
-        .value( "observation_time_scale",
-                tudat::input_output::TrackingDataType::observation_time_scale,
-                R"doc(No documentation available.)doc" )
-        .value( "file_name",
-                tudat::input_output::TrackingDataType::file_name,
-                R"doc(No documentation available.)doc" )
-        .value( "n_way_light_time",
-                tudat::input_output::TrackingDataType::n_way_light_time,
-                R"doc(No documentation available.)doc" )
-        .value( "light_time_measurement_delay",
-                tudat::input_output::TrackingDataType::light_time_measurement_delay,
-                R"doc(No documentation available.)doc" )
-        .value( "light_time_measurement_accuracy",
-                tudat::input_output::TrackingDataType::light_time_measurement_accuracy,
-                R"doc(No documentation available.)doc" )
-        .value( "dsn_transmitting_station_nr",
-                tudat::input_output::TrackingDataType::dsn_transmitting_station_nr,
-                R"doc(No documentation available.)doc" )
-        .value( "dsn_receiving_station_nr",
-                tudat::input_output::TrackingDataType::dsn_receiving_station_nr,
-                R"doc(No documentation available.)doc" )
-        .value( "observation_body",
-                tudat::input_output::TrackingDataType::observation_body,
-                R"doc(No documentation available.)doc" )
-        .value( "observed_body",
-                tudat::input_output::TrackingDataType::observed_body,
-                R"doc(No documentation available.)doc" )
-        .value( "spacecraft_id",
-                tudat::input_output::TrackingDataType::spacecraft_id,
-                R"doc(No documentation available.)doc" )
-        .value( "planet_nr",
-                tudat::input_output::TrackingDataType::planet_nr,
-                R"doc(No documentation available.)doc" )
-        .value( "tdb_spacecraft_j2000",
-                tudat::input_output::TrackingDataType::tdb_spacecraft_j2000,
-                R"doc(No documentation available.)doc" )
-        .value( "x_planet_frame",
-                tudat::input_output::TrackingDataType::x_planet_frame,
-                R"doc(No documentation available.)doc" )
-        .value( "y_planet_frame",
-                tudat::input_output::TrackingDataType::y_planet_frame,
-                R"doc(No documentation available.)doc" )
-        .value( "z_planet_frame",
-                tudat::input_output::TrackingDataType::z_planet_frame,
-                R"doc(No documentation available.)doc" )
-        .value( "vx_planet_frame",
-                tudat::input_output::TrackingDataType::vx_planet_frame,
-                R"doc(No documentation available.)doc" )
-        .value( "vy_planet_frame",
-                tudat::input_output::TrackingDataType::vy_planet_frame,
-                R"doc(No documentation available.)doc" )
-        .value( "vz_planet_frame",
-                tudat::input_output::TrackingDataType::vz_planet_frame,
-                R"doc(No documentation available.)doc" )
-        .value( "residual_de405",
-                tudat::input_output::TrackingDataType::residual_de405,
-                R"doc(No documentation available.)doc" )
-        .value( "spacecraft_transponder_delay",
-                tudat::input_output::TrackingDataType::spacecraft_transponder_delay,
-                R"doc(No documentation available.)doc" )
-        .value( "uplink_frequency",
-                tudat::input_output::TrackingDataType::uplink_frequency,
-                R"doc(No documentation available.)doc" )
-        .value( "downlink_frequency",
-                tudat::input_output::TrackingDataType::downlink_frequency,
-                R"doc(No documentation available.)doc" )
-        .value( "signal_to_noise",
-                tudat::input_output::TrackingDataType::signal_to_noise,
-                R"doc(No documentation available.)doc" )
-        .value( "spectral_max",
-                tudat::input_output::TrackingDataType::spectral_max,
-                R"doc(No documentation available.)doc" )
-        .value( "doppler_measured_frequency",
-                tudat::input_output::TrackingDataType::doppler_measured_frequency,
-                R"doc(No documentation available.)doc" )
-        .value( "doppler_base_frequency",
-                tudat::input_output::TrackingDataType::doppler_base_frequency,
-                R"doc(No documentation available.)doc" )
-        .value( "doppler_noise",
-                tudat::input_output::TrackingDataType::doppler_noise,
-                R"doc(No documentation available.)doc" )
-        .value( "doppler_bandwidth",
-                tudat::input_output::TrackingDataType::doppler_bandwidth,
-                R"doc(No documentation available.)doc" )
-        .value( "receiving_station_name",
-                tudat::input_output::TrackingDataType::receiving_station_name,
-                R"doc(No documentation available.)doc" )
-        .value( "transmitting_station_name",
-                tudat::input_output::TrackingDataType::transmitting_station_name,
-                R"doc(No documentation available.)doc" )
-        .export_values( );
+    py::enum_< tudat::input_output::TrackingDataType >( m, "TrackingDataType", R"doc(No documentation available.)doc" )
+            .value( "year", tudat::input_output::TrackingDataType::year, R"doc(No documentation available.)doc" )
+            .value( "month", tudat::input_output::TrackingDataType::month, R"doc(No documentation available.)doc" )
+            .value( "day", tudat::input_output::TrackingDataType::day, R"doc(No documentation available.)doc" )
+            .value( "hour", tudat::input_output::TrackingDataType::hour, R"doc(No documentation available.)doc" )
+            .value( "minute", tudat::input_output::TrackingDataType::minute, R"doc(No documentation available.)doc" )
+            .value( "second", tudat::input_output::TrackingDataType::second, R"doc(No documentation available.)doc" )
+            .value( "observation_time_scale",
+                    tudat::input_output::TrackingDataType::observation_time_scale,
+                    R"doc(No documentation available.)doc" )
+            .value( "file_name", tudat::input_output::TrackingDataType::file_name, R"doc(No documentation available.)doc" )
+            .value( "n_way_light_time", tudat::input_output::TrackingDataType::n_way_light_time, R"doc(No documentation available.)doc" )
+            .value( "light_time_measurement_delay",
+                    tudat::input_output::TrackingDataType::light_time_measurement_delay,
+                    R"doc(No documentation available.)doc" )
+            .value( "light_time_measurement_accuracy",
+                    tudat::input_output::TrackingDataType::light_time_measurement_accuracy,
+                    R"doc(No documentation available.)doc" )
+            .value( "dsn_transmitting_station_nr",
+                    tudat::input_output::TrackingDataType::dsn_transmitting_station_nr,
+                    R"doc(No documentation available.)doc" )
+            .value( "dsn_receiving_station_nr",
+                    tudat::input_output::TrackingDataType::dsn_receiving_station_nr,
+                    R"doc(No documentation available.)doc" )
+            .value( "observation_body", tudat::input_output::TrackingDataType::observation_body, R"doc(No documentation available.)doc" )
+            .value( "observed_body", tudat::input_output::TrackingDataType::observed_body, R"doc(No documentation available.)doc" )
+            .value( "spacecraft_id", tudat::input_output::TrackingDataType::spacecraft_id, R"doc(No documentation available.)doc" )
+            .value( "spacecraft_name", tudat::input_output::TrackingDataType::spacecraft_name, R"doc(No documentation available.)doc" )
+            .value( "planet_nr", tudat::input_output::TrackingDataType::planet_nr, R"doc(No documentation available.)doc" )
+            .value( "tdb_reception_time_j2000",
+                    tudat::input_output::TrackingDataType::tdb_reception_time_j2000,
+                    R"doc(No documentation available.)doc" )
+            .value( "utc_reception_time_j2000",
+                    tudat::input_output::TrackingDataType::utc_reception_time_j2000,
+                    R"doc(No documentation available.)doc" )
+            .value( "utc_ramp_referencee_j2000",
+                    tudat::input_output::TrackingDataType::utc_ramp_referencee_j2000,
+                    R"doc(No documentation available.)doc" )
+            .value( "tdb_spacecraft_j2000",
+                    tudat::input_output::TrackingDataType::tdb_spacecraft_j2000,
+                    R"doc(No documentation available.)doc" )
+            .value( "x_planet_frame", tudat::input_output::TrackingDataType::x_planet_frame, R"doc(No documentation available.)doc" )
+            .value( "y_planet_frame", tudat::input_output::TrackingDataType::y_planet_frame, R"doc(No documentation available.)doc" )
+            .value( "z_planet_frame", tudat::input_output::TrackingDataType::z_planet_frame, R"doc(No documentation available.)doc" )
+            .value( "vx_planet_frame", tudat::input_output::TrackingDataType::vx_planet_frame, R"doc(No documentation available.)doc" )
+            .value( "vy_planet_frame", tudat::input_output::TrackingDataType::vy_planet_frame, R"doc(No documentation available.)doc" )
+            .value( "vz_planet_frame", tudat::input_output::TrackingDataType::vz_planet_frame, R"doc(No documentation available.)doc" )
+            .value( "residual_de405", tudat::input_output::TrackingDataType::residual_de405, R"doc(No documentation available.)doc" )
+            .value( "spacecraft_transponder_delay",
+                    tudat::input_output::TrackingDataType::spacecraft_transponder_delay,
+                    R"doc(No documentation available.)doc" )
+            .value( "uplink_frequency", tudat::input_output::TrackingDataType::uplink_frequency, R"doc(No documentation available.)doc" )
+            .value( "downlink_frequency",
+                    tudat::input_output::TrackingDataType::downlink_frequency,
+                    R"doc(No documentation available.)doc" )
+            .value( "signal_to_noise", tudat::input_output::TrackingDataType::signal_to_noise, R"doc(No documentation available.)doc" )
+            .value( "spectral_max", tudat::input_output::TrackingDataType::spectral_max, R"doc(No documentation available.)doc" )
+            .value( "doppler_measured_frequency",
+                    tudat::input_output::TrackingDataType::doppler_measured_frequency,
+                    R"doc(No documentation available.)doc" )
+            .value( "doppler_averaged_frequency",
+                    tudat::input_output::TrackingDataType::doppler_averaged_frequency,
+                    R"doc(No documentation available.)doc" )
+            .value( "doppler_base_frequency",
+                    tudat::input_output::TrackingDataType::doppler_base_frequency,
+                    R"doc(No documentation available.)doc" )
+            .value( "doppler_noise", tudat::input_output::TrackingDataType::doppler_noise, R"doc(No documentation available.)doc" )
+            .value( "doppler_bandwidth", tudat::input_output::TrackingDataType::doppler_bandwidth, R"doc(No documentation available.)doc" )
+            .value( "receiving_station_name",
+                    tudat::input_output::TrackingDataType::receiving_station_name,
+                    R"doc(No documentation available.)doc" )
+            .value( "transmitting_station_name",
+                    tudat::input_output::TrackingDataType::transmitting_station_name,
+                    R"doc(No documentation available.)doc" )
+            .value( "time_tag_delay", tudat::input_output::TrackingDataType::time_tag_delay )
+            .value( "sample_number", tudat::input_output::TrackingDataType::sample_number )
+            .value( "utc_day_of_year", tudat::input_output::TrackingDataType::utc_day_of_year )
+            .value( "reference_body_distance", tudat::input_output::TrackingDataType::reference_body_distance )
+            .value( "transmission_frequency_constant_term", tudat::input_output::TrackingDataType::transmission_frequency_constant_term )
+            .value( "transmission_frequency_linear_term", tudat::input_output::TrackingDataType::transmission_frequency_linear_term )
+            .value( "doppler_predicted_frequency_hz", tudat::input_output::TrackingDataType::doppler_predicted_frequency_hz )
+            .value( "doppler_troposphere_correction", tudat::input_output::TrackingDataType::doppler_troposphere_correction )
+            .value( "scan_nr", tudat::input_output::TrackingDataType::scan_nr )
+            .export_values( );
 
     py::class_< tio::solar_activity::SolarActivityData,
                 std::shared_ptr< tio::solar_activity::SolarActivityData > >(
@@ -410,21 +380,16 @@ void expose_data( py::module &m )
            py::arg( "body_with_ground_stations_name" ) = "Earth",
            R"doc(No documentation available.)doc" );
 
-    py::class_< tudat::input_output::TrackingTxtFileContents,
-                std::shared_ptr< tudat::input_output::TrackingTxtFileContents > >(
+    py::class_< tudat::input_output::TrackingTxtFileContents, std::shared_ptr< tudat::input_output::TrackingTxtFileContents > >(
             m, "TrackingTxtFileContents", R"doc(No documentation available.)doc" )
-            .def( py::init< const std::string,
-                            const std::vector< std::string >,
-                            const char,
-                            const std::string >( ),
+            .def( py::init< const std::string, const std::vector< std::string >, const char, const std::string >( ),
                   py::arg( "file_name" ),
                   py::arg( "column_types" ),
                   py::arg( "comment_symbol" ) = '#',
                   py::arg( "value_separators" ) = ",:\t ",
                   R"doc(No documentation available.)doc" )
             .def( "add_metadata_val",
-                  py::overload_cast< tio::TrackingDataType, double >(
-                          &tio::TrackingTxtFileContents::addMetaData ),
+                  py::overload_cast< tio::TrackingDataType, double >( &tio::TrackingTxtFileContents::addMetaData ),
                   py::arg( "tracking_data_type" ),
                   py::arg( "value" ),
                   R"doc(No documentation available.)doc" )
@@ -432,24 +397,16 @@ void expose_data( py::module &m )
                   &tio::TrackingTxtFileContents::getAllAvailableDataTypes,
                   R"doc(No documentation available.)doc" )
             .def( "add_metadata_str",
-                  py::overload_cast< tio::TrackingDataType, const std::string & >(
-                          &tio::TrackingTxtFileContents::addMetaData ),
+                  py::overload_cast< tio::TrackingDataType, const std::string& >( &tio::TrackingTxtFileContents::addMetaData ),
                   py::arg( "tracking_data_type" ),
                   py::arg( "str_value" ),
                   R"doc(No documentation available.)doc" )
-            .def_property_readonly( "column_field_types",
-                                    &tio::TrackingTxtFileContents::getRawColumnTypes,
-                                    R"doc(No documentation available.)doc" )
-            .def_property_readonly( "double_datamap",
-                                    &tio::TrackingTxtFileContents::getDoubleDataMap,
-                                    R"doc(No documentation available.)doc" )
-            .def_property_readonly( "raw_datamap",
-                                    &tio::TrackingTxtFileContents::getRawDataMap,
-                                    R"doc(No documentation available.)doc" )
-            .def_property_readonly( "num_rows",
-                                    &tio::TrackingTxtFileContents::getNumRows,
-                                    R"doc(No documentation available.)doc" );
-
+            .def_property_readonly(
+                    "column_field_types", &tio::TrackingTxtFileContents::getRawColumnTypes, R"doc(No documentation available.)doc" )
+            .def_property_readonly(
+                    "double_datamap", &tio::TrackingTxtFileContents::getDoubleDataMap, R"doc(No documentation available.)doc" )
+            .def_property_readonly( "raw_datamap", &tio::TrackingTxtFileContents::getRawDataMap, R"doc(No documentation available.)doc" )
+            .def_property_readonly( "num_rows", &tio::TrackingTxtFileContents::getNumRows, R"doc(No documentation available.)doc" );
 
     m.def( "read_tracking_txt_file",
            &tio::createTrackingTxtFileContents,
@@ -477,7 +434,7 @@ void expose_data( py::module &m )
            &tio::readIfmsFile,
            py::arg( "file_name" ),
            py::arg( "apply_tropospheric_correction" ) = true,
-           R"doc(Load contents of IFMS file into dictionary
+           R"doc(Load contents of IFMS file into object
 
            The keys of the dictionary represent the different columns of the IFMS file, and their values are lists with all the values in the associated column as strings.
 

--- a/src/tudatpy/data/expose_data.cpp
+++ b/src/tudatpy/data/expose_data.cpp
@@ -472,6 +472,21 @@ void expose_data( py::module &m )
            py::arg( "file_name" ),
            py::arg( "data_level" ) = "1b",
            R"doc(No documentation available.)doc" );
+
+    m.def( "read_ifms_file",
+           &tio::readIfmsFile,
+           py::arg( "file_name" ),
+           py::arg( "apply_tropospheric_correction" ) = true,
+           R"doc(Load contents of IFMS file into dictionary
+
+           The keys of the dictionary represent the different columns of the IFMS file, and their values are lists with all the values in the associated column as strings.
+
+           Two of the columns of an IFMS file contain, respectively, the Doppler averaged frequency and a tropospheric correction for the station. When the `apply_tropospheric_correction` option is set to true, the content of the first column is modified by subtracting the values in the second.
+
+           :param file_name: String representing the path to the file to be loaded
+           :param apply_tropospheric_correction: Whether to modify the averaged Doppler frequency as described above (Default: True)
+           :return ifms_contents: Dictionary with contents of the IFMS file as lists of strings
+           )doc" );
 };
 
 }  // namespace data

--- a/src/tudatpy/data/mission_data_downloader/__init__.py
+++ b/src/tudatpy/data/mission_data_downloader/__init__.py
@@ -1,17 +1,1 @@
-from .mission_data_downloader import  LoadPDS, DownloadAtmosphericData
-from tudatpy.interface import spice
-import requests
-from bs4 import BeautifulSoup
-import os
-from urllib.request import urlretrieve
-from datetime import datetime, timedelta
-import glob
-import re
-from tudatpy.interface import spice
-from dateutil.relativedelta import relativedelta
-import subprocess
-from tabulate import tabulate
-from colorama import Fore
-from collections import defaultdict
-from tudatpy.astro.time_conversion import calendar_date_to_julian_day, date_time_from_iso_string, datetime_to_python
-import shutil
+from .mission_data_downloader import LoadPDS, DownloadAtmosphericData

--- a/src/tudatpy/data/mission_data_downloader/mission_data_downloader.py
+++ b/src/tudatpy/data/mission_data_downloader/mission_data_downloader.py
@@ -15,8 +15,13 @@ import subprocess
 from tabulate import tabulate
 from colorama import Fore
 from collections import defaultdict
-from tudatpy.astro.time_conversion import calendar_date_to_julian_day, date_time_from_iso_string, datetime_to_python
+from tudatpy.astro.time_representation import (
+    calendar_date_to_julian_day,
+    date_time_from_iso_string,
+    datetime_to_python,
+)
 import shutil
+
 
 ### Class for Loading PDS files
 class LoadPDS:
@@ -76,8 +81,7 @@ class LoadPDS:
                 "ck": r"^(?P<mission>ROS)?_?(?P<data>(ATNM|CATT|LATT|RATM|ROTT))?(?:_+(?P<token1>[A-Z0-9]+))?(?:_+(?P<token2>[A-Z0-9]+))?(?:_+(?P<token3>[A-Z0-9]+))?(?:_+(?P<token4>[A-Z0-9]+))?$",
                 "mes": r"()",
                 "spk": r"()",
-
-            }
+            },
         }
 
         self.cassini_titan_flyby_dict = {
@@ -173,8 +177,6 @@ class LoadPDS:
             },
         }
 
-
-
         # Mapping of data types to their expected file extensions
         self.type_to_extension = {
             "ck": ["bc"],
@@ -184,7 +186,7 @@ class LoadPDS:
             "mk": ["tm"],
             "ik": ["ti"],
             "lsk": ["tls"],
-            "pck": ["bpc", "tpc"],     # supports both PCK types
+            "pck": ["bpc", "tpc"],  # supports both PCK types
             "sclk": ["tsc"],
             "odf": ["odf"],
             "tnf": ["tnf"],
@@ -223,7 +225,6 @@ class LoadPDS:
             "grail-a": re.compile(r"^grail_v(\d{2})\.tm$"),
             "grail-b": re.compile(r"^grail_v(\d{2})\.tm$"),
             "ro": re.compile(r"ROS_OPS.TM"),
-
         }
 
         self.supported_mission_kernels_url = {
@@ -276,9 +277,15 @@ class LoadPDS:
         ]
 
         # Adding color to the header
-        colored_headers = [f"{Fore.MAGENTA}{header}{Fore.RESET}" for header in headers]
+        colored_headers = [
+            f"{Fore.MAGENTA}{header}{Fore.RESET}" for header in headers
+        ]
 
-        print(tabulate(data, colored_headers, tablefmt="fancy_grid", stralign="center"))
+        print(
+            tabulate(
+                data, colored_headers, tablefmt="fancy_grid", stralign="center"
+            )
+        )
 
     #########################################################################################################
 
@@ -315,7 +322,9 @@ class LoadPDS:
                 )
 
                 # Write the necessary inputs to the process' stdin stream
-                proc.stdin.write("T\n")  # Command to convert transfer files to binary
+                proc.stdin.write(
+                    "T\n"
+                )  # Command to convert transfer files to binary
                 proc.stdin.write(f"{input_file}\n")  # Input file
                 proc.stdin.write(f"{output_file}\n")  # Output file
 
@@ -351,7 +360,9 @@ class LoadPDS:
                 )
 
                 # Write the necessary inputs to the process' stdin stream
-                proc.stdin.write("T\n")  # Command to convert transfer files to binary
+                proc.stdin.write(
+                    "T\n"
+                )  # Command to convert transfer files to binary
                 proc.stdin.write(f"{input_file}\n")  # Input file
                 proc.stdin.write(f"{output_file}\n")  # Output file
 
@@ -388,9 +399,9 @@ class LoadPDS:
             # Replace fixed-length sequences of lowercase letters (e.g., "sc", "hg") with a general pattern
 
             if (
-                    placeholder == "start_date_file"
-                    or placeholder == "end_date_file"
-                    or placeholder == "version"
+                placeholder == "start_date_file"
+                or placeholder == "end_date_file"
+                or placeholder == "version"
             ):
                 pattern = r"[0-9]+"
 
@@ -499,12 +510,12 @@ class LoadPDS:
         #########################################################################################################
 
     def get_kernels(
-            self,
-            input_mission,
-            url,
-            wanted_files=None,
-            wanted_files_patterns=None,
-            custom_output=None,
+        self,
+        input_mission,
+        url,
+        wanted_files=None,
+        wanted_files_patterns=None,
+        custom_output=None,
     ):
         """
         Downloads specific SPICE kernel files or files matching a pattern from a given URL to a local directory
@@ -564,7 +575,9 @@ class LoadPDS:
 
             for wanted_files_pattern in wanted_files_patterns:
                 # Extract all links that match the pattern
-                regex_pattern = re.escape(wanted_files_pattern).replace(r"\*", ".*")
+                regex_pattern = re.escape(wanted_files_pattern).replace(
+                    r"\*", ".*"
+                )
                 matched_files = [
                     os.path.basename(link.get("href"))
                     for link in soup.find_all("a", href=True)
@@ -573,13 +586,14 @@ class LoadPDS:
                 matched_files_list.extend(matched_files)
 
         # Combine explicitly specified files and pattern-matched files
-        all_files_to_download = set(wanted_files or []) | set(matched_files_list)
+        all_files_to_download = set(wanted_files or []) | set(
+            matched_files_list
+        )
 
         self.files_to_load = [
-            os.path.join(base_folder, data_type, file) for file in all_files_to_download
+            os.path.join(base_folder, data_type, file)
+            for file in all_files_to_download
         ]
-
-
 
         # Download each file if not already present
         for file, local_file in zip(all_files_to_download, self.files_to_load):
@@ -588,14 +602,16 @@ class LoadPDS:
                 print(f"Downloading File: {full_url} to: {local_file}")
                 urlretrieve(full_url, local_file)
             else:
-                print(f"File: {local_file} already exists in: {base_folder} and will not be downloaded.")
+                print(
+                    f"File: {local_file} already exists in: {base_folder} and will not be downloaded."
+                )
 
         return self.files_to_load
 
     #########################################################################################################
 
     def add_custom_mission_kernel_pattern(
-            self, input_mission, custom_kernel_type, custom_pattern
+        self, input_mission, custom_kernel_type, custom_pattern
     ):
         """
         Description:
@@ -667,7 +683,9 @@ class LoadPDS:
 
         return self.supported_mission_kernels_url
 
-    def add_custom_mission_meta_kernel_pattern(self, input_mission, custom_pattern):
+    def add_custom_mission_meta_kernel_pattern(
+        self, input_mission, custom_pattern
+    ):
         """
         Description:
             Allows users to define and add custom regex patterns for a specific mission to the list of supported patterns. Once added, the custom pattern can be used for mission data file matching.
@@ -708,7 +726,7 @@ class LoadPDS:
         self.in_intervals = False
         for interval in intervals:
             if (date.date() >= interval[0].date()) and (
-                    date.date() <= interval[1].date()
+                date.date() <= interval[1].date()
             ):
                 self.in_intervals = True
         return self.in_intervals
@@ -731,7 +749,9 @@ class LoadPDS:
         if os.path.exists(local_folder):
             for directory in os.listdir(local_folder):
                 directory_path = os.path.join(local_folder, directory)
-                if os.path.isdir(directory_path) and not os.listdir(directory_path):
+                if os.path.isdir(directory_path) and not os.listdir(
+                    directory_path
+                ):
                     os.rmdir(directory_path)
         print(f"Done.")
 
@@ -786,7 +806,7 @@ class LoadPDS:
     #########################################################################################################
 
     def dynamic_download_url_files_single_time(
-            self, input_mission, local_path, start_date, end_date, url
+        self, input_mission, local_path, start_date, end_date, url
     ):
         """
         Description:
@@ -811,9 +831,10 @@ class LoadPDS:
         data_type = url.split("/")[-2]
         local_subfolder = os.path.join(local_path, data_type.lower())
 
-
         try:
-            supported_pattern = self.supported_patterns[input_mission][data_type.lower()]
+            supported_pattern = self.supported_patterns[input_mission][
+                data_type.lower()
+            ]
 
         except:
             raise ValueError("Pattern not found among supported patterns.")
@@ -889,21 +910,25 @@ class LoadPDS:
                                 ext = RS_dict.get("extension")
                                 # Extract the base filename without the version
                                 base_name_no_version_no_ext = (
-                                    filename_to_download.replace(version, "").replace(
-                                        ext, ""
-                                    )
+                                    filename_to_download.replace(
+                                        version, ""
+                                    ).replace(ext, "")
                                 )
                                 current_version = int(
                                     version[1:]
                                 )  # Extract numeric version (e.g., v02 -> 2)
                                 # Only store the highest version
                                 if not any(
-                                        base_name_no_version_no_ext in value
-                                        for value in files_url_dict.values()
+                                    base_name_no_version_no_ext in value
+                                    for value in files_url_dict.values()
                                 ):
-                                    files_url_dict[date_key] = filename_to_download
+                                    files_url_dict[date_key] = (
+                                        filename_to_download
+                                    )
                                 else:
-                                    stored_version = int(RS_dict.get("version")[1:])
+                                    stored_version = int(
+                                        RS_dict.get("version")[1:]
+                                    )
                                     if current_version >= stored_version:
                                         latest_filename_to_download = f"{base_name_no_version_no_ext}{version}{ext}"
                                         files_url_dict[date_key] = (
@@ -912,10 +937,12 @@ class LoadPDS:
 
                         except Exception as e:
                             if (
-                                    input_mission != "grail-a"
-                                    and input_mission != "grail-b"
+                                input_mission != "grail-a"
+                                and input_mission != "grail-b"
                             ):
-                                print(f"Could not parse file: {filename} - Error: {e}")
+                                print(
+                                    f"Could not parse file: {filename} - Error: {e}"
+                                )
                                 continue
                     else:
                         continue
@@ -930,9 +957,16 @@ class LoadPDS:
                 )
 
             else:
-                if input_mission in self.supported_mission_odf_time_formats.keys():
-                    format_key = self.supported_mission_odf_time_formats[input_mission]
-                    date_string = self.format_datetime_to_string(date, format_key)
+                if (
+                    input_mission
+                    in self.supported_mission_odf_time_formats.keys()
+                ):
+                    format_key = self.supported_mission_odf_time_formats[
+                        input_mission
+                    ]
+                    date_string = self.format_datetime_to_string(
+                        date, format_key
+                    )
                 else:
                     print(
                         f"No ODF time format associated to input mission: {input_mission}. Please provide it in self.supported_mission_odf_time_formats."
@@ -956,7 +990,9 @@ class LoadPDS:
                             )
                             self.relevant_files.append(full_local_path)
                         except Exception as e:
-                            print(f"!! Failed to download {full_download_url}: {e} !!")
+                            print(
+                                f"!! Failed to download {full_download_url}: {e} !!"
+                            )
                 else:
                     try:
                         print(
@@ -968,7 +1004,9 @@ class LoadPDS:
                         )
                         self.relevant_files.append(full_local_path)
                     except Exception as e:
-                        print(f"!! Failed to download {full_download_url}: {e} !!")
+                        print(
+                            f"!! Failed to download {full_download_url}: {e} !!"
+                        )
 
         if len(self.relevant_files) == 0:
             print("Nothing to download.")
@@ -979,7 +1017,9 @@ class LoadPDS:
 
     #########################################################################################################
 
-    def check_existing_files(self, data_type, local_subfolder, start_date, end_date):
+    def check_existing_files(
+        self, data_type, local_subfolder, start_date, end_date
+    ):
         """
         Description:
             Checks the local directory for files that match a given pattern and fall within a specified date range.
@@ -1008,7 +1048,7 @@ class LoadPDS:
     #########################################################################################################
 
     def dynamic_download_url_files_time_interval(
-            self, input_mission, local_path, start_date, end_date, url
+        self, input_mission, local_path, start_date, end_date, url
     ):
         """
         Description:
@@ -1047,7 +1087,9 @@ class LoadPDS:
         ]
 
         try:
-            supported_pattern = self.supported_patterns[input_mission][data_type]
+            supported_pattern = self.supported_patterns[input_mission][
+                data_type
+            ]
         except:
             raise ValueError(f"Pattern not found among supported patterns.")
 
@@ -1116,26 +1158,28 @@ class LoadPDS:
                                 continue
 
                             # Extract the base filename without the version
-                            base_name_no_version_no_ext = filename_to_download.replace(
-                                version, ""
-                            ).replace(ext, "")
+                            base_name_no_version_no_ext = (
+                                filename_to_download.replace(
+                                    version, ""
+                                ).replace(ext, "")
+                            )
                             current_version = int(
                                 version[1:]
                             )  # Extract numeric version (e.g., v02 -> 2)
                             # Only store the highest version
                             if not any(
-                                    base_name_no_version_no_ext in value
-                                    for value in files_url_dict.values()
+                                base_name_no_version_no_ext in value
+                                for value in files_url_dict.values()
                             ):
                                 files_url_dict[(start_time, end_time)] = (
                                     filename_to_download
                                 )
                             else:
-                                stored_version = int(dictionary.get("version")[1:])
+                                stored_version = int(
+                                    dictionary.get("version")[1:]
+                                )
                                 if current_version >= stored_version:
-                                    latest_filename_to_download = (
-                                        f"{base_name_no_version_no_ext}{version}{ext}"
-                                    )
+                                    latest_filename_to_download = f"{base_name_no_version_no_ext}{version}{ext}"
                                     files_url_dict[(start_time, end_time)] = (
                                         latest_filename_to_download
                                     )
@@ -1145,13 +1189,15 @@ class LoadPDS:
 
         # Download files for all intervals from the HTML response
         for new_interval, filename_to_download in files_url_dict.items():
-            full_local_path = os.path.join(local_subfolder, filename_to_download)
+            full_local_path = os.path.join(
+                local_subfolder, filename_to_download
+            )
 
             if existing_files:
                 if full_local_path not in existing_files:
                     if any(
-                            self.is_date_in_intervals(date, [new_interval])
-                            for date in all_dates
+                        self.is_date_in_intervals(date, [new_interval])
+                        for date in all_dates
                     ):
                         print(
                             f"Downloading: {os.path.join(url,filename_to_download)} to: {full_local_path}"
@@ -1163,8 +1209,8 @@ class LoadPDS:
                         self.relevant_files.append(full_local_path)
             else:
                 if any(
-                        self.is_date_in_intervals(date, [new_interval])
-                        for date in all_dates
+                    self.is_date_in_intervals(date, [new_interval])
+                    for date in all_dates
                 ):
                     print(
                         f"Downloading: {os.path.join(url,filename_to_download)} to: {full_local_path}"
@@ -1182,14 +1228,14 @@ class LoadPDS:
         return self.relevant_files
 
     def download_url_files_time(
-            self,
-            local_path,
-            filename_format,
-            start_date,
-            end_date,
-            url,
-            time_format,
-            indices_date_filename,
+        self,
+        local_path,
+        filename_format,
+        start_date,
+        end_date,
+        url,
+        time_format,
+        indices_date_filename,
     ):
         """
         Description:
@@ -1312,7 +1358,9 @@ class LoadPDS:
             # Check whether a matching file was found at the targeted url for this specific date, and split the filename at "/"
             # to account for the possibility that the targeted file is stored in a nested folder
             file_to_download = [
-                x for x in files_url if re.match(current_filename.split("/")[0], x)
+                x
+                for x in files_url
+                if re.match(current_filename.split("/")[0], x)
             ]
 
             # If the file is directly stored at the specified url (no nested folder), then the filename can be stored directly
@@ -1324,22 +1372,26 @@ class LoadPDS:
                 reqs2 = requests.get(url + file_to_download[0])
 
                 # Parse all files within the current folder
-                for nested_link in BeautifulSoup(reqs2.text, "html.parser").find_all(
-                        "a"
-                ):
+                for nested_link in BeautifulSoup(
+                    reqs2.text, "html.parser"
+                ).find_all("a"):
                     nested_file = nested_link.get("href")
 
                     # Retrieve all matching file names within the current folder
                     relevant_link = [
                         x
                         for x in [nested_file]
-                        if re.match(current_filename.split("/")[-1], x.split("/")[-1])
+                        if re.match(
+                            current_filename.split("/")[-1], x.split("/")[-1]
+                        )
                     ]
 
                     # If a match is found, store the filename that should be downloaded (now including the extra folder layer)
                     if len(relevant_link) == 1:
                         files_to_download.append(
-                            file_to_download[0] + "/" + relevant_link[0].split("/")[-1]
+                            file_to_download[0]
+                            + "/"
+                            + relevant_link[0].split("/")[-1]
                         )
 
             # Download all relevant files from the targeted url
@@ -1380,7 +1432,9 @@ class LoadPDS:
         if input_mission in self.supported_patterns:
             level_one_object = self.supported_patterns[input_mission]
         else:
-            raise ValueError("Selected Mission Not Supported (yet!) Aborting ...")
+            raise ValueError(
+                "Selected Mission Not Supported (yet!) Aborting ..."
+            )
 
         if data_type_lower == "all":
             data_type_types = all_supported_types
@@ -1414,7 +1468,8 @@ class LoadPDS:
                                 )  # Get the start position of the matched group
                                 if dictionary[key] is not None:
                                     if (
-                                            last_pos != current_pos and last_pos != 0
+                                        last_pos != current_pos
+                                        and last_pos != 0
                                     ):  # Check if there's a gap since last valid group
                                         underscore_indices.append(
                                             group_index
@@ -1426,36 +1481,41 @@ class LoadPDS:
 
                             # If present, convert start and end dates in utc (both will only be present in spice file names).
                             if (
-                                    "start_date_file" in dictionary
-                                    and "end_date_file" in dictionary
+                                "start_date_file" in dictionary
+                                and "end_date_file" in dictionary
                             ):
                                 if dictionary["start_date_file"] is not None:
 
                                     if (
-                                            dictionary["start_date_file"][0] == "P"
+                                        dictionary["start_date_file"][0] == "P"
                                     ):  # this deals with MEX ORMF files
 
                                         self.start_date_utc = (
                                             LoadPDS.format_string_to_datetime(
                                                 LoadPDS,
-                                                dictionary["start_date_file"][1:7],
+                                                dictionary["start_date_file"][
+                                                    1:7
+                                                ],
                                             )
                                         )
                                         self.end_date_utc = (
-                                                self.start_date_utc
-                                                + relativedelta(months=1)
+                                            self.start_date_utc
+                                            + relativedelta(months=1)
                                         )
                                         dictionary["start_date_utc"] = (
                                             self.start_date_utc
                                         )
-                                        dictionary["end_date_utc"] = self.end_date_utc
+                                        dictionary["end_date_utc"] = (
+                                            self.end_date_utc
+                                        )
 
                                     elif (
-                                            len(dictionary["start_date_file"]) == 4
-                                            and dictionary["purpose"] == "SA"
+                                        len(dictionary["start_date_file"]) == 4
+                                        and dictionary["purpose"] == "SA"
                                     ):
                                         mex_sa_date_trick = (
-                                                dictionary["start_date_file"] + "0101_"
+                                            dictionary["start_date_file"]
+                                            + "0101_"
                                         )
                                         self.start_date_utc = (
                                             LoadPDS.format_string_to_datetime(
@@ -1463,12 +1523,15 @@ class LoadPDS:
                                             )
                                         )
                                         self.end_date_utc = (
-                                                self.start_date_utc + relativedelta(years=1)
+                                            self.start_date_utc
+                                            + relativedelta(years=1)
                                         )
                                         dictionary["start_date_utc"] = (
                                             self.start_date_utc
                                         )
-                                        dictionary["end_date_utc"] = self.end_date_utc
+                                        dictionary["end_date_utc"] = (
+                                            self.end_date_utc
+                                        )
 
                                     else:
                                         self.start_date_utc = (
@@ -1482,19 +1545,24 @@ class LoadPDS:
                                                 LoadPDS,
                                                 dictionary["end_date_file"],
                                             )
-                                            if dictionary["end_date_file"] != "000000"
+                                            if dictionary["end_date_file"]
+                                            != "000000"
                                             else self.start_date_utc
-                                                 + relativedelta(months=1)
+                                            + relativedelta(months=1)
                                         )  # this deals with MEX ORMM files
                                         dictionary["start_date_utc"] = (
                                             self.start_date_utc
                                         )
-                                        dictionary["end_date_utc"] = self.end_date_utc
+                                        dictionary["end_date_utc"] = (
+                                            self.end_date_utc
+                                        )
 
                             # If present, convert date_file in utc (only one date is present in the Radio Science file names)
                             elif "date_file" in dictionary:
-                                self.date_utc = LoadPDS.format_string_to_datetime(
-                                    LoadPDS, dictionary["date_file"]
+                                self.date_utc = (
+                                    LoadPDS.format_string_to_datetime(
+                                        LoadPDS, dictionary["date_file"]
+                                    )
                                 )
                                 dictionary["date_utc"] = self.date_utc
 
@@ -1534,7 +1602,7 @@ class LoadPDS:
 
             # Check if the current index is in the underscore_indices list
             if (
-                    i + 1 in underscore_indices
+                i + 1 in underscore_indices
             ):  # Underscore comes *after* the current group (between i and i+1)
                 reconstructed_filename.append("_")
 
@@ -1594,14 +1662,17 @@ class LoadPDS:
                             (
                                 key
                                 for key, exts in self.type_to_extension.items()
-                                if file_extension in (exts if isinstance(exts, list) else [exts])
+                                if file_extension
+                                in (exts if isinstance(exts, list) else [exts])
                             ),
                             None,  # No fallback, unmatched extensions will be ignored
                         )
 
                         # Add to results if matched
                         if matched_key:
-                            self.kernel_files_names[matched_key].append(full_kernel_path)
+                            self.kernel_files_names[matched_key].append(
+                                full_kernel_path
+                            )
 
             # Add the meta-kernel URL to the dictionary
             file_extension = meta_kernel_url.split(".")[-1].lower()
@@ -1611,15 +1682,14 @@ class LoadPDS:
                 (
                     key
                     for key, exts in self.type_to_extension.items()
-                    if file_extension in (exts if isinstance(exts, list) else [exts])
+                    if file_extension
+                    in (exts if isinstance(exts, list) else [exts])
                 ),
                 None,  # No fallback, unmatched extensions will be ignored
             )
             # Add to results if matched
             if matched_key:
                 self.kernel_files_names[matched_key].append(meta_kernel_url)
-
-
 
             return self.kernel_files_names
 
@@ -1635,27 +1705,52 @@ class LoadPDS:
     def download_kernels_from_meta_kernel(self, input_mission, local_folder):
 
         input_mission = input_mission.lower()
-        self.kernel_files_to_load = self.extract_kernels_from_meta_kernel(input_mission)
+        self.kernel_files_to_load = self.extract_kernels_from_meta_kernel(
+            input_mission
+        )
 
         for kernel_type, kernel_urls in self.kernel_files_to_load.items():
             for kernel_url in kernel_urls:
-                if not kernel_type == 'mk': # some meta-kernel paths are different from kernel paths
-                    url_kernel_path = kernel_url[len(self.supported_mission_kernels_url[input_mission]):]
-                    local_file_path = os.path.join(local_folder, url_kernel_path)
+                if (
+                    not kernel_type == "mk"
+                ):  # some meta-kernel paths are different from kernel paths
+                    url_kernel_path = kernel_url[
+                        len(self.supported_mission_kernels_url[input_mission]) :
+                    ]
+                    local_file_path = os.path.join(
+                        local_folder, url_kernel_path
+                    )
                 else:
-                    url_kernel_path = os.path.join(kernel_type, kernel_url[len(self.supported_mission_meta_kernel_url[input_mission]):])
-                    local_file_path = os.path.join(local_folder, url_kernel_path)
+                    url_kernel_path = os.path.join(
+                        kernel_type,
+                        kernel_url[
+                            len(
+                                self.supported_mission_meta_kernel_url[
+                                    input_mission
+                                ]
+                            ) :
+                        ],
+                    )
+                    local_file_path = os.path.join(
+                        local_folder, url_kernel_path
+                    )
 
                 local_kernel_folder = os.path.dirname(local_file_path)
                 os.makedirs(local_kernel_folder, exist_ok=True)
 
                 # Meta-kernels should always be re-downloaded to assure the latest version
                 if kernel_type == "mk" or not os.path.exists(local_file_path):
-                    action = "Re-downloading" if kernel_type == "mk" else "Downloading"
+                    action = (
+                        "Re-downloading"
+                        if kernel_type == "mk"
+                        else "Downloading"
+                    )
                     print(f"{action}: '{kernel_url}' to: {local_file_path}")
                     urlretrieve(kernel_url, local_file_path)
                 else:
-                    print(f"File: {url_kernel_path} already exists in: {local_folder} and will not be downloaded.")
+                    print(
+                        f"File: {url_kernel_path} already exists in: {local_folder} and will not be downloaded."
+                    )
 
         return self.kernel_files_to_load
 
@@ -1697,13 +1792,17 @@ class LoadPDS:
                         )  # iterating through the past list of meta kernels
                     except:
                         self.latest_kernel = (
-                                base_url + link["href"]
+                            base_url + link["href"]
                         )  # there is just one exact name for juice and mex (no-brainer)
                         return self.latest_kernel
 
             if meta_kernels:
-                self.latest_kernel = max(meta_kernels, key=lambda x: (x[0], x[1]))
-                return self.latest_kernel[2]  # Return the URL of the most recent file
+                self.latest_kernel = max(
+                    meta_kernels, key=lambda x: (x[0], x[1])
+                )
+                return self.latest_kernel[
+                    2
+                ]  # Return the URL of the most recent file
             else:
                 print("No meta-kernels found matching the pattern.")
                 return None
@@ -1720,14 +1819,18 @@ class LoadPDS:
     def get_latest_clock_kernel_name(self, input_mission):
 
         input_mission = input_mission.lower()
-        kernels_from_meta_kernel = self.extract_kernels_from_meta_kernel(input_mission)
+        kernels_from_meta_kernel = self.extract_kernels_from_meta_kernel(
+            input_mission
+        )
 
         clock_files_list = []
         for kernel_type, kernel_files in kernels_from_meta_kernel.items():
             for kernel_file in kernel_files:
                 if kernel_type == "sclk":
                     if len(kernel_files) > 1:
-                        print(f"Warning: Clock Kernel Ambiguity Found: {kernel_files}.")
+                        print(
+                            f"Warning: Clock Kernel Ambiguity Found: {kernel_files}."
+                        )
                         for clock_file in kernel_files:
                             clock_files_list.append(clock_file.split("/")[-1])
 
@@ -1740,16 +1843,16 @@ class LoadPDS:
     #########################################################################################################
 
     def get_mission_files(
-            self,
-            input_mission,
-            start_date=None,
-            end_date=None,
-            flyby_IDs=None,
-            custom_output=None,
-            all_meta_kernel_files=None,
-            load_kernels=None,
-            radio_observation_type=None,
-            radio_science_file_type="odf",
+        self,
+        input_mission,
+        start_date=None,
+        end_date=None,
+        flyby_IDs=None,
+        custom_output=None,
+        all_meta_kernel_files=None,
+        load_kernels=None,
+        radio_observation_type=None,
+        radio_science_file_type="odf",
     ):
         """
         Description:
@@ -1800,7 +1903,7 @@ class LoadPDS:
 
         if custom_output:
             if (
-                    input_mission == "grail-a" or input_mission == "grail-b"
+                input_mission == "grail-a" or input_mission == "grail-b"
             ):  # both grail-a and -b found in grail archive
                 base_folder = f"{custom_output}/{input_mission}"
             else:
@@ -1808,7 +1911,7 @@ class LoadPDS:
 
         else:
             if (
-                    input_mission == "grail-a" or input_mission == "grail-b"
+                input_mission == "grail-a" or input_mission == "grail-b"
             ):  # both grail-a and -b found in grail archive
                 base_folder = f"grail_archive/{input_mission}"
             else:
@@ -1836,8 +1939,8 @@ class LoadPDS:
                 if "ALL_TITAN" in flyby_IDs:
                     print("removing")
                     flyby_IDs.remove("ALL_TITAN")  # Remove 'ALL_TITAN'
-                    full_moon_flybys_list = self.get_cassini_full_moon_flybys_list(
-                        "TITAN"
+                    full_moon_flybys_list = (
+                        self.get_cassini_full_moon_flybys_list("TITAN")
                     )
                     flyby_IDs.extend(full_moon_flybys_list)
                     # Remove duplicates
@@ -1848,8 +1951,8 @@ class LoadPDS:
                 # Process Enceladus flybys if 'ALL_ENCELADUS' is in the list
                 if "ALL_ENCELADUS" in flyby_IDs:
                     flyby_IDs.remove("ALL_ENCELADUS")  # Remove 'ALL_ENCELADUS'
-                    full_moon_flybys_list = self.get_cassini_full_moon_flybys_list(
-                        "ENCELADUS"
+                    full_moon_flybys_list = (
+                        self.get_cassini_full_moon_flybys_list("ENCELADUS")
                     )
                     flyby_IDs.extend(full_moon_flybys_list)
                     # Remove duplicates
@@ -1863,7 +1966,9 @@ class LoadPDS:
                 if len(processed_moons) != 0:
                     for moon in processed_moons:
                         for flyby_ID in flyby_IDs:
-                            local_folder = os.path.join(base_folder, moon, flyby_ID)
+                            local_folder = os.path.join(
+                                base_folder, moon, flyby_ID
+                            )
                             local_folder_list.append(
                                 local_folder
                             )  # Append to local_folder_list
@@ -1882,14 +1987,18 @@ class LoadPDS:
                 for moon in ["TITAN", "ENCELADUS"]:
                     if f"ALL_{moon}" == flyby_IDs:
                         flyby_IDs.remove(f"ALL_{moon}")
-                        full_moon_flybys_list = self.get_cassini_full_moon_flybys_list(
-                            moon
+                        full_moon_flybys_list = (
+                            self.get_cassini_full_moon_flybys_list(moon)
                         )
                         flyby_IDs.extend(full_moon_flybys_list)
-                        flyby_IDs = list(set(flyby_IDs))  # This removes duplicates
+                        flyby_IDs = list(
+                            set(flyby_IDs)
+                        )  # This removes duplicates
 
                         for flyby_ID in flyby_IDs:
-                            local_folder = os.path.join(base_folder, moon, flyby_ID)
+                            local_folder = os.path.join(
+                                base_folder, moon, flyby_ID
+                            )
                             local_folder_list.append(
                                 local_folder
                             )  # append to local_folder_list
@@ -1929,7 +2038,6 @@ class LoadPDS:
                 f"Folder: {base_folder} already exists and will not be overwritten."
             )
 
-
         print(
             f"===============================================================================================================\n"
         )
@@ -1967,7 +2075,6 @@ class LoadPDS:
                         end_date,
                         radio_observation_type,
                     )
-
 
             if input_mission == "mex":
                 if kernel_files_to_load:
@@ -2043,7 +2150,9 @@ class LoadPDS:
             elif input_mission == "grail-a":
                 if kernel_files_to_load:
                     _, radio_science_files_to_load, ancillary_files_to_load = (
-                        self.get_grail_a_files(local_folder, start_date, end_date)
+                        self.get_grail_a_files(
+                            local_folder, start_date, end_date
+                        )
                     )
 
                 else:
@@ -2051,11 +2160,15 @@ class LoadPDS:
                         kernel_files_to_load,
                         radio_science_files_to_load,
                         ancillary_files_to_load,
-                    ) = self.get_grail_a_files(local_folder, start_date, end_date)
+                    ) = self.get_grail_a_files(
+                        local_folder, start_date, end_date
+                    )
             elif input_mission == "grail-b":
                 if kernel_files_to_load:
                     _, radio_science_files_to_load, ancillary_files_to_load = (
-                        self.get_grail_b_files(local_folder, start_date, end_date)
+                        self.get_grail_b_files(
+                            local_folder, start_date, end_date
+                        )
                     )
 
                 else:
@@ -2063,7 +2176,9 @@ class LoadPDS:
                         kernel_files_to_load,
                         radio_science_files_to_load,
                         ancillary_files_to_load,
-                    ) = self.get_grail_b_files(local_folder, start_date, end_date)
+                    ) = self.get_grail_b_files(
+                        local_folder, start_date, end_date
+                    )
 
         if kernel_files_to_load:
             meta_kernel_present = "mk" in kernel_files_to_load
@@ -2072,8 +2187,12 @@ class LoadPDS:
             for kernel_type, kernel_files in kernel_files_to_load.items():
                 self.all_kernel_files[kernel_type] = []
                 for kernel_file in kernel_files:
-                    converted_kernel_file = self.spice_transfer2binary(kernel_file)
-                    self.all_kernel_files[kernel_type].append(converted_kernel_file)
+                    converted_kernel_file = self.spice_transfer2binary(
+                        kernel_file
+                    )
+                    self.all_kernel_files[kernel_type].append(
+                        converted_kernel_file
+                    )
 
             # If meta-kernel is present and load_kernels is True: load only meta-kernel
             if meta_kernel_present and load_kernels:
@@ -2101,15 +2220,20 @@ class LoadPDS:
 
         if ancillary_files_to_load:
             for (
-                    ancillary_type,
-                    ancillary_files,
+                ancillary_type,
+                ancillary_files,
             ) in ancillary_files_to_load.items():
                 for (
-                        ancillary_file
+                    ancillary_file
                 ) in ancillary_files:  # Iterate over each file in the list
                     try:
-                        if ancillary_type not in self.all_ancillary_files.keys():
-                            self.all_ancillary_files[ancillary_type] = [ancillary_file]
+                        if (
+                            ancillary_type
+                            not in self.all_ancillary_files.keys()
+                        ):
+                            self.all_ancillary_files[ancillary_type] = [
+                                ancillary_file
+                            ]
                             if load_kernels:
                                 spice.load_kernel(ancillary_file)
                         else:
@@ -2120,19 +2244,24 @@ class LoadPDS:
                                 spice.load_kernel(ancillary_file)
 
                     except Exception as e:
-                        print(f"!! Failed to load kernel: {ancillary_file}, Error: {e} !!")
+                        print(
+                            f"!! Failed to load kernel: {ancillary_file}, Error: {e} !!"
+                        )
         else:
             print("No Ancillary Files to Load.")
 
         if radio_science_files_to_load:
             for (
-                    radio_science_type,
-                    radio_science_files,
+                radio_science_type,
+                radio_science_files,
             ) in radio_science_files_to_load.items():
                 for (
-                        radio_science_file
+                    radio_science_file
                 ) in radio_science_files:  # Iterate over each file in the list
-                    if radio_science_type not in self.all_radio_science_files.keys():
+                    if (
+                        radio_science_type
+                        not in self.all_radio_science_files.keys()
+                    ):
                         self.all_radio_science_files[radio_science_type] = [
                             radio_science_file
                         ]
@@ -2149,13 +2278,17 @@ class LoadPDS:
                 print(
                     f"==============================================================================================================="
                 )
-                print(f"Number of Loaded Existing + Downloaded Kernels: {n_kernels}")
+                print(
+                    f"Number of Loaded Existing + Downloaded Kernels: {n_kernels}"
+                )
                 std_kernels = spice.load_standard_kernels()
                 self.flag_load_standard_kernels = True
                 n_standard_kernels = (
-                        spice.get_total_count_of_kernels_loaded() - n_kernels
+                    spice.get_total_count_of_kernels_loaded() - n_kernels
                 )
-                print(f"Number of Loaded Standard Kernels: {n_standard_kernels}")
+                print(
+                    f"Number of Loaded Standard Kernels: {n_standard_kernels}"
+                )
                 print(
                     f"==============================================================================================================="
                 )
@@ -2180,7 +2313,7 @@ class LoadPDS:
     ########################################################################################################################################
 
     def get_mex_files(
-            self, local_folder, start_date, end_date, radio_observation_type=None
+        self, local_folder, start_date, end_date, radio_observation_type=None
     ):
         """
         Description:
@@ -2256,7 +2389,9 @@ class LoadPDS:
                     self.ancillary_files_to_load[key] = tropo_files_to_load
 
                 else:
-                    print("No tropospheric or ionospheric files to download this time.")
+                    print(
+                        "No tropospheric or ionospheric files to download this time."
+                    )
 
         print(
             f"==========================================================================================================="
@@ -2269,9 +2404,9 @@ class LoadPDS:
             for closed_loop_type in ["ifms/dp2/", "dsn/dps/", "dsn/dpx/"]:
                 try:
                     url_radio_science_file = (
-                            url_radio_science_file_new
-                            + "data/level02/closed_loop/"
-                            + closed_loop_type
+                        url_radio_science_file_new
+                        + "data/level02/closed_loop/"
+                        + closed_loop_type
                     )
                     files = self.dynamic_download_url_files_single_time(
                         input_mission,
@@ -2354,12 +2489,14 @@ class LoadPDS:
 
         else:
             for url_spk_file in url_spk_files:
-                spk_files_to_load = self.dynamic_download_url_files_time_interval(
-                    input_mission,
-                    local_path=local_folder,
-                    start_date=start_date,
-                    end_date=end_date,
-                    url=url_spk_file,
+                spk_files_to_load = (
+                    self.dynamic_download_url_files_time_interval(
+                        input_mission,
+                        local_path=local_folder,
+                        start_date=start_date,
+                        end_date=end_date,
+                        url=url_spk_file,
+                    )
                 )
 
         if spk_files_to_load:
@@ -2388,12 +2525,14 @@ class LoadPDS:
 
         else:
             for url_ck_file in url_ck_files:
-                ck_files_to_load = self.dynamic_download_url_files_time_interval(
-                    input_mission,
-                    local_path=local_folder,
-                    start_date=start_date,
-                    end_date=end_date,
-                    url=url_ck_file,
+                ck_files_to_load = (
+                    self.dynamic_download_url_files_time_interval(
+                        input_mission,
+                        local_path=local_folder,
+                        start_date=start_date,
+                        end_date=end_date,
+                        url=url_ck_file,
+                    )
                 )
 
         if ck_files_to_load:
@@ -2439,7 +2578,7 @@ class LoadPDS:
 
     #########################################################################################################
     def get_url_mex_radio_science_files(
-            self, start_date_mex, end_date_mex, radio_observation_type=None
+        self, start_date_mex, end_date_mex, radio_observation_type=None
     ):
 
         # url = "https://pds-geosciences.wustl.edu/mex/mex-m-mrs-1_2_3-v1/mexmrs_0735/aareadme.txt"
@@ -2503,7 +2642,7 @@ class LoadPDS:
     #########################################################################################################
 
     def filter_mapping_dict_by_radio_observation_type(
-            self, mapping_dict, radio_observation_type, start_date_mex, end_date_mex
+        self, mapping_dict, radio_observation_type, start_date_mex, end_date_mex
     ):
         """
         Description:
@@ -2530,7 +2669,7 @@ class LoadPDS:
                 entry
                 for entry in values
                 if entry["radio_observation_type"] == radio_observation_type
-                   and start_date_mex <= entry["start_date_utc"] <= end_date_mex
+                and start_date_mex <= entry["start_date_utc"] <= end_date_mex
             ]
             for key, values in mapping_dict.items()
             if any(
@@ -2544,7 +2683,7 @@ class LoadPDS:
     #########################################################################################################
 
     def filter_mapping_dict_by_radio_observation_type(
-            self, mapping_dict, radio_observation_type, start_date_mex, end_date_mex
+        self, mapping_dict, radio_observation_type, start_date_mex, end_date_mex
     ):
         """
         Description:
@@ -2571,7 +2710,7 @@ class LoadPDS:
                 entry
                 for entry in values
                 if entry["radio_observation_type"] == radio_observation_type
-                   and start_date_mex <= entry["start_date_utc"] <= end_date_mex
+                and start_date_mex <= entry["start_date_utc"] <= end_date_mex
             ]
             for key, values in mapping_dict.items()
             if any(
@@ -2622,7 +2761,9 @@ class LoadPDS:
             start_date_file = (
                 match.group(2) if len(match.group(2)) == 10 else match.group(3)
             )
-            end_date_file = match.group(3) if len(match.group(2)) == 10 else None
+            end_date_file = (
+                match.group(3) if len(match.group(2)) == 10 else None
+            )
             start_date_utc = self.format_string_to_datetime(start_date_file)
             end_date_utc = (
                 self.format_string_to_datetime(end_date_file)
@@ -2679,7 +2820,9 @@ class LoadPDS:
             - `ancillary_files_to_load` (`dict`): An empty dictionary for now, intended for ancillary files.
         """
 
-        self.radio_science_files_to_load = {}  # empty for now, since we need fdets
+        self.radio_science_files_to_load = (
+            {}
+        )  # empty for now, since we need fdets
         self.kernel_files_to_load = {}
         self.ancillary_files_to_load = {}  # empty for now
 
@@ -2689,7 +2832,9 @@ class LoadPDS:
             f"==========================================================================================================="
         )
         print(f"Download {input_mission.upper()} Clock Files:")
-        url_clock_files = "https://spiftp.esac.esa.int/data/SPICE/JUICE/kernels/sclk/"
+        url_clock_files = (
+            "https://spiftp.esac.esa.int/data/SPICE/JUICE/kernels/sclk/"
+        )
         wanted_clock_files = self.get_latest_clock_kernel_name(input_mission)
         clock_files_to_load = self.get_kernels(
             input_mission=input_mission,
@@ -2708,7 +2853,9 @@ class LoadPDS:
             f"==========================================================================================================="
         )
         print(f"Download {input_mission.upper()} Frame Files:")
-        url_frame_files = "https://spiftp.esac.esa.int/data/SPICE/JUICE/kernels/fk/"
+        url_frame_files = (
+            "https://spiftp.esac.esa.int/data/SPICE/JUICE/kernels/fk/"
+        )
         wanted_frame_files = [
             "juice_v41.tf",
             "juice_events_crema_5_1_150lb_23_1_v02.tf",
@@ -2762,12 +2909,14 @@ class LoadPDS:
             "https://spiftp.esac.esa.int/data/SPICE/JUICE/kernels/ck/"
         ]
         if len(measured_url_ck_files) == 1:
-            measured_ck_files_to_load = self.dynamic_download_url_files_time_interval(
-                input_mission,
-                local_path=local_folder,
-                start_date=start_date,
-                end_date=end_date,
-                url=measured_url_ck_files[0],
+            measured_ck_files_to_load = (
+                self.dynamic_download_url_files_time_interval(
+                    input_mission,
+                    local_path=local_folder,
+                    start_date=start_date,
+                    end_date=end_date,
+                    url=measured_url_ck_files[0],
+                )
             )
         else:
             for measured_url_ck_file in measured_url_ck_files:
@@ -2803,12 +2952,14 @@ class LoadPDS:
         ]
 
         if len(measured_url_spk_files) == 1:
-            measured_spk_files_to_load = self.dynamic_download_url_files_time_interval(
-                input_mission,
-                local_path=local_folder,
-                start_date=start_date,
-                end_date=end_date,
-                url=measured_url_spk_files[0],
+            measured_spk_files_to_load = (
+                self.dynamic_download_url_files_time_interval(
+                    input_mission,
+                    local_path=local_folder,
+                    start_date=start_date,
+                    end_date=end_date,
+                    url=measured_url_spk_files[0],
+                )
             )
         else:
             for measured_url_spk_file in measured_url_spk_files:
@@ -2878,7 +3029,7 @@ class LoadPDS:
     ########################################################################################################################################
 
     def get_mro_files(
-            self, local_folder, start_date, end_date, radio_science_file_type="odf"
+        self, local_folder, start_date, end_date, radio_science_file_type="odf"
     ):
         """
         Description:
@@ -3011,12 +3162,14 @@ class LoadPDS:
         ]
 
         if len(measured_url_ck_files) == 1:
-            measured_ck_files_to_load = self.dynamic_download_url_files_time_interval(
-                input_mission,
-                local_path=local_folder,
-                start_date=start_date,
-                end_date=end_date,
-                url=measured_url_ck_files[0],
+            measured_ck_files_to_load = (
+                self.dynamic_download_url_files_time_interval(
+                    input_mission,
+                    local_path=local_folder,
+                    start_date=start_date,
+                    end_date=end_date,
+                    url=measured_url_ck_files[0],
+                )
             )
         else:
             for measured_url_ck_file in measured_url_ck_files:
@@ -3039,7 +3192,9 @@ class LoadPDS:
         print(
             f"==========================================================================================================="
         )
-        print(f"Download {input_mission.upper()} Tropospheric Corrections Files")
+        print(
+            f"Download {input_mission.upper()} Tropospheric Corrections Files"
+        )
         url_tropo_files = "https://pds-geosciences.wustl.edu/mro/mro-m-rss-1-magr-v1/mrors_0xxx/ancillary/tro/"
         tropo_files_to_load = self.dynamic_download_url_files_time_interval(
             input_mission,
@@ -3255,7 +3410,8 @@ class LoadPDS:
 
         # Create dictionary of filenames by pds_repo
         filenames_dict = {
-            pds_repo: data["file_name"] for pds_repo, data in cumindex_dict.items()
+            pds_repo: data["file_name"]
+            for pds_repo, data in cumindex_dict.items()
         }
 
         for pds_repo, filenames_list in filenames_dict.items():
@@ -3298,14 +3454,14 @@ class LoadPDS:
                 # Add file paths for 'ck' type files
 
                 if file_ext.lower() in ["ion", "tro"]:
-                    self.ancillary_files_to_load.setdefault(file_ext, []).append(
-                        local_file_path
-                    )
+                    self.ancillary_files_to_load.setdefault(
+                        file_ext, []
+                    ).append(local_file_path)
 
                 elif file_ext.lower() in ["odf"]:
-                    self.radio_science_files_to_load.setdefault(file_ext, []).append(
-                        local_file_path
-                    )
+                    self.radio_science_files_to_load.setdefault(
+                        file_ext, []
+                    ).append(local_file_path)
                 else:
                     self.kernel_files_to_load.setdefault(file_ext, []).append(
                         local_file_path
@@ -3318,18 +3474,18 @@ class LoadPDS:
                     print(f"Downloading: '{filename}' to: {local_file_path}")
 
                     if file_ext.lower() in ["ion", "tro", "eop"]:
-                        self.ancillary_files_to_load.setdefault(file_ext, []).append(
-                            local_file_path
-                        )
+                        self.ancillary_files_to_load.setdefault(
+                            file_ext, []
+                        ).append(local_file_path)
 
                     elif file_ext.lower() in ["odf"]:
                         self.radio_science_files_to_load.setdefault(
                             file_ext, []
                         ).append(local_file_path)
                     else:
-                        self.kernel_files_to_load.setdefault(file_ext, []).append(
-                            local_file_path
-                        )
+                        self.kernel_files_to_load.setdefault(
+                            file_ext, []
+                        ).append(local_file_path)
 
                 except Exception as e:
                     try:
@@ -3348,9 +3504,9 @@ class LoadPDS:
                                 file_ext, []
                             ).append(local_file_path)
                         else:
-                            self.kernel_files_to_load.setdefault(file_ext, []).append(
-                                local_file_path
-                            )
+                            self.kernel_files_to_load.setdefault(
+                                file_ext, []
+                            ).append(local_file_path)
 
                     except:
                         print(f"Error downloading {filename.lower()}: {e}")
@@ -3360,7 +3516,9 @@ class LoadPDS:
             f"==========================================================================================================="
         )
         print(f"Download {input_mission.upper()} Frame Kernels from NAIF:")
-        url_frame_files = "https://naif.jpl.nasa.gov/pub/naif/CASSINI/kernels/fk/"
+        url_frame_files = (
+            "https://naif.jpl.nasa.gov/pub/naif/CASSINI/kernels/fk/"
+        )
         wanted_frame_files = ["cas_v43.tf"]
         frame_files_to_load = self.get_kernels(
             input_mission=input_mission,
@@ -3458,9 +3616,7 @@ class LoadPDS:
         experiment = flyby_dict["experiment"]
 
         # Define the URL template
-        pds_repo_url = (
-            f"https://atmos.nmsu.edu/pdsd/archive/data/co-ssa-rss-1-{experiment}-v10/"
-        )
+        pds_repo_url = f"https://atmos.nmsu.edu/pdsd/archive/data/co-ssa-rss-1-{experiment}-v10/"
 
         # Check if the URL exists by sending a HEAD request
         try:
@@ -3586,17 +3742,27 @@ class LoadPDS:
             # Extract the columns
             pds_repo = cols[0].replace('"', "").replace("'", "").strip()
             file_label = cols[1].replace('"', "").replace("'", "").strip()
-            file_label_path = file_label.split("/")[0] + "/" + file_label.split("/")[1]
+            file_label_path = (
+                file_label.split("/")[0] + "/" + file_label.split("/")[1]
+            )
 
             file_name = (
-                    file_label_path
-                    + "/"
-                    + cols[2].replace('"', "").replace("'", "").strip()
+                file_label_path
+                + "/"
+                + cols[2].replace('"', "").replace("'", "").strip()
             )
-            external_file_name = cols[3].replace('"', "").replace("'", "").strip()
-            start_date_utc = cols[4].replace('"', "").replace("'", "").strip()[:-2]
-            end_date_utc = cols[5].replace('"', "").replace("'", "").strip()[:-2]
-            creation_date_utc = cols[6].replace('"', "").replace("'", "").strip()
+            external_file_name = (
+                cols[3].replace('"', "").replace("'", "").strip()
+            )
+            start_date_utc = (
+                cols[4].replace('"', "").replace("'", "").strip()[:-2]
+            )
+            end_date_utc = (
+                cols[5].replace('"', "").replace("'", "").strip()[:-2]
+            )
+            creation_date_utc = (
+                cols[6].replace('"', "").replace("'", "").strip()
+            )
 
             keywords = [
                 ("tigm", "odf"),
@@ -3610,16 +3776,21 @@ class LoadPDS:
 
             # Check if both words in any pair appear in the file_label
             if any(
-                    all(word in file_label.lower() for word in pair) for pair in keywords
+                all(word in file_label.lower() for word in pair)
+                for pair in keywords
             ):
                 try:
-                    start_date_utc = self.format_string_to_datetime(start_date_utc)
+                    start_date_utc = self.format_string_to_datetime(
+                        start_date_utc
+                    )
                     end_date_utc = self.format_string_to_datetime(end_date_utc)
                     creation_date_utc = self.format_string_to_datetime(
                         creation_date_utc
                     )
                 except ValueError:
-                    print("Skipping time conversion due to invalid date format.")
+                    print(
+                        "Skipping time conversion due to invalid date format."
+                    )
                     continue  # Skip rows with invalid date format
 
                 # Use setdefault to ensure the key exists and initialize lists if not
@@ -3639,9 +3810,13 @@ class LoadPDS:
                 cumindex_table[pds_repo]["external_file_name"].append(
                     external_file_name
                 )
-                cumindex_table[pds_repo]["start_date_utc"].append(start_date_utc)
+                cumindex_table[pds_repo]["start_date_utc"].append(
+                    start_date_utc
+                )
                 cumindex_table[pds_repo]["end_date_utc"].append(end_date_utc)
-                cumindex_table[pds_repo]["creation_date_utc"].append(creation_date_utc)
+                cumindex_table[pds_repo]["creation_date_utc"].append(
+                    creation_date_utc
+                )
 
         # Return the cumindex_table
         return cumindex_table
@@ -3803,12 +3978,14 @@ class LoadPDS:
             )
         else:
             for url_spk_file in url_spk_files:
-                spk_files_to_load = self.dynamic_download_url_files_time_interval(
-                    input_mission,
-                    local_path=local_folder,
-                    start_date=start_date,
-                    end_date=end_date,
-                    url=url_spk_file,
+                spk_files_to_load = (
+                    self.dynamic_download_url_files_time_interval(
+                        input_mission,
+                        local_path=local_folder,
+                        start_date=start_date,
+                        end_date=end_date,
+                        url=url_spk_file,
+                    )
                 )
 
         if spk_files_to_load:
@@ -3826,12 +4003,14 @@ class LoadPDS:
         ]
 
         if len(measured_url_ck_files) == 1:
-            measured_ck_files_to_load = self.dynamic_download_url_files_time_interval(
-                input_mission,
-                local_path=local_folder,
-                start_date=start_date,
-                end_date=end_date,
-                url=measured_url_ck_files[0],
+            measured_ck_files_to_load = (
+                self.dynamic_download_url_files_time_interval(
+                    input_mission,
+                    local_path=local_folder,
+                    start_date=start_date,
+                    end_date=end_date,
+                    url=measured_url_ck_files[0],
+                )
             )
         else:
             for measured_url_ck_file in measured_url_ck_files:
@@ -3854,7 +4033,9 @@ class LoadPDS:
         print(
             f"==========================================================================================================="
         )
-        print(f"Download {input_mission.upper()} Tropospheric Corrections Files")
+        print(
+            f"Download {input_mission.upper()} Tropospheric Corrections Files"
+        )
         url_tropo_files = "https://pds-geosciences.wustl.edu/grail/grail-l-rss-2-edr-v1/grail_0201/ancillary/tro/"
         tropo_files_to_load = self.dynamic_download_url_files_time_interval(
             input_mission,
@@ -4043,12 +4224,14 @@ class LoadPDS:
             )
         else:
             for url_spk_file in url_spk_files:
-                spk_files_to_load = self.dynamic_download_url_files_time_interval(
-                    input_mission,
-                    local_path=local_folder,
-                    start_date=start_date,
-                    end_date=end_date,
-                    url=url_spk_file,
+                spk_files_to_load = (
+                    self.dynamic_download_url_files_time_interval(
+                        input_mission,
+                        local_path=local_folder,
+                        start_date=start_date,
+                        end_date=end_date,
+                        url=url_spk_file,
+                    )
                 )
 
         if spk_files_to_load:
@@ -4066,12 +4249,14 @@ class LoadPDS:
         ]
 
         if len(measured_url_ck_files) == 1:
-            measured_ck_files_to_load = self.dynamic_download_url_files_time_interval(
-                input_mission,
-                local_path=local_folder,
-                start_date=start_date,
-                end_date=end_date,
-                url=measured_url_ck_files[0],
+            measured_ck_files_to_load = (
+                self.dynamic_download_url_files_time_interval(
+                    input_mission,
+                    local_path=local_folder,
+                    start_date=start_date,
+                    end_date=end_date,
+                    url=measured_url_ck_files[0],
+                )
             )
         else:
             for measured_url_ck_file in measured_url_ck_files:
@@ -4094,7 +4279,9 @@ class LoadPDS:
         print(
             f"==========================================================================================================="
         )
-        print(f"Download {input_mission.upper()} Tropospheric Corrections Files")
+        print(
+            f"Download {input_mission.upper()} Tropospheric Corrections Files"
+        )
         url_tropo_files = "https://pds-geosciences.wustl.edu/grail/grail-l-rss-2-edr-v1/grail_0201/ancillary/tro/"
         tropo_files_to_load = self.dynamic_download_url_files_time_interval(
             input_mission,
@@ -4134,7 +4321,6 @@ class LoadPDS:
             self.ancillary_files_to_load,
         )
 
-
     ########################################################################################################################################
     ########################################## END OF GRAIL-B SECTION ####################################################################
     ########################################################################################################################################
@@ -4143,9 +4329,8 @@ class LoadPDS:
     ########################################## START OF ROSETTA SECTION ####################################################################
     ########################################################################################################################################
 
-
     def get_ro_files(
-            self, local_folder, start_date, end_date, radio_observation_type=None
+        self, local_folder, start_date, end_date, radio_observation_type=None
     ):
         """
         Description:
@@ -4234,9 +4419,9 @@ class LoadPDS:
             for closed_loop_type in ["IFMS/DP2/", "DSN/DPS/", "DSN/DPX/"]:
                 try:
                     url_radio_science_file = (
-                            url_radio_science_file_new
-                            + "DATA/LEVEL02/CLOSED_LOOP/"
-                            + closed_loop_type
+                        url_radio_science_file_new
+                        + "DATA/LEVEL02/CLOSED_LOOP/"
+                        + closed_loop_type
                     )
                     files = self.dynamic_download_url_files_single_time(
                         input_mission,
@@ -4258,7 +4443,6 @@ class LoadPDS:
         url_clock_files = (
             "https://spiftp.esac.esa.int/data/SPICE/ROSETTA/kernels/sclk/"
         )
-
 
         # wanted_clock_files = self.get_latest_clock_kernel_name(input_mission)
         wanted_clock_files = [
@@ -4315,7 +4499,6 @@ class LoadPDS:
         spk_files_to_load = []
 
         # TODO: check which files to download
-
 
         if len(url_spk_files) == 1:
             spk_files_to_load = self.dynamic_download_url_files_time_interval(
@@ -4392,17 +4575,13 @@ class LoadPDS:
             self.ancillary_files_to_load,
         )
 
-
     #########################################################################################################
     def get_url_ro_radio_science_files(
-            self, start_date_ro, end_date_ro, radio_observation_type=None
+        self, start_date_ro, end_date_ro, radio_observation_type=None
     ):
 
         url = "https://archives.esac.esa.int/psa/ftp/INTERNATIONAL-ROSETTA-MISSION/RSI/RO-C-RSI-1-2-3-EXT3-1881-V1.0/AAREADME.TXT"
-        radio_science_base_url = (
-            "https://archives.esac.esa.int/psa/ftp/INTERNATIONAL-ROSETTA-MISSION/RSI/"
-        )
-
+        radio_science_base_url = "https://archives.esac.esa.int/psa/ftp/INTERNATIONAL-ROSETTA-MISSION/RSI/"
 
         mapping_dict = self.get_ro_rsi_volume_ID_mapping(url)
         mapping_dict = self.add_ro_mission_phase_designation(mapping_dict)
@@ -4421,7 +4600,6 @@ class LoadPDS:
             start_date_ro, end_date_ro, mapping_dict
         )
 
-
         if self.get_ro_rsi_volume_ID(start_date_ro, end_date_ro, mapping_dict):
             # Here, rsi_volume_ID_list is assumed to be a list of keys (rsi_volume_id strings)
             for rsi_id in rsi_volume_ID_list:
@@ -4432,15 +4610,22 @@ class LoadPDS:
 
                     target = entry.get("target", "").strip()
                     abbn = entry.get("abbn", "").strip()
-                    rsi_volume_ID_num = entry.get("rsi_volume_id_num", "").strip()
-
+                    rsi_volume_ID_num = entry.get(
+                        "rsi_volume_id_num", ""
+                    ).strip()
 
                     # Construct the URL using the target, Abbn and rsi_volume_id.
                     # The URL pattern:
                     # "https://archives.esac.esa.int/psa/ftp/INTERNATIONAL-ROSETTA-MISSION/RSI/RO-X-RSI-1-2-3-PPP-RRRR-V1.0/"
                     volume_ID_url = (
-                            radio_science_base_url +
-                            "RO-" + target + "-RSI-1-2-3-" + abbn + "-" + rsi_volume_ID_num + "-V1.0/"
+                        radio_science_base_url
+                        + "RO-"
+                        + target
+                        + "-RSI-1-2-3-"
+                        + abbn
+                        + "-"
+                        + rsi_volume_ID_num
+                        + "-V1.0/"
                     )
                     # Check if URL exists with a HEAD request
                     response = requests.head(volume_ID_url)
@@ -4452,7 +4637,6 @@ class LoadPDS:
                 except Exception as e:
                     print(f"Error occurred for rsi_volume_id {rsi_id}: {e}")
                     continue
-
 
         if len(self.radio_science_urls) > 0:
             return self.radio_science_urls
@@ -4495,7 +4679,9 @@ class LoadPDS:
                     record_date = item.get("start_date_utc")
                     if record_date is None:
                         # Log or skip entries without a valid date.
-                        print(f"Warning: Missing start_date_utc in item: {item}")
+                        print(
+                            f"Warning: Missing start_date_utc in item: {item}"
+                        )
                         continue
                     # Check if the record_date falls within the input interval.
                     if start_date <= record_date <= end_date:
@@ -4507,9 +4693,9 @@ class LoadPDS:
         if rsi_volume_id_list:
             return rsi_volume_id_list
         else:
-            raise ValueError(f"No RSI Volume_ID found associated with input interval: {start_date} - {end_date}.")
-
-
+            raise ValueError(
+                f"No RSI Volume_ID found associated with input interval: {start_date} - {end_date}."
+            )
 
     #########################################################################################################
 
@@ -4528,32 +4714,35 @@ class LoadPDS:
               - "Abbn": the mission phase abbreviation.
               - "target": the target designation ("X" for non-target-specific or pre-comet phases, "C" for comet, "M" for Mars, "A" for asteroid flybys).
 
-    """
-
+        """
 
         # Define the mission phase date ranges for the Rosetta mission, in which RSI experiments were conducted.
         mission_phases = {
-            'CVP1': {'start': '2004-03-05',     'end': '2004-06-06'},
-            'CVP2': {'start': '2004-09-06',     'end': '2004-10-16'},
-            'CR2':  {'start': '2005-04-05',     'end': '2006-07-28'},
-            'MARS': {'start': '2006-07-29',     'end': '2007-05-28'},
-            'EAR2': {'start': '2007-09-13',     'end': '2008-01-27'},
-            'CR4B': {'start': '2008-10-06',     'end': '2009-09-13'},
-            'AST2': {'start': '2010-05-17',     'end': '2010-09-03'},
-            'PRL':  {'start': '2014-01-21',     'end': '2014-11-19'},
-            'ESC1': {'start': '2014-11-20',     'end': '2015-03-10'},
-            'ESC2': {'start': '2015-03-11',     'end': '2015-06-30'},
-            'ESC3': {'start': '2015-07-01',     'end': '2015-10-21'},
-            'ESC4': {'start': '2015-10-22',     'end': '2015-12-31'},
-            'EXT1': {'start': '2016-01-01',     'end': '2016-04-05'},
-            'EXT2': {'start': '2016-04-06',     'end': '2016-06-30'},
-            'EXT3': {'start': '2016-07-01',     'end': '2016-09-30'},
+            "CVP1": {"start": "2004-03-05", "end": "2004-06-06"},
+            "CVP2": {"start": "2004-09-06", "end": "2004-10-16"},
+            "CR2": {"start": "2005-04-05", "end": "2006-07-28"},
+            "MARS": {"start": "2006-07-29", "end": "2007-05-28"},
+            "EAR2": {"start": "2007-09-13", "end": "2008-01-27"},
+            "CR4B": {"start": "2008-10-06", "end": "2009-09-13"},
+            "AST2": {"start": "2010-05-17", "end": "2010-09-03"},
+            "PRL": {"start": "2014-01-21", "end": "2014-11-19"},
+            "ESC1": {"start": "2014-11-20", "end": "2015-03-10"},
+            "ESC2": {"start": "2015-03-11", "end": "2015-06-30"},
+            "ESC3": {"start": "2015-07-01", "end": "2015-10-21"},
+            "ESC4": {"start": "2015-10-22", "end": "2015-12-31"},
+            "EXT1": {"start": "2016-01-01", "end": "2016-04-05"},
+            "EXT2": {"start": "2016-04-06", "end": "2016-06-30"},
+            "EXT3": {"start": "2016-07-01", "end": "2016-09-30"},
         }
 
         for phase, dates in mission_phases.items():
             # Convert the start date and end date string using the provided method.
-            dates['start_dt'] = self.format_string_to_datetime(dates['start']).date()
-            dates['end_dt'] = self.format_string_to_datetime(dates['end']).date()
+            dates["start_dt"] = self.format_string_to_datetime(
+                dates["start"]
+            ).date()
+            dates["end_dt"] = self.format_string_to_datetime(
+                dates["end"]
+            ).date()
 
         # Cache mapping: map each unique entry start date (as date object) to its phase abbreviation.
         date_to_phase = {}
@@ -4567,37 +4756,35 @@ class LoadPDS:
         for d in unique_dates:
             found_phase = None
             for phase, data in mission_phases.items():
-                start_dt = data['start_dt']
-                end_dt = data['end_dt']
-                if ((start_dt is None or d >= start_dt) and
-                        (end_dt is None or d <= end_dt)):
+                start_dt = data["start_dt"]
+                end_dt = data["end_dt"]
+                if (start_dt is None or d >= start_dt) and (
+                    end_dt is None or d <= end_dt
+                ):
                     found_phase = phase
                     break
             date_to_phase[d] = found_phase
 
-
-
         # Define a mapping from mission phase abbreviation to target designation.
         # (X: early/launch phases, C: comet target, M: Mars, A: asteroid)
         phase_to_target = {
-            'CVP1': 'X',
-            'CVP2': 'X',
-            'CR2': 'X',
-            'MARS': 'M',
-            'EAR2': 'X',
-            'AST2': 'A',
-            'CR4B': 'X',
+            "CVP1": "X",
+            "CVP2": "X",
+            "CR2": "X",
+            "MARS": "M",
+            "EAR2": "X",
+            "AST2": "A",
+            "CR4B": "X",
             # After the flybys, the mission target becomes the comet (67P)
-            'PRL': 'C',
-            'ESC1': 'C',
-            'ESC2': 'C',
-            'ESC3': 'C',
-            'ESC4': 'C',
-            'EXT1': 'C',
-            'EXT2': 'C',
-            'EXT3': 'C',
+            "PRL": "C",
+            "ESC1": "C",
+            "ESC2": "C",
+            "ESC3": "C",
+            "ESC4": "C",
+            "EXT1": "C",
+            "EXT2": "C",
+            "EXT3": "C",
         }
-
 
         # Update each entry in mapping_dict, adding both the mission phase abbreviation ("abbn")
         # and the corresponding target designation ("target").
@@ -4613,7 +4800,6 @@ class LoadPDS:
                     entry["target"] = None
 
         return mapping_dict
-
 
     #########################################################################################################
 
@@ -4656,7 +4842,9 @@ class LoadPDS:
             # Remove the "RORSI_" prefix to keep only the numeric part.
             rsi_volume_id_num = full_rsi_volume_id.replace("RORSI_", "")
             volume_id = match.group(2)
-            start_date_file = match.group(3) if len(match.group(3)) == 10 else None
+            start_date_file = (
+                match.group(3) if len(match.group(3)) == 10 else None
+            )
             start_date_utc = (
                 self.format_string_to_datetime(start_date_file)
                 if start_date_file is not None
@@ -4687,20 +4875,21 @@ class LoadPDS:
 ########################################## END OF ROSETTA SECTION ####################################################################
 ########################################################################################################################################
 
+
 class DownloadAtmosphericData:
     def download_ionex_vmf3_files(
-            self,
-            start_utc: str,
-            end_utc: str,
-            dac: str = "JPL",
-            typ: str = "FIN",
-            smp: str = "02H",
-            vmf_technique: str = "GNSS",
-            ionex_repo: str = "Data/ionex_temp",
-            vmf3_repo: str = "Data/vmf3_temp",
-            ionex: bool = True,
-            vmf3: bool = True,
-            clear_repository: bool = False
+        self,
+        start_utc: str,
+        end_utc: str,
+        dac: str = "JPL",
+        typ: str = "FIN",
+        smp: str = "02H",
+        vmf_technique: str = "GNSS",
+        ionex_repo: str = "Data/ionex_temp",
+        vmf3_repo: str = "Data/vmf3_temp",
+        ionex: bool = True,
+        vmf3: bool = True,
+        clear_repository: bool = False,
     ):
         # Ensure local directories exist
         os.makedirs(ionex_repo, exist_ok=True)
@@ -4718,39 +4907,53 @@ class DownloadAtmosphericData:
         # Get DOY range
         year = start_utc[0:4]
         base_date = year + "-01-01T00:00:00"
-        doy0 = calendar_date_to_julian_day(datetime_to_python(date_time_from_iso_string(base_date)))
+        doy0 = calendar_date_to_julian_day(
+            datetime_to_python(date_time_from_iso_string(base_date))
+        )
 
         doy_start = int(
-            calendar_date_to_julian_day(datetime_to_python(date_time_from_iso_string(start_utc))) - doy0)
+            calendar_date_to_julian_day(
+                datetime_to_python(date_time_from_iso_string(start_utc))
+            )
+            - doy0
+        )
         doy_end = int(
-            calendar_date_to_julian_day(datetime_to_python(date_time_from_iso_string(end_utc))) - doy0)
+            calendar_date_to_julian_day(
+                datetime_to_python(date_time_from_iso_string(end_utc))
+            )
+            - doy0
+        )
 
         # Prepare HTTP session
         session = requests.Session()
-        session.auth = requests.auth.HTTPBasicAuth('', '')  # Use .netrc
+        session.auth = requests.auth.HTTPBasicAuth("", "")  # Use .netrc
 
         for doy in range(doy_start, doy_end + 1):
             doy_str = f"{doy+1:03d}"  # +1 since doy0 corresponds to Jan 1
 
             if ionex:
                 # Build IONEX filename and URL
-                ionex_filename = f"{dac}0OPS{typ}_{year}{doy_str}0000_01D_{smp}_GIM.INX.gz"
+                ionex_filename = (
+                    f"{dac}0OPS{typ}_{year}{doy_str}0000_01D_{smp}_GIM.INX.gz"
+                )
                 ionex_url = f"https://cddis.nasa.gov/archive/gnss/products/ionex/{year}/{doy_str}/{ionex_filename}"
                 ionex_path = os.path.join(ionex_repo, ionex_filename)
-                ionex_path_unzipped = ionex_path[:-3] # remove .gz
+                ionex_path_unzipped = ionex_path[:-3]  # remove .gz
 
                 try:
                     print(f"🔽 Downloading IONEX: {ionex_url}")
                     response = session.get(ionex_url, allow_redirects=True)
                     if response.status_code == 200:
-                        with open(ionex_path, 'wb') as f:
+                        with open(ionex_path, "wb") as f:
                             f.write(response.content)
                         print(f"IONEX data saved to: {ionex_path}")
                     else:
-                        print(f"Failed IONEX data retrieval from {ionex_url} (status: {response.status_code})")
+                        print(
+                            f"Failed IONEX data retrieval from {ionex_url} (status: {response.status_code})"
+                        )
                     # 🔓 Unzip the file
-                    with gzip.open(ionex_path, 'rb') as f_in:
-                        with open(ionex_path_unzipped, 'wb') as f_out:
+                    with gzip.open(ionex_path, "rb") as f_in:
+                        with open(ionex_path_unzipped, "wb") as f_out:
                             shutil.copyfileobj(f_in, f_out)
                     print(f"Unzipped IONEX data to: {ionex_path_unzipped}")
                 except Exception as e:
@@ -4758,7 +4961,7 @@ class DownloadAtmosphericData:
 
             if vmf3:
                 # Build VMF3 filename and URL
-                assert (vmf_technique in ("VLBI", "GNSS"))
+                assert vmf_technique in ("VLBI", "GNSS")
                 if vmf_technique == "VLBI":
                     vmf3_format = "v3gr_r"
                 if vmf_technique == "GNSS":
@@ -4771,10 +4974,12 @@ class DownloadAtmosphericData:
                     print(f"🔽 Downloading VMF3: {vmf3_url}")
                     response = session.get(vmf3_url, allow_redirects=True)
                     if response.status_code == 200:
-                        with open(vmf3_path, 'wb') as f:
+                        with open(vmf3_path, "wb") as f:
                             f.write(response.content)
                         print(f"VMF3 data saved to: {vmf3_path}")
                     else:
-                        print(f"Failed to retrieve VMF3 data from {vmf3_url} (status: {response.status_code})")
+                        print(
+                            f"Failed to retrieve VMF3 data from {vmf3_url} (status: {response.status_code})"
+                        )
                 except Exception as e:
                     print(f"Error downloading VMF3 data from {vmf3_url}: {e}")

--- a/src/tudatpy/dynamics/environment/expose_environment.cpp
+++ b/src/tudatpy/dynamics/environment/expose_environment.cpp
@@ -50,8 +50,7 @@ namespace tudat
 namespace aerodynamics
 {
 
-double getTotalSurfaceArea(
-        const std::shared_ptr< HypersonicLocalInclinationAnalysis > coefficientGenerator )
+double getTotalSurfaceArea( const std::shared_ptr< HypersonicLocalInclinationAnalysis > coefficientGenerator )
 {
     double totalSurfaceArea = 0.0;
     for( int i = 0; i < coefficientGenerator->getNumberOfVehicleParts( ); i++ )
@@ -66,10 +65,8 @@ double getTotalSurfaceArea(
 std::pair< std::vector< Eigen::Vector3d >, std::vector< Eigen::Vector3d > > getVehicleMesh(
         const std::shared_ptr< HypersonicLocalInclinationAnalysis > localInclinationAnalysis )
 {
-    std::vector< boost::multi_array< Eigen::Vector3d, 2 > > meshPoints =
-            localInclinationAnalysis->getMeshPoints( );
-    std::vector< boost::multi_array< Eigen::Vector3d, 2 > > meshSurfaceNormals =
-            localInclinationAnalysis->getPanelSurfaceNormals( );
+    std::vector< boost::multi_array< Eigen::Vector3d, 2 > > meshPoints = localInclinationAnalysis->getMeshPoints( );
+    std::vector< boost::multi_array< Eigen::Vector3d, 2 > > meshSurfaceNormals = localInclinationAnalysis->getPanelSurfaceNormals( );
 
     //    boost::array< int, 3 > independentVariables;
     //    independentVariables[ 0 ] = 0;
@@ -235,14 +232,14 @@ void expose_environment( py::module& m )
                                                                                                   "ConstantEphemeris",
                                                                                                   R"doc(No documentation found.)doc" )
             .def( py::init< const std::function< Eigen::Vector6d( ) >,  //<pybind11/functional.h>,<pybind11/eigen.h>
-                            const std::string &,
-                            const std::string & >( ),
+                            const std::string&,
+                            const std::string& >( ),
                   py::arg( "constant_state_function" ),
                   py::arg( "reference_frame_origin" ) = "SSB",
                   py::arg( "reference_frame_orientation" ) = "ECLIPJ2000" )
             .def( py::init< const Eigen::Vector6d,  //<pybind11/eigen.h>
-                            const std::string &,
-                            const std::string & >( ),
+                            const std::string&,
+                            const std::string& >( ),
                   py::arg( "constant_state" ),
                   py::arg( "reference_frame_origin" ) = "SSB",
                   py::arg( "reference_frame_orientation" ) = "ECLIPJ2000" )
@@ -254,7 +251,7 @@ void expose_environment( py::module& m )
     py::class_< te::KeplerEphemeris, std::shared_ptr< te::KeplerEphemeris >, te::Ephemeris >( m, "KeplerEphemeris" );
 
     py::class_< te::MultiArcEphemeris, std::shared_ptr< te::MultiArcEphemeris >, te::Ephemeris >( m, "MultiArcEphemeris" )
-            .def( py::init< const std::map< double, std::shared_ptr< te::Ephemeris > > &, const std::string &, const std::string & >( ),
+            .def( py::init< const std::map< double, std::shared_ptr< te::Ephemeris > >&, const std::string&, const std::string& >( ),
                   py::arg( "single_arc_ephemerides" ),
                   py::arg( "reference_frame_origin" ) = "SSB",
                   py::arg( "reference_frame_orientation" ) = "ECLIPJ2000" );
@@ -269,11 +266,11 @@ void expose_environment( py::module& m )
 
     py::class_< te::Tle, std::shared_ptr< te::Tle > >( m, "Tle" )
             .def( py::init<  // ctor 1
-                          const std::string & >( ),
+                          const std::string& >( ),
                   py::arg( "lines" ) )
             .def( py::init<  // ctor 2
-                          const std::string &,
-                          const std::string & >( ),
+                          const std::string&,
+                          const std::string& >( ),
                   py::arg( "line_1" ),
                   py::arg( "line_2" ) )
             .def( "get_epoch", &te::Tle::getEpoch )
@@ -287,7 +284,7 @@ void expose_environment( py::module& m )
             .def( "get_mean_motion", &te::Tle::getMeanMotion );
 
     py::class_< te::TleEphemeris, std::shared_ptr< te::TleEphemeris >, te::Ephemeris >( m, "TleEphemeris" )
-            .def( py::init< const std::string &, const std::string &, const std::shared_ptr< te::Tle >, const bool >( ),
+            .def( py::init< const std::string&, const std::string&, const std::shared_ptr< te::Tle >, const bool >( ),
                   py::arg( "frame_origin" ) = "Earth",
                   py::arg( "frame_orientation" ) = "J2000",
                   py::arg( "tle" ) = nullptr,
@@ -307,8 +304,6 @@ Provides the vertical total electron content (VTEC) in TECU (1 TECU = 1e16 e-/mÂ
 This is the base class from which models like TabulatedIonosphereModel or GlobalIonosphereModelVtecCalculator retrieve electron content data. The model is typically stored
 inside a `Body` instance and used in observation corrections or environmental queries.
 )doc" );
-
-
 
     py::class_< ta::AtmosphereModel, std::shared_ptr< ta::AtmosphereModel > >( m,
                                                                                "AtmosphereModel",
@@ -466,8 +461,7 @@ inside a `Body` instance and used in observation corrections or environmental qu
 
      )doc" );
 
-    py::class_< ta::AerodynamicCoefficientInterface,
-                std::shared_ptr< ta::AerodynamicCoefficientInterface > >(
+    py::class_< ta::AerodynamicCoefficientInterface, std::shared_ptr< ta::AerodynamicCoefficientInterface > >(
             m,
             "AerodynamicCoefficientInterface",
             R"doc(
@@ -498,10 +492,9 @@ inside a `Body` instance and used in observation corrections or environmental qu
 
          :type: float
       )doc" )
-            .def_property_readonly(
-                    "current_force_coefficients",
-                    &ta::AerodynamicCoefficientInterface::getCurrentForceCoefficients,
-                    R"doc(
+            .def_property_readonly( "current_force_coefficients",
+                                    &ta::AerodynamicCoefficientInterface::getCurrentForceCoefficients,
+                                    R"doc(
 
          **read-only**
 
@@ -511,10 +504,9 @@ inside a `Body` instance and used in observation corrections or environmental qu
 
          :type: numpy.ndarray
       )doc" )
-            .def_property_readonly(
-                    "current_moment_coefficients",
-                    &ta::AerodynamicCoefficientInterface::getCurrentMomentCoefficients,
-                    R"doc(
+            .def_property_readonly( "current_moment_coefficients",
+                                    &ta::AerodynamicCoefficientInterface::getCurrentMomentCoefficients,
+                                    R"doc(
 
          **read-only**
 
@@ -524,10 +516,9 @@ inside a `Body` instance and used in observation corrections or environmental qu
 
          :type: numpy.ndarray
       )doc" )
-            .def_property_readonly(
-                    "current_coefficients",
-                    &ta::AerodynamicCoefficientInterface::getCurrentAerodynamicCoefficients,
-                    R"doc(
+            .def_property_readonly( "current_coefficients",
+                                    &ta::AerodynamicCoefficientInterface::getCurrentAerodynamicCoefficients,
+                                    R"doc(
 
          **read-only**
 
@@ -547,10 +538,9 @@ inside a `Body` instance and used in observation corrections or environmental qu
 
          :type: AerodynamicCoefficientFrames
       )doc" )
-            .def_property_readonly(
-                    "moment_coefficient_frame",
-                    &ta::AerodynamicCoefficientInterface::getMomentCoefficientsFrame,
-                    R"doc(
+            .def_property_readonly( "moment_coefficient_frame",
+                                    &ta::AerodynamicCoefficientInterface::getMomentCoefficientsFrame,
+                                    R"doc(
 
          **read-only**
 
@@ -559,10 +549,9 @@ inside a `Body` instance and used in observation corrections or environmental qu
 
          :type: AerodynamicCoefficientFrames
       )doc" )
-            .def_property_readonly(
-                    "independent_variable_names",
-                    &ta::AerodynamicCoefficientInterface::getIndependentVariableNames,
-                    R"doc(
+            .def_property_readonly( "independent_variable_names",
+                                    &ta::AerodynamicCoefficientInterface::getIndependentVariableNames,
+                                    R"doc(
 
          **read-only**
 
@@ -572,8 +561,7 @@ inside a `Body` instance and used in observation corrections or environmental qu
          :type: list[AerodynamicCoefficientsIndependentVariables]
       )doc" )
             .def_property_readonly( "current_control_surface_free_force_coefficients",
-                                    &ta::AerodynamicCoefficientInterface::
-                                            getCurrentControlSurfaceFreeForceCoefficients,
+                                    &ta::AerodynamicCoefficientInterface::getCurrentControlSurfaceFreeForceCoefficients,
                                     R"doc(
 
          **read-only**
@@ -584,8 +572,7 @@ inside a `Body` instance and used in observation corrections or environmental qu
          :type: numpy.ndarray
       )doc" )
             .def_property_readonly( "current_control_surface_free_moment_coefficients",
-                                    &ta::AerodynamicCoefficientInterface::
-                                            getCurrentControlSurfaceFreeMomentCoefficients,
+                                    &ta::AerodynamicCoefficientInterface::getCurrentControlSurfaceFreeMomentCoefficients,
                                     R"doc(
 
          **read-only**
@@ -595,10 +582,9 @@ inside a `Body` instance and used in observation corrections or environmental qu
 
          :type: numpy.ndarray
       )doc" )
-            .def_property_readonly(
-                    "control_surface_independent_variable_names",
-                    &ta::AerodynamicCoefficientInterface::getControlSurfaceIndependentVariables,
-                    R"doc(
+            .def_property_readonly( "control_surface_independent_variable_names",
+                                    &ta::AerodynamicCoefficientInterface::getControlSurfaceIndependentVariables,
+                                    R"doc(
 
          **read-only**
 
@@ -739,22 +725,20 @@ inside a `Body` instance and used in observation corrections or environmental qu
 
     py::class_< ta::AerodynamicCoefficientGenerator< 3, 6 >,
                 std::shared_ptr< ta::AerodynamicCoefficientGenerator< 3, 6 > >,
-                ta::AerodynamicCoefficientInterface >(
-            m, "AerodynamicCoefficientGenerator36", "<no_doc, only_dec>" );
+                ta::AerodynamicCoefficientInterface >( m, "AerodynamicCoefficientGenerator36", "<no_doc, only_dec>" );
 
     py::class_< ta::HypersonicLocalInclinationAnalysis,
                 std::shared_ptr< ta::HypersonicLocalInclinationAnalysis >,
-                ta::AerodynamicCoefficientGenerator< 3, 6 > >(
-            m, "HypersonicLocalInclinationAnalysis" )
-            .def( py::init< const std::vector< std::vector< double > > &,
+                ta::AerodynamicCoefficientGenerator< 3, 6 > >( m, "HypersonicLocalInclinationAnalysis" )
+            .def( py::init< const std::vector< std::vector< double > >&,
                             const std::shared_ptr< tudat::SurfaceGeometry >,
-                            const std::vector< int > &,
-                            const std::vector< int > &,
-                            const std::vector< bool > &,
-                            const std::vector< std::vector< int > > &,
+                            const std::vector< int >&,
+                            const std::vector< int >&,
+                            const std::vector< bool >&,
+                            const std::vector< std::vector< int > >&,
                             const double,
                             const double,
-                            const Eigen::Vector3d &,
+                            const Eigen::Vector3d&,
                             const bool >( ),
                   py::arg( "independent_variable_points" ),
                   py::arg( "body_shape" ),
@@ -836,17 +820,15 @@ inside a `Body` instance and used in observation corrections or environmental qu
      )doc" )
             .def( "clear_data", &ta::HypersonicLocalInclinationAnalysis::clearData );
 
-    py::class_< ta::ControlSurfaceIncrementAerodynamicInterface,
-                std::shared_ptr< ta::ControlSurfaceIncrementAerodynamicInterface > >(
+    py::class_< ta::ControlSurfaceIncrementAerodynamicInterface, std::shared_ptr< ta::ControlSurfaceIncrementAerodynamicInterface > >(
             m, "ControlSurfaceIncrementAerodynamicInterface", "<no_doc, only_dec>" );
 
     py::class_< ta::CustomControlSurfaceIncrementAerodynamicInterface,
                 std::shared_ptr< ta::CustomControlSurfaceIncrementAerodynamicInterface >,
                 ta::ControlSurfaceIncrementAerodynamicInterface >(
             m, "CustomControlSurfaceIncrementAerodynamicInterface", "<no_doc, only_dec>" )
-            .def( py::init<
-                          const std::function< Eigen::Vector6d( const std::vector< double > & ) >,
-                          const std::vector< ta::AerodynamicCoefficientsIndependentVariables > >( ),
+            .def( py::init< const std::function< Eigen::Vector6d( const std::vector< double >& ) >,
+                            const std::vector< ta::AerodynamicCoefficientsIndependentVariables > >( ),
                   py::arg( "coefficient_function" ),
                   py::arg( "independent_variable_names" ) );
 
@@ -854,11 +836,9 @@ inside a `Body` instance and used in observation corrections or environmental qu
            &ta::getDefaultHypersonicLocalInclinationMachPoints,
            py::arg( "mach_regime" ) = "Full" );
 
-    m.def( "get_default_local_inclination_angle_of_attack_points",
-           &ta::getDefaultHypersonicLocalInclinationAngleOfAttackPoints );
+    m.def( "get_default_local_inclination_angle_of_attack_points", &ta::getDefaultHypersonicLocalInclinationAngleOfAttackPoints );
 
-    m.def( "get_default_local_inclination_sideslip_angle_points",
-           &ta::getDefaultHypersonicLocalInclinationAngleOfSideslipPoints );
+    m.def( "get_default_local_inclination_sideslip_angle_points", &ta::getDefaultHypersonicLocalInclinationAngleOfSideslipPoints );
 
     m.def( "save_vehicle_mesh_to_file",
            &ta::saveVehicleMeshToFile,
@@ -895,13 +875,9 @@ inside a `Body` instance and used in observation corrections or environmental qu
 
      )doc" );
 
-    m.def( "get_local_inclination_total_vehicle_area",
-           &ta::getTotalSurfaceArea,
-           py::arg( "local_inclination_analysis_object" ) );
+    m.def( "get_local_inclination_total_vehicle_area", &ta::getTotalSurfaceArea, py::arg( "local_inclination_analysis_object" ) );
 
-    m.def( "get_local_inclination_mesh",
-           &ta::getVehicleMesh,
-           py::arg( "local_inclination_analysis_object" ) );
+    m.def( "get_local_inclination_mesh", &ta::getVehicleMesh, py::arg( "local_inclination_analysis_object" ) );
 
     py::class_< tsm::VehicleSystems, std::shared_ptr< tsm::VehicleSystems > >( m, "VehicleSystems", R"doc(
 
@@ -944,7 +920,7 @@ inside a `Body` instance and used in observation corrections or environmental qu
 
      )doc" )
             .def( "set_transponder_turnaround_ratio",
-                  py::overload_cast< std::map< std::pair< tom::FrequencyBands, tom::FrequencyBands >, double > & >(
+                  py::overload_cast< std::map< std::pair< tom::FrequencyBands, tom::FrequencyBands >, double >& >(
                           &tsm::VehicleSystems::setTransponderTurnaroundRatio ),
                   py::arg( "transponder_ratio_per_uplink_and_downlink_"
                            "frequency_band" ),
@@ -982,7 +958,7 @@ inside a `Body` instance and used in observation corrections or environmental qu
 
      )doc" )
             .def( "set_reference_point",
-                  py::overload_cast< const std::string, const Eigen::Vector3d &, const std::string, const std::string >(
+                  py::overload_cast< const std::string, const Eigen::Vector3d&, const std::string, const std::string >(
                           &tsm::VehicleSystems::setReferencePointPosition ),
                   py::arg( "reference_point" ),
                   py::arg( "location" ),
@@ -1022,8 +998,7 @@ inside a `Body` instance and used in observation corrections or environmental qu
      )doc" )
             .def( "set_timing_system", &tsm::VehicleSystems::setTimingSystem, py::arg( "timing_system" ) );
 
-    py::class_< tss::RigidBodyProperties, std::shared_ptr< tss::RigidBodyProperties > >(
-            m, "RigidBodyProperties", R"doc(
+    py::class_< tss::RigidBodyProperties, std::shared_ptr< tss::RigidBodyProperties > >( m, "RigidBodyProperties", R"doc(
 
          Object that defines the mass, center of mass, and inertia tensor as a function of time.
 
@@ -1070,16 +1045,14 @@ inside a `Body` instance and used in observation corrections or environmental qu
 
       )doc" );
 
-    py::class_< tsm::TimingSystem, std::shared_ptr< tsm::TimingSystem > >(
-            m,
-            "TimingSystem",
-            R"doc(No documentation found.)doc" )
+    py::class_< tsm::TimingSystem, std::shared_ptr< tsm::TimingSystem > >( m,
+                                                                           "TimingSystem",
+                                                                           R"doc(No documentation found.)doc" )
 
             .def(  // ctor 1
                     py::init< const std::vector< tudat::Time >,
                               const std::vector< double >,
-                              const std::function< std::function< double( const double ) >(
-                                      const double, const double, const double ) >,
+                              const std::function< std::function< double( const double ) >( const double, const double, const double ) >,
                               const double >( ),
                     py::arg( "arc_times" ),
                     py::arg( "all_arcs_polynomial_drift_coefficients" ) = std::vector< double >( ),
@@ -1088,8 +1061,7 @@ inside a `Body` instance and used in observation corrections or environmental qu
             .def(  // ctor 2
                     py::init< const std::vector< tudat::Time >,
                               const std::vector< std::vector< double > >,
-                              const std::function< std::function< double( const double ) >(
-                                      const double, const double, const double ) >,
+                              const std::function< std::function< double( const double ) >( const double, const double, const double ) >,
                               const double >( ),
                     py::arg( "arc_times" ),
                     py::arg( "polynomial_drift_coefficients" ),
@@ -1104,18 +1076,14 @@ inside a `Body` instance and used in observation corrections or environmental qu
                     py::arg( "arc_times" ) );
 
     py::class_< tsm::EngineModel, std::shared_ptr< tsm::EngineModel > >( m, "EngineModel" )
-            .def_property_readonly( "thrust_magnitude_calculator",
-                                    &tsm::EngineModel::getThrustMagnitudeWrapper );
+            .def_property_readonly( "thrust_magnitude_calculator", &tsm::EngineModel::getThrustMagnitudeWrapper );
 
     /*!
      **************   FLIGHT CONDITIONS AND ASSOCIATED FUNCTIONALITY
      *******************
      */
 
-
-
-    py::class_< trf::AerodynamicAngleCalculator,
-                std::shared_ptr< trf::AerodynamicAngleCalculator > >(
+    py::class_< trf::AerodynamicAngleCalculator, std::shared_ptr< trf::AerodynamicAngleCalculator > >(
             m, "AerodynamicAngleCalculator", R"doc(
 
          Object to calculate (aerodynamic) orientation angles, and frame transformations,
@@ -1200,17 +1168,13 @@ inside a `Body` instance and used in observation corrections or environmental qu
             // Function removed; error is shown
             .def( "set_body_orientation_angle_functions",
                   &trf::AerodynamicAngleCalculator::setOrientationAngleFunctionsRemoved1,
-                  py::arg( "angle_of_attack_function" ) =
-                          std::function< double( ) >( ),  // <pybind11/functional.h>
-                  py::arg( "angle_of_sideslip_function" ) =
-                          std::function< double( ) >( ),  // <pybind11/functional.h>
-                  py::arg( "bank_angle_function" ) =
-                          std::function< double( ) >( ),  // <pybind11/functional.h>
+                  py::arg( "angle_of_attack_function" ) = std::function< double( ) >( ),    // <pybind11/functional.h>
+                  py::arg( "angle_of_sideslip_function" ) = std::function< double( ) >( ),  // <pybind11/functional.h>
+                  py::arg( "bank_angle_function" ) = std::function< double( ) >( ),         // <pybind11/functional.h>
                   py::arg( "angle_update_function" ) = std::function< void( const double ) >( ),
                   py::arg( "silence_warnings" ) = false );
 
-    py::class_< ta::FlightConditions, std::shared_ptr< ta::FlightConditions > >(
-            m, "FlightConditions", R"doc(
+    py::class_< ta::FlightConditions, std::shared_ptr< ta::FlightConditions > >( m, "FlightConditions", R"doc(
 
          Object that calculates various state-derived quantities typically
          relevant for flight dynamics.
@@ -1241,9 +1205,7 @@ inside a `Body` instance and used in observation corrections or environmental qu
             //                 py::arg("aerodynamic_angle_calculator") =
             //                 std::shared_ptr<
             //                 tr::AerodynamicAngleCalculator>())
-            .def( "update_conditions",
-                  &ta::FlightConditions::updateConditions,
-                  py::arg( "current_time" ) )
+            .def( "update_conditions", &ta::FlightConditions::updateConditions, py::arg( "current_time" ) )
             .def_property_readonly( "aerodynamic_angle_calculator",
                                     &ta::FlightConditions::getAerodynamicAngleCalculator,
                                     R"doc(
@@ -1327,9 +1289,8 @@ inside a `Body` instance and used in observation corrections or environmental qu
          :type: float
       )doc" );
 
-    py::class_< ta::AtmosphericFlightConditions,
-                std::shared_ptr< ta::AtmosphericFlightConditions >,
-                ta::FlightConditions >( m, "AtmosphericFlightConditions", R"doc(
+    py::class_< ta::AtmosphericFlightConditions, std::shared_ptr< ta::AtmosphericFlightConditions >, ta::FlightConditions >(
+            m, "AtmosphericFlightConditions", R"doc(
 
          Object that calculates various state-derived quantities typically
          relevant for flight dynamics, for flight in an atmosphere.
@@ -1362,10 +1323,9 @@ inside a `Body` instance and used in observation corrections or environmental qu
 
          :type: float
       )doc" )
-            .def_property_readonly(
-                    "temperature",
-                    &ta::AtmosphericFlightConditions::getCurrentFreestreamTemperature,
-                    R"doc(
+            .def_property_readonly( "temperature",
+                                    &ta::AtmosphericFlightConditions::getCurrentFreestreamTemperature,
+                                    R"doc(
 
          **read-only**
 
@@ -1421,10 +1381,9 @@ inside a `Body` instance and used in observation corrections or environmental qu
 
          :type: float
       )doc" )
-            .def_property_readonly(
-                    "airspeed_velocity",
-                    &ta::AtmosphericFlightConditions::getCurrentAirspeedBasedVelocity,
-                    R"doc(
+            .def_property_readonly( "airspeed_velocity",
+                                    &ta::AtmosphericFlightConditions::getCurrentAirspeedBasedVelocity,
+                                    R"doc(
 
          **read-only**
 
@@ -1446,10 +1405,9 @@ inside a `Body` instance and used in observation corrections or environmental qu
 
          :type: float
       )doc" )
-            .def_property_readonly(
-                    "aero_coefficient_independent_variables",
-                    &ta::AtmosphericFlightConditions::getAerodynamicCoefficientIndependentVariables,
-                    R"doc(
+            .def_property_readonly( "aero_coefficient_independent_variables",
+                                    &ta::AtmosphericFlightConditions::getAerodynamicCoefficientIndependentVariables,
+                                    R"doc(
 
          **read-only**
 
@@ -1465,8 +1423,7 @@ inside a `Body` instance and used in observation corrections or environmental qu
             .def_property_readonly(
                     "control_surface_aero_coefficient_independent_"
                     "variables",
-                    &ta::AtmosphericFlightConditions::
-                            getControlSurfaceAerodynamicCoefficientIndependentVariables,
+                    &ta::AtmosphericFlightConditions::getControlSurfaceAerodynamicCoefficientIndependentVariables,
                     R"doc(
 
          **read-only**
@@ -1482,10 +1439,9 @@ inside a `Body` instance and used in observation corrections or environmental qu
 
          :type: numpy.ndarray
       )doc" )
-            .def_property_readonly(
-                    "aerodynamic_coefficient_interface",
-                    &ta::AtmosphericFlightConditions::getAerodynamicCoefficientInterface,
-                    R"doc(
+            .def_property_readonly( "aerodynamic_coefficient_interface",
+                                    &ta::AtmosphericFlightConditions::getAerodynamicCoefficientInterface,
+                                    R"doc(
 
          **read-only**
 
@@ -1971,17 +1927,13 @@ inside a `Body` instance and used in observation corrections or environmental qu
          :type: list[GravityFieldVariationModel]
         )doc" );
 
-    py::class_< tg::PolyhedronGravityField,
-                std::shared_ptr< tg::PolyhedronGravityField >,
-                tg::GravityFieldModel >( m, "PolyhedronGravityField" )
+    py::class_< tg::PolyhedronGravityField, std::shared_ptr< tg::PolyhedronGravityField >, tg::GravityFieldModel >(
+            m, "PolyhedronGravityField" )
             .def_property_readonly( "volume", &tg::PolyhedronGravityField::getVolume )
-            .def_property_readonly( "vertices_coordinates",
-                                    &tg::PolyhedronGravityField::getVerticesCoordinates )
-            .def_property_readonly( "vertices_defining_each_facet",
-                                    &tg::PolyhedronGravityField::getVerticesDefiningEachFacet );
+            .def_property_readonly( "vertices_coordinates", &tg::PolyhedronGravityField::getVerticesCoordinates )
+            .def_property_readonly( "vertices_defining_each_facet", &tg::PolyhedronGravityField::getVerticesDefiningEachFacet );
 
-    py::class_< tg::GravityFieldVariations, std::shared_ptr< tg::GravityFieldVariations > >(
-            m, "GravityFieldVariationModel", R"doc(
+    py::class_< tg::GravityFieldVariations, std::shared_ptr< tg::GravityFieldVariations > >( m, "GravityFieldVariationModel", R"doc(
 
         Object that computes a single type of gravity field variation.
 
@@ -1991,9 +1943,8 @@ inside a `Body` instance and used in observation corrections or environmental qu
     /*!
      **************   RADIATION MODELS  ******************
      */
-    py::class_< tem::RadiationPressureTargetModel,
-                std::shared_ptr< tem::RadiationPressureTargetModel > >(
-            m, "RadiationPressureTargetModel" );
+    py::class_< tem::RadiationPressureTargetModel, std::shared_ptr< tem::RadiationPressureTargetModel > >( m,
+                                                                                                           "RadiationPressureTargetModel" );
 
     py::class_< tem::CannonballRadiationPressureTargetModel,
                 std::shared_ptr< tem::CannonballRadiationPressureTargetModel >,
@@ -2002,9 +1953,7 @@ inside a `Body` instance and used in observation corrections or environmental qu
                            &tem::CannonballRadiationPressureTargetModel::getCoefficient,
                            &tem::CannonballRadiationPressureTargetModel::resetCoefficient );
 
-    py::class_< tem::RadiationSourceModel,
-        std::shared_ptr< tem::RadiationSourceModel > >(
-        m, "RadiationSourceModel" );
+    py::class_< tem::RadiationSourceModel, std::shared_ptr< tem::RadiationSourceModel > >( m, "RadiationSourceModel" );
     /*!
      **************   SHAPE MODELS  ******************
      */
@@ -2036,8 +1985,7 @@ inside a `Body` instance and used in observation corrections or environmental qu
      *******************
      */
 
-    py::class_< tgs::GroundStationState, std::shared_ptr< tgs::GroundStationState > >(
-            m, "GroundStationState", R"doc(
+    py::class_< tgs::GroundStationState, std::shared_ptr< tgs::GroundStationState > >( m, "GroundStationState", R"doc(
 
          Object that performs computations of the current (body-fixed) position and frame conversions of the ground station.
 
@@ -2111,11 +2059,9 @@ inside a `Body` instance and used in observation corrections or environmental qu
          :type: numpy.ndarray[numpy.float64[3, 1]]
 
      )doc" )
-            .def_property_readonly(
-                    "rotation_matrix_body_fixed_to_topocentric",
-                    &tgs::GroundStationState::
-                            getConstantRotationMatrixFromBodyFixedToTopocentricFrame,
-                    R"doc(
+            .def_property_readonly( "rotation_matrix_body_fixed_to_topocentric",
+                                    &tgs::GroundStationState::getConstantRotationMatrixFromBodyFixedToTopocentricFrame,
+                                    R"doc(
 
          **read-only**
 
@@ -2130,8 +2076,7 @@ inside a `Body` instance and used in observation corrections or environmental qu
 
      )doc" );
 
-    py::class_< tgs::GroundStation, std::shared_ptr< tgs::GroundStation > >(
-            m, "GroundStation", R"doc(
+    py::class_< tgs::GroundStation, std::shared_ptr< tgs::GroundStation > >( m, "GroundStation", R"doc(
 
          Object used to define and store properties of a ground station.
 
@@ -2161,16 +2106,14 @@ inside a `Body` instance and used in observation corrections or environmental qu
          :type: TransmittingFrequencyCalculator
 
      )doc" )
-            .def_property_readonly(
-                    "temperature_function", &tgs::GroundStation::getTemperatureFunction, R"doc(
+            .def_property_readonly( "temperature_function", &tgs::GroundStation::getTemperatureFunction, R"doc(
 
          Function that provides the local temperature at the ground station (typically use for media corrections) as a function of time
 
          :type: :type: Callable[[float], float]
 
      )doc" )
-            .def_property_readonly(
-                    "pressure_function", &tgs::GroundStation::getPressureFunction, R"doc(
+            .def_property_readonly( "pressure_function", &tgs::GroundStation::getPressureFunction, R"doc(
 
          Function that provides the local pressure at the ground station (typically use for media corrections) as a function of time
 
@@ -2197,8 +2140,7 @@ inside a `Body` instance and used in observation corrections or environmental qu
          :type: PointingAnglesCalculator
 
      )doc" )
-            .def_property_readonly(
-                    "station_state", &tgs::GroundStation::getNominalStationState, R"doc(
+            .def_property_readonly( "station_state", &tgs::GroundStation::getNominalStationState, R"doc(
 
          **read-only**
 
@@ -2207,15 +2149,11 @@ inside a `Body` instance and used in observation corrections or environmental qu
          :type: GroundStationState
 
      )doc" )
-            .def( "set_timing_system",
-                  &tgs::GroundStation::setTimingSystem,
-                  py::arg( "timing_system" ) )
+            .def( "set_timing_system", &tgs::GroundStation::setTimingSystem, py::arg( "timing_system" ) )
 
-            .def("set_station_meteo_data", &tudat::ground_stations::GroundStation::setMeteoData, py::arg("meteo_data"));
+            .def( "set_station_meteo_data", &tudat::ground_stations::GroundStation::setMeteoData, py::arg( "meteo_data" ) );
 
-
-    py::class_< tgs::StationFrequencyInterpolator,
-                std::shared_ptr< tgs::StationFrequencyInterpolator > >(
+    py::class_< tgs::StationFrequencyInterpolator, std::shared_ptr< tgs::StationFrequencyInterpolator > >(
             m, "TransmittingFrequencyCalculator", R"doc(No documentation found.)doc" );
 
     py::class_< tgs::ConstantFrequencyInterpolator,
@@ -2234,20 +2172,22 @@ inside a `Body` instance and used in observation corrections or environmental qu
                   py::arg( "end_times" ),
                   py::arg( "ramp_rates" ),
                   py::arg( "start_frequency" ) )
+            .def_property_readonly( "start_times", &tgs::PiecewiseLinearFrequencyInterpolator::getStartTimes )
+            .def_property_readonly( "end_times", &tgs::PiecewiseLinearFrequencyInterpolator::getEndTimes )
+            .def_property_readonly( "ramp_rates", &tgs::PiecewiseLinearFrequencyInterpolator::getRampRates )
+            .def_property_readonly( "start_frequencies", &tgs::PiecewiseLinearFrequencyInterpolator::getStartFrequencies )
             .def( "compute_current_frequency",
                   &tgs::PiecewiseLinearFrequencyInterpolator::computeCurrentFrequency< double, tudat::Time >,
                   py::arg( "lookup_time_original" ) );
 
-    py::class_< tgs::PointingAnglesCalculator, std::shared_ptr< tgs::PointingAnglesCalculator > >(
-            m, "PointingAnglesCalculator" )
+    py::class_< tgs::PointingAnglesCalculator, std::shared_ptr< tgs::PointingAnglesCalculator > >( m, "PointingAnglesCalculator" )
             .def( "calculate_elevation_angle",
-                  py::overload_cast< const Eigen::Vector3d &, const double >(
-                          &tgs::PointingAnglesCalculator::
-                                  calculateElevationAngleFromInertialVector ),
+                  py::overload_cast< const Eigen::Vector3d&, const double >(
+                          &tgs::PointingAnglesCalculator::calculateElevationAngleFromInertialVector ),
                   py::arg( "inertial_vector_to_target" ),
                   py::arg( "time" ) )
             .def( "calculate_azimuth_angle",
-                  py::overload_cast< const Eigen::Vector3d &, const double >(
+                  py::overload_cast< const Eigen::Vector3d&, const double >(
                           &tgs::PointingAnglesCalculator::calculateAzimuthAngleFromInertialVector ),
                   py::arg( "inertial_vector_to_target" ),
                   py::arg( "time" ) )
@@ -2257,26 +2197,23 @@ inside a `Body` instance and used in observation corrections or environmental qu
                   py::arg( "time" ) );
 
     py::enum_< tudat::ground_stations::MeteoDataEntries >( m, "MeteoDataEntries" )
-                  .value( "temperature_meteo_data", tudat::ground_stations::temperature_meteo_data )
-                  .value( "pressure_meteo_data", tudat::ground_stations::pressure_meteo_data )
-                  .value( "water_vapor_pressure_meteo_data", tudat::ground_stations::water_vapor_pressure_meteo_data )
-                  .value( "relative_humidity_meteo_data", tudat::ground_stations::relative_humidity_meteo_data )
-                  .value( "dew_point_meteo_data", tudat::ground_stations::dew_point_meteo_data )
-                  .export_values();
+            .value( "temperature_meteo_data", tudat::ground_stations::temperature_meteo_data )
+            .value( "pressure_meteo_data", tudat::ground_stations::pressure_meteo_data )
+            .value( "water_vapor_pressure_meteo_data", tudat::ground_stations::water_vapor_pressure_meteo_data )
+            .value( "relative_humidity_meteo_data", tudat::ground_stations::relative_humidity_meteo_data )
+            .value( "dew_point_meteo_data", tudat::ground_stations::dew_point_meteo_data )
+            .export_values( );
 
-    py::class_< tudat::ground_stations::StationMeteoData,
-                std::shared_ptr< tudat::ground_stations::StationMeteoData > >(
-        m, "StationMeteoData" );
+    py::class_< tudat::ground_stations::StationMeteoData, std::shared_ptr< tudat::ground_stations::StationMeteoData > >(
+            m, "StationMeteoData" );
 
     py::class_< tudat::ground_stations::ContinuousInterpolatedMeteoData,
                 std::shared_ptr< tudat::ground_stations::ContinuousInterpolatedMeteoData >,
-                tudat::ground_stations::StationMeteoData >(
-            m, "ContinuousInterpolatedMeteoData" )
-            .def( py::init<
-                std::shared_ptr< tudat::interpolators::OneDimensionalInterpolator< double, Eigen::VectorXd > >,
-                std::map< tudat::ground_stations::MeteoDataEntries, int > >( ),
-                py::arg( "interpolator" ),
-                py::arg( "vector_entries" ) );
+                tudat::ground_stations::StationMeteoData >( m, "ContinuousInterpolatedMeteoData" )
+            .def( py::init< std::shared_ptr< tudat::interpolators::OneDimensionalInterpolator< double, Eigen::VectorXd > >,
+                            std::map< tudat::ground_stations::MeteoDataEntries, int > >( ),
+                  py::arg( "interpolator" ),
+                  py::arg( "vector_entries" ) );
 
     /*!
      **************   BODY OBJECTS AND ASSOCIATED FUNCTIONALITY
@@ -2457,8 +2394,7 @@ inside a `Body` instance and used in observation corrections or environmental qu
       )doc" )
             .def_property( "inertia_tensor",
                            &tss::Body::getBodyInertiaTensor,
-                           py::overload_cast< const Eigen::Matrix3d & >(
-                                   &tss::Body::setBodyInertiaTensor ),
+                           py::overload_cast< const Eigen::Matrix3d& >( &tss::Body::setBodyInertiaTensor ),
                            R"doc(
 
          The current inertia tensor :math:`\mathbf{I}` of the vehicle, as used in the calculation of
@@ -2520,8 +2456,7 @@ inside a `Body` instance and used in observation corrections or environmental qu
 
          :type: AtmosphereModel
       )doc" )
-            .def_property(
-                    "shape_model", &tss::Body::getShapeModel, &tss::Body::setShapeModel, R"doc(
+            .def_property( "shape_model", &tss::Body::getShapeModel, &tss::Body::setShapeModel, R"doc(
 
          Object defining the a shape model of this body, used to define the exterior shape of the body, for instance for
          the calculation of vehicle's altitude. Depending on the selected type of model, the type of this attribute
@@ -2618,10 +2553,10 @@ inside a `Body` instance and used in observation corrections or environmental qu
         :type: list[RadiationPressureTargetModel]
 
      )doc" )
-        .def_property( "radiation_pressure_source_model",
-                       &tss::Body::getRadiationSourceModel,
-                       &tss::Body::setRadiationSourceModel,
-                       R"doc(
+            .def_property( "radiation_pressure_source_model",
+                           &tss::Body::getRadiationSourceModel,
+                           &tss::Body::setRadiationSourceModel,
+                           R"doc(
 
         Object that defines the radiation that a body emits, primarily for the calculation of radiation pressure acceleration.
         It computes the irradiance at a given target location.
@@ -2632,8 +2567,7 @@ inside a `Body` instance and used in observation corrections or environmental qu
         :type: RadiationSourceModel
 
      )doc" )
-            .def_property_readonly(
-                    "gravitational_parameter", &tss::Body::getGravitationalParameter, R"doc(
+            .def_property_readonly( "gravitational_parameter", &tss::Body::getGravitationalParameter, R"doc(
          **read-only**
 
          Attribute of convenience, equivalent to ``.gravity_field_model.gravitational_parameter``
@@ -2678,8 +2612,7 @@ inside a `Body` instance and used in observation corrections or environmental qu
          :type: dict[str,GroundStation]
       )doc" );
 
-    py::class_< tss::SystemOfBodies, std::shared_ptr< tss::SystemOfBodies > >(
-            m, "SystemOfBodies", R"doc(
+    py::class_< tss::SystemOfBodies, std::shared_ptr< tss::SystemOfBodies > >( m, "SystemOfBodies", R"doc(
 
          Object that contains a set of Body objects and associated frame
          information.

--- a/src/tudatpy/dynamics/environment/expose_environment.cpp
+++ b/src/tudatpy/dynamics/environment/expose_environment.cpp
@@ -82,6 +82,7 @@ std::pair< std::vector< Eigen::Vector3d >, std::vector< Eigen::Vector3d > > getV
     std::vector< Eigen::Vector3d > surfaceNormalsList;
     //    std::map< int, Eigen::Vector1d > pressureCoefficientsList;
 
+    // int counter = 0;
     for( unsigned int i = 0; i < meshPoints.size( ); i++ )
     {
         for( unsigned int j = 0; j < meshPoints.at( i ).shape( )[ 0 ] - 1; j++ )
@@ -94,7 +95,7 @@ std::pair< std::vector< Eigen::Vector3d >, std::vector< Eigen::Vector3d > > getV
                 //                ( Eigen::Vector1d( ) <<
                 //                pressureCoefficients[ i ][ j ][ k ]
                 //                ).finished( );
-                counter++;
+                // counter++;
             }
         }
     }

--- a/src/tudatpy/dynamics/environment/expose_environment.cpp
+++ b/src/tudatpy/dynamics/environment/expose_environment.cpp
@@ -78,7 +78,6 @@ std::pair< std::vector< Eigen::Vector3d >, std::vector< Eigen::Vector3d > > getV
     //            localInclinationAnalysis->getPressureCoefficientList(
     //            independentVariables );
 
-    int counter = 0;
     std::vector< Eigen::Vector3d > meshPointsList;
     std::vector< Eigen::Vector3d > surfaceNormalsList;
     //    std::map< int, Eigen::Vector1d > pressureCoefficientsList;

--- a/src/tudatpy/dynamics/environment/expose_environment.cpp
+++ b/src/tudatpy/dynamics/environment/expose_environment.cpp
@@ -903,8 +903,7 @@ inside a `Body` instance and used in observation corrections or environmental qu
            &ta::getVehicleMesh,
            py::arg( "local_inclination_analysis_object" ) );
 
-    py::class_< tsm::VehicleSystems, std::shared_ptr< tsm::VehicleSystems > >(
-            m, "VehicleSystems", R"doc(
+    py::class_< tsm::VehicleSystems, std::shared_ptr< tsm::VehicleSystems > >( m, "VehicleSystems", R"doc(
 
          Object used to store physical (hardware) properties of a vehicle.
 
@@ -945,15 +944,14 @@ inside a `Body` instance and used in observation corrections or environmental qu
 
      )doc" )
             .def( "set_transponder_turnaround_ratio",
-                  py::overload_cast<
-                          std::map< std::pair< tom::FrequencyBands, tom::FrequencyBands >, double >
-                                  & >( &tsm::VehicleSystems::setTransponderTurnaroundRatio ),
+                  py::overload_cast< std::map< std::pair< tom::FrequencyBands, tom::FrequencyBands >, double > & >(
+                          &tsm::VehicleSystems::setTransponderTurnaroundRatio ),
                   py::arg( "transponder_ratio_per_uplink_and_downlink_"
                            "frequency_band" ),
                   R"doc(No documentation found.)doc" )
             .def( "set_default_transponder_turnaround_ratio_function",
                   &tsm::VehicleSystems::setDefaultTransponderTurnaroundRatio,
-                  R"doc(No documentation found.)doc" )
+                  R"doc(Retrieve standard, DSN turnaround ratios based on the frequency bands of the link)doc" )
             .def( "get_control_surface_deflection",
                   &tsm::VehicleSystems::getCurrentControlSurfaceDeflection,
                   py::arg( "control_surface_id" ),
@@ -984,10 +982,7 @@ inside a `Body` instance and used in observation corrections or environmental qu
 
      )doc" )
             .def( "set_reference_point",
-                  py::overload_cast< const std::string,
-                                     const Eigen::Vector3d &,
-                                     const std::string,
-                                     const std::string >(
+                  py::overload_cast< const std::string, const Eigen::Vector3d &, const std::string, const std::string >(
                           &tsm::VehicleSystems::setReferencePointPosition ),
                   py::arg( "reference_point" ),
                   py::arg( "location" ),
@@ -1025,9 +1020,7 @@ inside a `Body` instance and used in observation corrections or environmental qu
 
 
      )doc" )
-            .def( "set_timing_system",
-                  &tsm::VehicleSystems::setTimingSystem,
-                  py::arg( "timing_system" ) );
+            .def( "set_timing_system", &tsm::VehicleSystems::setTimingSystem, py::arg( "timing_system" ) );
 
     py::class_< tss::RigidBodyProperties, std::shared_ptr< tss::RigidBodyProperties > >(
             m, "RigidBodyProperties", R"doc(

--- a/src/tudatpy/dynamics/environment/expose_environment.cpp
+++ b/src/tudatpy/dynamics/environment/expose_environment.cpp
@@ -2226,14 +2226,17 @@ inside a `Body` instance and used in observation corrections or environmental qu
     py::class_< tgs::PiecewiseLinearFrequencyInterpolator,
                 std::shared_ptr< tgs::PiecewiseLinearFrequencyInterpolator >,
                 tgs::StationFrequencyInterpolator >( m, "PiecewiseLinearFrequencyInterpolator" )
-            .def( py::init< const std::vector< tudat::Time > &,
-                            const std::vector< tudat::Time > &,
-                            const std::vector< double > &,
-                            const std::vector< double > & >( ),
+            .def( py::init< const std::vector< tudat::Time >&,
+                            const std::vector< tudat::Time >&,
+                            const std::vector< double >&,
+                            const std::vector< double >& >( ),
                   py::arg( "start_times" ),
                   py::arg( "end_times" ),
                   py::arg( "ramp_rates" ),
-                  py::arg( "start_frequency" ) );
+                  py::arg( "start_frequency" ) )
+            .def( "compute_current_frequency",
+                  &tgs::PiecewiseLinearFrequencyInterpolator::computeCurrentFrequency< double, tudat::Time >,
+                  py::arg( "lookup_time_original" ) );
 
     py::class_< tgs::PointingAnglesCalculator, std::shared_ptr< tgs::PointingAnglesCalculator > >(
             m, "PointingAnglesCalculator" )

--- a/src/tudatpy/dynamics/environment_setup/ephemeris/expose_ephemeris.cpp
+++ b/src/tudatpy/dynamics/environment_setup/ephemeris/expose_ephemeris.cpp
@@ -66,13 +66,13 @@ namespace ephemeris
 
 void expose_ephemeris_setup( py::module& m )
 {
+    py::module_::import( "tudatpy.dynamics.environment" ).attr( "Ephemeris" );
     /////////////////////////////////////////////////////////////////////////////
     // createEphemeris.h (complete, unverified)
     /////////////////////////////////////////////////////////////////////////////
-    py::class_< tss::EphemerisSettings, std::shared_ptr< tss::EphemerisSettings > >(
-            m,
-            "EphemerisSettings",
-            R"doc(
+    py::class_< tss::EphemerisSettings, std::shared_ptr< tss::EphemerisSettings > >( m,
+                                                                                     "EphemerisSettings",
+                                                                                     R"doc(
 
          Base class for providing settings for ephemeris model.
 
@@ -129,11 +129,10 @@ void expose_ephemeris_setup( py::module& m )
          :type: EphemerisType
       )doc" );
 
-    py::class_< tss::DirectSpiceEphemerisSettings,
-                std::shared_ptr< tss::DirectSpiceEphemerisSettings >,
-                tss::EphemerisSettings >( m,
-                                          "DirectSpiceEphemerisSettings",
-                                          R"doc(
+    py::class_< tss::DirectSpiceEphemerisSettings, std::shared_ptr< tss::DirectSpiceEphemerisSettings >, tss::EphemerisSettings >(
+            m,
+            "DirectSpiceEphemerisSettings",
+            R"doc(
 
          Class for defining settings of an ephemeris linked directly to Spice.
 
@@ -157,10 +156,9 @@ void expose_ephemeris_setup( py::module& m )
             //                py::arg("converge_light_time_aberration")
             //                = false, py::arg("ephemeris_type") =
             //                tss::direct_spice_ephemeris)
-            .def_property_readonly(
-                    "correct_for_stellar_aberration",
-                    &tss::DirectSpiceEphemerisSettings::getCorrectForStellarAberration,
-                    R"doc(
+            .def_property_readonly( "correct_for_stellar_aberration",
+                                    &tss::DirectSpiceEphemerisSettings::getCorrectForStellarAberration,
+                                    R"doc(
 
          **read-only**
 
@@ -168,10 +166,9 @@ void expose_ephemeris_setup( py::module& m )
 
          :type: bool
       )doc" )
-            .def_property_readonly(
-                    "correct_for_light_time_aberration",
-                    &tss::DirectSpiceEphemerisSettings::getCorrectForLightTimeAberration,
-                    R"doc(
+            .def_property_readonly( "correct_for_light_time_aberration",
+                                    &tss::DirectSpiceEphemerisSettings::getCorrectForLightTimeAberration,
+                                    R"doc(
 
          **read-only**
 
@@ -179,12 +176,11 @@ void expose_ephemeris_setup( py::module& m )
 
          :type: bool
       )doc" )
-            .def_property_readonly(
-                    "converge_light_time_aberration",
-                    // TODO : Fix getConvergeLighTimeAberration typo in
-                    // Tudat.
-                    &tss::DirectSpiceEphemerisSettings::getConvergeLighTimeAberration,
-                    R"doc(
+            .def_property_readonly( "converge_light_time_aberration",
+                                    // TODO : Fix getConvergeLighTimeAberration typo in
+                                    // Tudat.
+                                    &tss::DirectSpiceEphemerisSettings::getConvergeLighTimeAberration,
+                                    R"doc(
 
          **read-only**
 
@@ -251,11 +247,10 @@ void expose_ephemeris_setup( py::module& m )
          :type: float
       )doc" );
 
-    py::class_< tss::ApproximateJplEphemerisSettings,
-                std::shared_ptr< tss::ApproximateJplEphemerisSettings >,
-                tss::EphemerisSettings >( m,
-                                          "ApproximateJplEphemerisSettings",
-                                          R"doc(
+    py::class_< tss::ApproximateJplEphemerisSettings, std::shared_ptr< tss::ApproximateJplEphemerisSettings >, tss::EphemerisSettings >(
+            m,
+            "ApproximateJplEphemerisSettings",
+            R"doc(
 
          Class for creating settings of approximate ephemeris for major planets.
 
@@ -265,15 +260,12 @@ void expose_ephemeris_setup( py::module& m )
 
 
       )doc" )
-            .def_property_readonly( "body_name",
-                                    &tss::ApproximateJplEphemerisSettings::getBodyName,
-                                    R"doc(No documentation found.)doc" );
+            .def_property_readonly( "body_name", &tss::ApproximateJplEphemerisSettings::getBodyName, R"doc(No documentation found.)doc" );
 
-    py::class_< tss::ScaledEphemerisSettings,
-                std::shared_ptr< tss::ScaledEphemerisSettings >,
-                tss::EphemerisSettings >( m,
-                                          "ScaledEphemerisSettings",
-                                          R"doc(
+    py::class_< tss::ScaledEphemerisSettings, std::shared_ptr< tss::ScaledEphemerisSettings >, tss::EphemerisSettings >(
+            m,
+            "ScaledEphemerisSettings",
+            R"doc(
 
          Class for defining settings from scaling existing ephemeris settings.
 
@@ -284,11 +276,10 @@ void expose_ephemeris_setup( py::module& m )
 
       )doc" );
 
-    py::class_< tss::ConstantEphemerisSettings,
-                std::shared_ptr< tss::ConstantEphemerisSettings >,
-                tss::EphemerisSettings >( m,
-                                          "ConstantEphemerisSettings",
-                                          R"doc(
+    py::class_< tss::ConstantEphemerisSettings, std::shared_ptr< tss::ConstantEphemerisSettings >, tss::EphemerisSettings >(
+            m,
+            "ConstantEphemerisSettings",
+            R"doc(
 
          Class for defining settings of constant ephemerides.
 
@@ -306,11 +297,10 @@ void expose_ephemeris_setup( py::module& m )
     //                 py::arg("frame_orientation") =
     //                 "ECLIPJ2000");
 
-    py::class_< tss::CustomEphemerisSettings,
-                std::shared_ptr< tss::CustomEphemerisSettings >,
-                tss::EphemerisSettings >( m,
-                                          "CustomEphemerisSettings",
-                                          R"doc(
+    py::class_< tss::CustomEphemerisSettings, std::shared_ptr< tss::CustomEphemerisSettings >, tss::EphemerisSettings >(
+            m,
+            "CustomEphemerisSettings",
+            R"doc(
 
          Class for defining settings of a custom ephemeris.
 
@@ -333,9 +323,7 @@ void expose_ephemeris_setup( py::module& m )
                                     &tss::CustomEphemerisSettings::getCustomStateFunction,
                                     R"doc(No documentation found.)doc" );
 
-    py::class_< tss::KeplerEphemerisSettings,
-                std::shared_ptr< tss::KeplerEphemerisSettings >,
-                tss::EphemerisSettings >(
+    py::class_< tss::KeplerEphemerisSettings, std::shared_ptr< tss::KeplerEphemerisSettings >, tss::EphemerisSettings >(
             m, "KeplerEphemerisSettings", R"doc(No documentation found.)doc" )
             //            .def(py::init<const Eigen::Vector6d &,
             //            const double, const double,
@@ -354,30 +342,25 @@ void expose_ephemeris_setup( py::module& m )
             //            std::numeric_limits<double>::epsilon(),
             //                 py::arg("root_finder_maximum_number_of_iterations")
             //                 = 1000.0)
-            .def_property_readonly(
-                    "initial_state_in_keplerian_elements",
-                    &tss::KeplerEphemerisSettings::getInitialStateInKeplerianElements,
-                    R"doc(No documentation found.)doc" )
-            .def_property_readonly( "epoch_of_initial_state",
-                                    &tss::KeplerEphemerisSettings::getEpochOfInitialState,
+            .def_property_readonly( "initial_state_in_keplerian_elements",
+                                    &tss::KeplerEphemerisSettings::getInitialStateInKeplerianElements,
                                     R"doc(No documentation found.)doc" )
             .def_property_readonly(
-                    "central_body_gravitational_parameter",
-                    &tss::KeplerEphemerisSettings::getCentralBodyGravitationalParameter,
-                    R"doc(No documentation found.)doc" )
+                    "epoch_of_initial_state", &tss::KeplerEphemerisSettings::getEpochOfInitialState, R"doc(No documentation found.)doc" )
+            .def_property_readonly( "central_body_gravitational_parameter",
+                                    &tss::KeplerEphemerisSettings::getCentralBodyGravitationalParameter,
+                                    R"doc(No documentation found.)doc" )
             .def_property_readonly( "root_finder_absolute_tolerance",
                                     &tss::KeplerEphemerisSettings::getRootFinderAbsoluteTolerance,
                                     R"doc(No documentation found.)doc" )
-            .def_property_readonly(
-                    "root_finder_maximum_number_of_iterations",
-                    &tss::KeplerEphemerisSettings::getRootFinderMaximumNumberOfIterations,
-                    R"doc(No documentation found.)doc" );
+            .def_property_readonly( "root_finder_maximum_number_of_iterations",
+                                    &tss::KeplerEphemerisSettings::getRootFinderMaximumNumberOfIterations,
+                                    R"doc(No documentation found.)doc" );
 
-    py::class_< tss::TabulatedEphemerisSettings,
-                std::shared_ptr< tss::TabulatedEphemerisSettings >,
-                tss::EphemerisSettings >( m,
-                                          "TabulatedEphemerisSettings",
-                                          R"doc(
+    py::class_< tss::TabulatedEphemerisSettings, std::shared_ptr< tss::TabulatedEphemerisSettings >, tss::EphemerisSettings >(
+            m,
+            "TabulatedEphemerisSettings",
+            R"doc(
 
          Class for defining settings of ephemeris to be created from tabulated data.
 
@@ -414,8 +397,7 @@ void expose_ephemeris_setup( py::module& m )
            py::arg( "central_body_gravitational_parameter" ),
            py::arg( "frame_origin" ) = "SSB",
            py::arg( "frame_orientation" ) = "ECLIPJ2000",
-           py::arg( "root_finder_absolute_tolerance" ) =
-                   200.0 * std::numeric_limits< double >::epsilon( ),
+           py::arg( "root_finder_absolute_tolerance" ) = 200.0 * std::numeric_limits< double >::epsilon( ),
            py::arg( "root_finder_maximum_iterations" ) = 1000.0,
            R"doc(
 
@@ -490,8 +472,7 @@ void expose_ephemeris_setup( py::module& m )
            py::arg( "central_body_gravitational_parameter" ),
            py::arg( "frame_origin" ) = "SSB",
            py::arg( "frame_orientation" ) = "ECLIPJ2000",
-           py::arg( "root_finder_absolute_tolerance" ) =
-                   200.0 * std::numeric_limits< double >::epsilon( ),
+           py::arg( "root_finder_absolute_tolerance" ) = 200.0 * std::numeric_limits< double >::epsilon( ),
            py::arg( "root_finder_maximum_iterations" ) = 1000.0,
            R"doc(
 
@@ -608,8 +589,7 @@ void expose_ephemeris_setup( py::module& m )
      )doc" );
 
     m.def( "direct_spice",
-           py::overload_cast< const std::string, const std::string, const std::string >(
-                   &tss::directSpiceEphemerisSettings ),
+           py::overload_cast< const std::string, const std::string, const std::string >( &tss::directSpiceEphemerisSettings ),
            py::arg( "frame_origin" ) = "SSB",
            py::arg( "frame_orientation" ) = "ECLIPJ2000",
            py::arg( "body_name_to_use" ) = "",
@@ -671,8 +651,7 @@ void expose_ephemeris_setup( py::module& m )
            py::arg( "time_step" ),
            py::arg( "frame_origin" ) = "SSB",
            py::arg( "frame_orientation" ) = "ECLIPJ2000",
-           py::arg( "interpolator_settings" ) =
-                   std::make_shared< ti::LagrangeInterpolatorSettings >( 6 ),
+           py::arg( "interpolator_settings" ) = std::make_shared< ti::LagrangeInterpolatorSettings >( 6 ),
            py::arg( "body_name_to_use" ) = "",
            R"doc(
 
@@ -737,9 +716,7 @@ void expose_ephemeris_setup( py::module& m )
      )doc" );
 
     m.def( "tabulated",
-           py::overload_cast< const std::map< double, Eigen::Vector6d >&,
-                              std::string,
-                              std::string >( &tss::tabulatedEphemerisSettings ),
+           py::overload_cast< const std::map< double, Eigen::Vector6d >&, std::string, std::string >( &tss::tabulatedEphemerisSettings ),
            py::arg( "body_state_history" ),
            py::arg( "frame_origin" ) = "SSB",
            py::arg( "frame_orientation" ) = "ECLIPJ2000",
@@ -799,14 +776,12 @@ void expose_ephemeris_setup( py::module& m )
                               const double,
                               const double,
                               const double,
-                              const std::shared_ptr< ti::InterpolatorSettings > >(
-                   &tss::tabulatedEphemerisSettings ),
+                              const std::shared_ptr< ti::InterpolatorSettings > >( &tss::tabulatedEphemerisSettings ),
            py::arg( "ephemeris_settings" ),
            py::arg( "start_time" ),
            py::arg( "end_time" ),
            py::arg( "time_step" ),
-           py::arg( "interpolator_settings" ) =
-                   std::make_shared< ti::LagrangeInterpolatorSettings >( 8 ),
+           py::arg( "interpolator_settings" ) = std::make_shared< ti::LagrangeInterpolatorSettings >( 8 ),
            R"doc(
 
  Function for creating tabulated ephemeris model settings from existing ephemeris.
@@ -955,9 +930,7 @@ void expose_ephemeris_setup( py::module& m )
      )doc" );
 
     m.def( "scaled_by_constant",
-           py::overload_cast< const std::shared_ptr< tss::EphemerisSettings >,
-                              const double,
-                              const bool >( &tss::scaledEphemerisSettings ),
+           py::overload_cast< const std::shared_ptr< tss::EphemerisSettings >, const double, const bool >( &tss::scaledEphemerisSettings ),
            py::arg( "unscaled_ephemeris_settings" ),
            py::arg( "scaling_constant" ),
            py::arg( "is_scaling_absolute" ) = false,
@@ -1006,9 +979,8 @@ void expose_ephemeris_setup( py::module& m )
      )doc" );
 
     m.def( "scaled_by_vector",
-           py::overload_cast< const std::shared_ptr< tss::EphemerisSettings >,
-                              const Eigen::Vector6d,
-                              const bool >( &tss::scaledEphemerisSettings ),
+           py::overload_cast< const std::shared_ptr< tss::EphemerisSettings >, const Eigen::Vector6d, const bool >(
+                   &tss::scaledEphemerisSettings ),
            py::arg( "unscaled_ephemeris_settings" ),
            py::arg( "scaling_vector" ),
            py::arg( "is_scaling_absolute" ) = false,

--- a/src/tudatpy/dynamics/environment_setup/ephemeris/expose_ephemeris.cpp
+++ b/src/tudatpy/dynamics/environment_setup/ephemeris/expose_ephemeris.cpp
@@ -19,6 +19,7 @@
 // #include <pybind11/chrono.h>
 #include <pybind11/eigen.h>
 #include <pybind11/functional.h>
+#include <pybind11/native_enum.h>
 // #include <pybind11/numpy.h>
 #include <pybind11/complex.h>
 #include <pybind11/pybind11.h>
@@ -67,6 +68,26 @@ namespace ephemeris
 void expose_ephemeris_setup( py::module& m )
 {
     py::module_::import( "tudatpy.dynamics.environment" ).attr( "Ephemeris" );
+
+    // Types of ephemerides
+    py::native_enum< tss::EphemerisType >( m, "EphemerisType", "enum.Enum", R"doc(
+        List of ephemeris objects available in simulations.
+
+        An ephemeris model not defined by this enumeration cannot be used for automatic model setup
+    )doc" )
+            .value( "approximate_planet_positions", tss::EphemerisType::approximate_planet_positions )
+            .value( "direct_spice_ephemeris", tss::EphemerisType::direct_spice_ephemeris )
+            .value( "tabulated_ephemeris", tss::EphemerisType::tabulated_ephemeris )
+            .value( "auto_generated_tabulated_ephemeris", tss::EphemerisType::auto_generated_tabulated_ephemeris )
+            .value( "interpolated_spice", tss::EphemerisType::interpolated_spice )
+            .value( "constant_ephemeris", tss::EphemerisType::constant_ephemeris )
+            .value( "kepler_ephemeris", tss::EphemerisType::kepler_ephemeris )
+            .value( "custom_ephemeris", tss::EphemerisType::custom_ephemeris )
+            .value( "direct_tle_ephemeris", tss::EphemerisType::direct_tle_ephemeris )
+            .value( "interpolated_tle_ephemeris", tss::EphemerisType::interpolated_tle_ephemeris )
+            .value( "scaled_ephemeris", tss::EphemerisType::scaled_ephemeris )
+            .finalize( );
+
     /////////////////////////////////////////////////////////////////////////////
     // createEphemeris.h (complete, unverified)
     /////////////////////////////////////////////////////////////////////////////

--- a/src/tudatpy/dynamics/environment_setup/gravity_field/expose_gravity_field.cpp
+++ b/src/tudatpy/dynamics/environment_setup/gravity_field/expose_gravity_field.cpp
@@ -140,7 +140,7 @@ Enumeration of predefined spherical harmonics models.
 Enumeration of predefined spherical harmonics models supported by tudat, for which thee coefficient files are automatically available (downloaded from
 `here <https://github.com/tudat-team/tudat-resources/tree/master/resource/gravity_models>`_). The directory where these files are stored can be
 extracted using the :func:`~tudatpy.data.get_gravity_models_path` function.
-                 
+
         )doc" )
             .value( "egm96",
                     tss::SphericalHarmonicsModel::egm96,
@@ -270,10 +270,6 @@ Coefficients for the SHGJ180U Moon gravity field up to degree and order 180, (se
 
          Derived class of `GravityFieldSettings` for gravity fields, which are defined by a spherical harmonic gravity field representation.
 
-
-
-
-
       )doc" )
             //            .def(py::init<const double, const double,
             //            const Eigen::MatrixXd, const
@@ -283,11 +279,10 @@ Coefficients for the SHGJ180U Moon gravity field up to degree and order 180, (se
             //                 py::arg("cosine_coefficients"),
             //                 py::arg("sine_coefficients"),
             //                 py::arg("associated_reference_frame"))
-            .def_property(
-                    "gravitational_parameter",
-                    &tss::SphericalHarmonicsGravityFieldSettings::getGravitationalParameter,
-                    &tss::SphericalHarmonicsGravityFieldSettings::resetGravitationalParameter,
-                    R"doc(
+            .def_property( "gravitational_parameter",
+                           &tss::SphericalHarmonicsGravityFieldSettings::getGravitationalParameter,
+                           &tss::SphericalHarmonicsGravityFieldSettings::resetGravitationalParameter,
+                           R"doc(
 
          Gravitational parameter of gravity field.
 
@@ -311,31 +306,28 @@ Coefficients for the SHGJ180U Moon gravity field up to degree and order 180, (se
 
          :type: numpy.ndarray
       )doc" )
-            .def_property(
-                    "associated_reference_frame",
-                    &tss::SphericalHarmonicsGravityFieldSettings::getAssociatedReferenceFrame,
-                    &tss::SphericalHarmonicsGravityFieldSettings::resetAssociatedReferenceFrame,
-                    R"doc(
+            .def_property( "associated_reference_frame",
+                           &tss::SphericalHarmonicsGravityFieldSettings::getAssociatedReferenceFrame,
+                           &tss::SphericalHarmonicsGravityFieldSettings::resetAssociatedReferenceFrame,
+                           R"doc(
 
          Identifier for body-fixed reference frame with which the coefficients are associated.
 
          :type: str
       )doc" )
-            .def_property(
-                    "create_time_dependent_field",
-                    &tss::SphericalHarmonicsGravityFieldSettings::getCreateTimeDependentField,
-                    &tss::SphericalHarmonicsGravityFieldSettings::setCreateTimeDependentField,
-                    R"doc(
+            .def_property( "create_time_dependent_field",
+                           &tss::SphericalHarmonicsGravityFieldSettings::getCreateTimeDependentField,
+                           &tss::SphericalHarmonicsGravityFieldSettings::setCreateTimeDependentField,
+                           R"doc(
 
          Boolean that denotes whether the field should be created as time-dependent (even if no variations are imposed initially).
 
          :type: bool
       )doc" )
-            .def_property(
-                    "scaled_mean_moment_of_inertia",
-                    &tss::SphericalHarmonicsGravityFieldSettings::getScaledMeanMomentOfInertia,
-                    &tss::SphericalHarmonicsGravityFieldSettings::setScaledMeanMomentOfInertia,
-                    R"doc(
+            .def_property( "scaled_mean_moment_of_inertia",
+                           &tss::SphericalHarmonicsGravityFieldSettings::getScaledMeanMomentOfInertia,
+                           &tss::SphericalHarmonicsGravityFieldSettings::setScaledMeanMomentOfInertia,
+                           R"doc(
 
          Value of the scaled mean moment of inertia :math:`I_{xx}+I_{yy}+I_{zz}/(MR^{2})`. This value does not influence the gravity field itself,
          but together with the degree 2 gravity field coefficients defines the body's inertia tensor.
@@ -343,10 +335,9 @@ Coefficients for the SHGJ180U Moon gravity field up to degree and order 180, (se
 
          :type: float
       )doc" )
-            .def_property_readonly(
-                    "reference_radius",
-                    &tss::SphericalHarmonicsGravityFieldSettings::getReferenceRadius,
-                    R"doc(
+            .def_property_readonly( "reference_radius",
+                                    &tss::SphericalHarmonicsGravityFieldSettings::getReferenceRadius,
+                                    R"doc(
 
          **read-only**
 
@@ -626,8 +617,8 @@ Coefficients for the SHGJ180U Moon gravity field up to degree and order 180, (se
  - Each subsequent line should contain a set of spherical harmonic coefficients (first ordered in ascending order by degree, then in ascending order by order), where the first, second, third and fourth value of the line should be: degree :math:`l`, order :math:`m`, normalized cosine coefficient :math:`\bar{C}_{lm}`, normalized sine coefficient :math:`\bar{S}_{lm}`. Additional entries (for instance with coefficient uncertainties) are ignored.
 
  .. warning::
-    
-    The function expects exponents to be indicated by either "e" or "E". If the exponent is indicated by "d" or "D", the exponent will not be parsed and the function will read wrong coefficients! 
+
+    The function expects exponents to be indicated by either "e" or "E". If the exponent is indicated by "d" or "D", the exponent will not be parsed and the function will read wrong coefficients!
 
  The following example shows the first lines of a file with correct format:
 
@@ -641,7 +632,7 @@ Coefficients for the SHGJ180U Moon gravity field up to degree and order 180, (se
     2    1 -2.189810040712E-10  1.467451636117E-09  7.75160E-12  7.81670E-12
     2    2  2.439349093502E-06 -1.400284857733E-06  7.80670E-12  7.80760E-12
     ...
- 
+
 
  Parameters
  ----------

--- a/src/tudatpy/dynamics/environment_setup/ground_station/expose_ground_station.cpp
+++ b/src/tudatpy/dynamics/environment_setup/ground_station/expose_ground_station.cpp
@@ -15,6 +15,7 @@
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/native_enum.h>
 #include <tudat/simulation/environment_setup/createGroundStations.h>
 #include <tudat/simulation/environment_setup/defaultBodies.h>
 
@@ -34,19 +35,16 @@ namespace ground_station
 
 void expose_ground_station_setup( py::module &m )
 {
-    py::class_< tss::GroundStationSettings, std::shared_ptr< tss::GroundStationSettings > >( m,
-                                                                                             "GroundStationSettings",
-                                                                                             R"doc(
 
-         Base class for providing settings for the creation of a ground station.
-
-
-      )doc" )
-            .def_property( "station_position",
-                           &tss::GroundStationSettings::getGroundStationPosition,
-                           &tss::GroundStationSettings::resetGroundStationPosition )
-
-            .def_property_readonly( "station_name", &tss::GroundStationSettings::getStationName );
+    // Ground station motion settings
+    py::native_enum< tss::StationMotionModelTypes >( m, "StationMotionModelTypes", "enum.Enum" )
+            .value( "linear", tss::StationMotionModelTypes::linear_station_motion )
+            .value( "piecewise_constant", tss::StationMotionModelTypes::piecewise_constant_station_motion )
+            .value( "custom", tss::StationMotionModelTypes::custom_station_motion )
+            .value( "body_deformation", tss::StationMotionModelTypes::body_deformation_station_motion )
+            .value( "bodycentric_to_barycentric_station_position_motion",
+                    tss::StationMotionModelTypes::bodycentric_to_barycentric_station_position_motion )
+            .finalize( );
 
     py::class_< tss::GroundStationMotionSettings, std::shared_ptr< tss::GroundStationMotionSettings > >( m,
                                                                                                          "GroundStationMotionSettings",
@@ -61,7 +59,8 @@ void expose_ground_station_setup( py::module &m )
 
 
 
-      )doc" );
+      )doc" )
+            .def_property_readonly( "model_type", &tss::GroundStationMotionSettings::getModelType );
 
     py::class_< tss::LinearGroundStationMotionSettings,
                 std::shared_ptr< tss::LinearGroundStationMotionSettings >,
@@ -76,7 +75,15 @@ void expose_ground_station_setup( py::module &m )
 
 
 
-      )doc" );
+      )doc" )
+            .def( py::init< const Eigen::Vector3d, const double >( ),
+                  py::arg( "linear_velocity" ),
+                  py::arg( "reference_epoch" ) = 0.,
+                  R"doc(Define linear motion settings for ground station
+
+                  :param linear_velocity: Constant velocity of the station in body-fixed reference frame
+                  :param reference_epoch: Epoch at which the position of the station is known
+                  )doc" );
 
     py::class_< tss::PiecewiseConstantGroundStationMotionSettings,
                 std::shared_ptr< tss::PiecewiseConstantGroundStationMotionSettings >,
@@ -93,6 +100,15 @@ void expose_ground_station_setup( py::module &m )
 
       )doc" );
 
+    py::class_< tss::BodyDeformationStationMotionSettings,
+                std::shared_ptr< tss::BodyDeformationStationMotionSettings >,
+                tss::GroundStationMotionSettings >( m,
+                                                    "BodyDeformationStationMotionSettings",
+                                                    R"doc(
+                    Define station motion settings based on body deformation
+                    )doc" )
+            .def( py::init< const bool >( ), py::arg( "fail_if_not_available" ) = true );
+
     py::class_< tss::CustomGroundStationMotionSettings,
                 std::shared_ptr< tss::CustomGroundStationMotionSettings >,
                 tss::GroundStationMotionSettings >( m,
@@ -107,6 +123,22 @@ void expose_ground_station_setup( py::module &m )
 
 
       )doc" );
+
+    py::class_< tss::GroundStationSettings, std::shared_ptr< tss::GroundStationSettings > >( m,
+                                                                                             "GroundStationSettings",
+                                                                                             R"doc(
+
+         Base class for providing settings for the creation of a ground station.
+
+
+      )doc" )
+            .def_property( "station_position",
+                           &tss::GroundStationSettings::getGroundStationPosition,
+                           &tss::GroundStationSettings::resetGroundStationPosition )
+
+            .def_property_readonly( "station_name", &tss::GroundStationSettings::getStationName )
+            .def_property_readonly( "position_element_type", &tss::GroundStationSettings::getPositionElementType )
+            .def_property_readonly( "station_motion_settings", &tss::GroundStationSettings::getStationMotionSettings );
 
     m.def( "add_motion_model_to_each_groun_station",
            &tss::addStationMotionModelToEachGroundStation,
@@ -360,6 +392,9 @@ void expose_ground_station_setup( py::module &m )
      )doc" );
 
     m.def( "approximate_ground_stations_position", &tss::getCombinedApproximateGroundStationPositions, R"doc(No documentation found.)doc" );
+
+    m.def( "get_vlbi_station_positions", &tss::getVlbiStationPositions );
+    m.def( "get_vlbi_station_velocities", &tss::getVlbiStationVelocities );
 }
 
 }  // namespace ground_station

--- a/src/tudatpy/dynamics/environment_setup/rotation_model/expose_rotation_model.cpp
+++ b/src/tudatpy/dynamics/environment_setup/rotation_model/expose_rotation_model.cpp
@@ -166,6 +166,9 @@ void expose_rotation_model_setup( py::module &m )
                 tss::RotationModelSettings>(
             m, "IAURotationModelSettings", R"doc(No documentation found.)doc" );
 
+    py::class_< tss::GcrsToItrsRotationModelSettings, std::shared_ptr< tss::GcrsToItrsRotationModelSettings >, tss::RotationModelSettings >(
+            m, "GcrsToItrsRotationModelSettings", R"doc(No documentation found.)doc" )
+            .def_property_readonly( "eop_file", &tss::GcrsToItrsRotationModelSettings::getEopFile );
 
     m.def( "simple",
            py::overload_cast< const std::string &,

--- a/src/tudatpy/dynamics/environment_setup/shape/expose_shape.cpp
+++ b/src/tudatpy/dynamics/environment_setup/shape/expose_shape.cpp
@@ -51,11 +51,10 @@ void expose_shape_setup( py::module &m )
 
       )doc" );
 
-    py::class_< tss::SphericalBodyShapeSettings,
-                std::shared_ptr< tss::SphericalBodyShapeSettings >,
-                tss::BodyShapeSettings >( m,
-                                          "SphericalBodyShapeSettings",
-                                          R"doc(
+    py::class_< tss::SphericalBodyShapeSettings, std::shared_ptr< tss::SphericalBodyShapeSettings >, tss::BodyShapeSettings >(
+            m,
+            "SphericalBodyShapeSettings",
+            R"doc(
 
          Class for defining model settings of a strictly spherical body shape.
 

--- a/src/tudatpy/dynamics/expose_dynamics.cpp
+++ b/src/tudatpy/dynamics/expose_dynamics.cpp
@@ -25,12 +25,11 @@ namespace dynamics
 
 void expose_dynamics( py::module &m )
 {
-    
-    auto environment_setup_submodule = m.def_submodule( "environment_setup" );
-    environment_setup::expose_environment_setup( environment_setup_submodule );
-
     auto environment_submodule = m.def_submodule( "environment" );
     environment::expose_environment( environment_submodule );
+
+    auto environment_setup_submodule = m.def_submodule( "environment_setup" );
+    environment_setup::expose_environment_setup( environment_setup_submodule );
 
     auto propagation_setup_submodule = m.def_submodule( "propagation_setup" );
     propagation_setup::expose_propagation_setup( propagation_setup_submodule );

--- a/src/tudatpy/estimation/expose_estimation.cpp
+++ b/src/tudatpy/estimation/expose_estimation.cpp
@@ -32,11 +32,11 @@ void expose_estimation( py::module &m )
     auto observable_models_submodule = m.def_submodule( "observable_models" );
     observable_models::expose_observable_models( observable_models_submodule );
 
-    auto observations_setup_submodule = m.def_submodule( "observations_setup" );
-    observations_setup::expose_observations_setup( observations_setup_submodule );
-
     auto observations_submodule = m.def_submodule( "observations" );
     observations::expose_observations( observations_submodule );
+
+    auto observations_setup_submodule = m.def_submodule( "observations_setup" );
+    observations_setup::expose_observations_setup( observations_setup_submodule );
 
     auto estimation_analysis_submodule = m.def_submodule( "estimation_analysis" );
     estimation_analysis::expose_estimation_analysis_estimator( estimation_analysis_submodule );

--- a/src/tudatpy/estimation/observable_models_setup/light_time_corrections/expose_light_time_corrections.cpp
+++ b/src/tudatpy/estimation/observable_models_setup/light_time_corrections/expose_light_time_corrections.cpp
@@ -12,6 +12,7 @@
 #include <pybind11/functional.h>
 #include "scalarTypes.h"
 #include "tudat/simulation/estimation_setup/createObservationModel.h"
+#include <pybind11/native_enum.h>
 
 namespace tom = tudat::observation_models;
 namespace tuc = tudat::unit_conversions;
@@ -110,7 +111,7 @@ void expose_light_time_corrections( py::module& m )
 
       )doc" );
 
-      py::enum_< tom::LightTimeFailureHandling >( m, "LightTimeFailureHandling", R"doc(
+    py::enum_< tom::LightTimeFailureHandling >( m, "LightTimeFailureHandling", R"doc(
 
 Enumeration of behaviour when failing to converge light-time with required settings.
 
@@ -206,7 +207,7 @@ Examples
 
      )doc" );
 
-     m.def(
+    m.def(
             "first_order_relativistic_light_time_correction",
             []( const std::vector< std::string >& perturbingBodies ) {
                 // Force bending to always be false
@@ -320,16 +321,17 @@ Examples
 
      )doc" );
 
-    py::enum_< tom::TroposphericMappingModel >( m, "TroposphericMappingModel", R"doc(No documentation found.)doc" )
+    py::native_enum< tom::TroposphericMappingModel >( m, "TroposphericMappingModel", "enum.IntEnum", R"doc(No documentation found.)doc" )
             .value( "simplified_chao", tom::TroposphericMappingModel::simplified_chao )
             .value( "niell", tom::TroposphericMappingModel::niell )
             .value( "vmf3", tom::TroposphericMappingModel::vmf3 )
-            .export_values( );
+            .finalize( );
 
-    py::enum_< tom::WaterVaporPartialPressureModel >( m, "WaterVaporPartialPressureModel", R"doc(No documentation found.)doc" )
+    py::native_enum< tom::WaterVaporPartialPressureModel >(
+            m, "WaterVaporPartialPressureModel", "enum.IntEnum", R"doc(No documentation found.)doc" )
             .value( "tabulated", tom::WaterVaporPartialPressureModel::tabulated )
             .value( "bean_and_dutton", tom::WaterVaporPartialPressureModel::bean_and_dutton )
-            .export_values( );
+            .finalize( );
 
     m.def( "dsn_tabulated_tropospheric_light_time_correction",
            &tom::tabulatedTroposphericCorrectionSettings,
@@ -367,19 +369,19 @@ Examples
 
     // IONEX-based VTEC correction
     m.def( "ionex_ionospheric_light_time_correction",
-        &tom::ionexIonosphericCorrectionSettings,
-        py::arg( "body_with_ionosphere_name" ),
-        py::arg( "ionosphere_height" ),
-        py::arg( "first_order_delay_coefficient" ) = 40.3,
-        R"doc(Create IONEX-based ionospheric light time correction settings.)doc" );
+           &tom::ionexIonosphericCorrectionSettings,
+           py::arg( "body_with_ionosphere_name" ),
+           py::arg( "ionosphere_height" ),
+           py::arg( "first_order_delay_coefficient" ) = 40.3,
+           R"doc(Create IONEX-based ionospheric light time correction settings.)doc" );
 
     // VMF3 Tropospheric correction
     m.def( "vmf3_tropospheric_light_time_correction",
-        &tom::vmf3TroposphericCorrectionSettings,
-        py::arg( "body_with_atmosphere_name" ) = "Earth",
-        py::arg( "use_gradient_correction" ) = true,
-        py::arg( "tropospheric_mapping_model" ) = tom::vmf3,
-        R"doc(Create VMF3 tropospheric light time correction settings.)doc" );
+           &tom::vmf3TroposphericCorrectionSettings,
+           py::arg( "body_with_atmosphere_name" ) = "Earth",
+           py::arg( "use_gradient_correction" ) = true,
+           py::arg( "tropospheric_mapping_model" ) = tom::TroposphericMappingModel::vmf3,
+           R"doc(Create VMF3 tropospheric light time correction settings.)doc" );
 
     m.def( "inverse_power_series_solar_corona_light_time_correction",
            &tom::inversePowerSeriesSolarCoronaCorrectionSettings,
@@ -389,32 +391,27 @@ Examples
            py::arg( "sun_body_name" ) = "Sun",
            R"doc(No documentation found.)doc" );
 
-    py::class_<tom::VtecCalculator, std::shared_ptr<tom::VtecCalculator>>(m, "VtecCalculator");
+    py::class_< tom::VtecCalculator, std::shared_ptr< tom::VtecCalculator > >( m, "VtecCalculator" );
 
-    py::class_<tom::JakowskiVtecCalculator, std::shared_ptr<tom::JakowskiVtecCalculator>, tom::VtecCalculator>(
-        m, "JakowskiVtecCalculator")
-        .def(py::init<
-            std::function<double(double)>,
-            std::function<double(double)>,
-            bool>(),
-            py::arg("sun_declination_function"),
-            py::arg("f10p7_function"),
-            py::arg("use_utc_time_for_local_time") = false)
-        .def( "calculate_vtec",
-            &tudat::observation_models::JakowskiVtecCalculator::calculateVtec,
-            py::arg( "time" ),
-            py::arg( "sub_ionospheric_point" ));
+    py::class_< tom::JakowskiVtecCalculator, std::shared_ptr< tom::JakowskiVtecCalculator >, tom::VtecCalculator >(
+            m, "JakowskiVtecCalculator" )
+            .def( py::init< std::function< double( double ) >, std::function< double( double ) >, bool >( ),
+                  py::arg( "sun_declination_function" ),
+                  py::arg( "f10p7_function" ),
+                  py::arg( "use_utc_time_for_local_time" ) = false )
+            .def( "calculate_vtec",
+                  &tudat::observation_models::JakowskiVtecCalculator::calculateVtec,
+                  py::arg( "time" ),
+                  py::arg( "sub_ionospheric_point" ) );
 
-    py::class_<tom::GlobalIonosphereModelVtecCalculator,
-            std::shared_ptr<tom::GlobalIonosphereModelVtecCalculator>,
-            tom::VtecCalculator>(
-        m, "GlobalIonosphereModelVtecCalculator")
-        .def(py::init< std::shared_ptr<tudat::environment::IonosphereModel> >(),
-            py::arg("ionosphere_model"))
-        .def( "calculate_vtec",
-          &tudat::observation_models::GlobalIonosphereModelVtecCalculator::calculateVtec,
-          py::arg( "time" ),
-          py::arg( "sub_ionospheric_point" ));
+    py::class_< tom::GlobalIonosphereModelVtecCalculator,
+                std::shared_ptr< tom::GlobalIonosphereModelVtecCalculator >,
+                tom::VtecCalculator >( m, "GlobalIonosphereModelVtecCalculator" )
+            .def( py::init< std::shared_ptr< tudat::environment::IonosphereModel > >( ), py::arg( "ionosphere_model" ) )
+            .def( "calculate_vtec",
+                  &tudat::observation_models::GlobalIonosphereModelVtecCalculator::calculateVtec,
+                  py::arg( "time" ),
+                  py::arg( "sub_ionospheric_point" ) );
 
     m.def( "set_vmf_troposphere_data",
            &tom::setVmfTroposphereCorrections,
@@ -427,13 +424,13 @@ Examples
            py::arg( "interpolator_settings" ) = ti::cubicSplineInterpolation( ) );
 
     m.def( "set_ionosphere_model_from_ionex",
-       &tom::setIonosphereModelFromIonex,
-       py::arg( "data_files" ),
-       py::arg( "bodies" ),
-       py::arg( "interpolator_settings" ) = std::shared_ptr< ti::InterpolatorSettings >( ) );
+           &tom::setIonosphereModelFromIonex,
+           py::arg( "data_files" ),
+           py::arg( "bodies" ),
+           py::arg( "interpolator_settings" ) = std::shared_ptr< ti::InterpolatorSettings >( ) );
 }
 
-}
-}
-}
-}
+}  // namespace light_time_corrections
+}  // namespace observable_models_setup
+}  // namespace estimation
+}  // namespace tudatpy

--- a/src/tudatpy/estimation/observable_models_setup/light_time_corrections/expose_light_time_corrections.cpp
+++ b/src/tudatpy/estimation/observable_models_setup/light_time_corrections/expose_light_time_corrections.cpp
@@ -323,6 +323,7 @@ Examples
     py::enum_< tom::TroposphericMappingModel >( m, "TroposphericMappingModel", R"doc(No documentation found.)doc" )
             .value( "simplified_chao", tom::TroposphericMappingModel::simplified_chao )
             .value( "niell", tom::TroposphericMappingModel::niell )
+            .value( "vmf3", tom::TroposphericMappingModel::vmf3 )
             .export_values( );
 
     py::enum_< tom::WaterVaporPartialPressureModel >( m, "WaterVaporPartialPressureModel", R"doc(No documentation found.)doc" )
@@ -363,7 +364,7 @@ Examples
            py::arg( "use_utc_for_local_time_computation" ) = false,
            py::arg( "body_with_atmosphere_name" ) = "Earth",
            R"doc(No documentation found.)doc" );
-    
+
     // IONEX-based VTEC correction
     m.def( "ionex_ionospheric_light_time_correction",
         &tom::ionexIonosphericCorrectionSettings,

--- a/src/tudatpy/estimation/observations/expose_observations.cpp
+++ b/src/tudatpy/estimation/observations/expose_observations.cpp
@@ -78,10 +78,9 @@ void expose_observations( py::module& m )
     // SINGLE OBSERVATION SET
 
     py::class_< tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >,
-                std::shared_ptr< tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE > > >(
-            m,
-            "SingleObservationSet",
-            R"doc(
+                std::shared_ptr< tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE > > >( m,
+                                                                                                "SingleObservationSet",
+                                                                                                R"doc(
 
          Class collecting a single set of observations and associated data, of a given observable type, link ends, and ancilliary data.
 
@@ -90,48 +89,54 @@ void expose_observations( py::module& m )
 
 
       )doc" )
+            .def( py::init< const tom::ObservableType,
+                            const tom::LinkDefinition,
+                            const std::vector< Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 > >,
+                            const std::vector< TIME_TYPE >,
+                            const tom::LinkEndType,
+                            const std::vector< Eigen::VectorXd >,
+                            const std::shared_ptr< tss::ObservationDependentVariableCalculator >,
+                            const std::shared_ptr< tom::ObservationAncilliarySimulationSettings > >( ),
+                  py::arg( "observable_type" ),
+                  py::arg( "link_ends" ),
+                  py::arg( "observations" ),
+                  py::arg( "observation_epochs" ),
+                  py::arg( "reference_link_end" ),
+                  py::arg( "observation_dependent_variables" ) = std::vector< Eigen::VectorXd >( ),
+                  py::arg( "dependent_variable_calculator" ) = nullptr,
+                  py::arg( "ancilliary_settings" ) = nullptr )
             .def( "set_observations",
-                  py::overload_cast< const std::vector<
-                          Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 > >& >(
-                          &tom::SingleObservationSet< STATE_SCALAR_TYPE,
-                                                      TIME_TYPE >::setObservations ),
+                  py::overload_cast< const std::vector< Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 > >& >(
+                          &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::setObservations ),
                   py::arg( "observations" ),
                   R"doc(No documentation found.)doc" )
             .def( "set_observations",
                   py::overload_cast< const Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 >& >(
-                          &tom::SingleObservationSet< STATE_SCALAR_TYPE,
-                                                      TIME_TYPE >::setObservations ),
+                          &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::setObservations ),
                   py::arg( "observations" ),
                   R"doc(No documentation found.)doc" )
             .def( "set_residuals",
-                  py::overload_cast< const std::vector<
-                          Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 > >& >(
-                          &tom::SingleObservationSet< STATE_SCALAR_TYPE,
-                                                      TIME_TYPE >::setResiduals ),
+                  py::overload_cast< const std::vector< Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 > >& >(
+                          &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::setResiduals ),
                   py::arg( "residuals" ),
                   R"doc(No documentation found.)doc" )
             .def( "set_residuals",
                   py::overload_cast< const Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 >& >(
-                          &tom::SingleObservationSet< STATE_SCALAR_TYPE,
-                                                      TIME_TYPE >::setResiduals ),
+                          &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::setResiduals ),
                   py::arg( "residuals" ),
                   R"doc(No documentation found.)doc" )
             .def( "set_constant_weight",
-                  py::overload_cast< const double >(
-                          &tom::SingleObservationSet< STATE_SCALAR_TYPE,
-                                                      TIME_TYPE >::setConstantWeight ),
+                  py::overload_cast< const double >( &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::setConstantWeight ),
                   py::arg( "weight" ),
                   R"doc(No documentation found.)doc" )
             .def( "set_constant_weight",
                   py::overload_cast< const Eigen::Matrix< double, Eigen::Dynamic, 1 >& >(
-                          &tom::SingleObservationSet< STATE_SCALAR_TYPE,
-                                                      TIME_TYPE >::setConstantWeight ),
+                          &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::setConstantWeight ),
                   py::arg( "weight" ),
                   R"doc(No documentation found.)doc" )
             .def( "set_tabulated_weights",
                   py::overload_cast< const Eigen::VectorXd& >(
-                          &tom::SingleObservationSet< STATE_SCALAR_TYPE,
-                                                      TIME_TYPE >::setTabulatedWeights ),
+                          &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::setTabulatedWeights ),
                   py::arg( "weights" ),
                   R"doc(No documentation found.)doc" )
             .def( "filter_observations",
@@ -139,10 +144,9 @@ void expose_observations( py::module& m )
                   py::arg( "filter" ),
                   py::arg( "save_filtered_obs" ) = true,
                   R"doc(No documentation found.)doc" )
-            .def_property_readonly(
-                    "observable_type",
-                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getObservableType,
-                    R"doc(
+            .def_property_readonly( "observable_type",
+                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getObservableType,
+                                    R"doc(
 
          **read-only**
 
@@ -161,10 +165,9 @@ void expose_observations( py::module& m )
 
          :type: LinkDefinition
       )doc" )
-            .def_property_readonly(
-                    "reference_link_end",
-                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getReferenceLinkEnd,
-                    R"doc(
+            .def_property_readonly( "reference_link_end",
+                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getReferenceLinkEnd,
+                                    R"doc(
 
          **read-only**
 
@@ -173,27 +176,20 @@ void expose_observations( py::module& m )
          :type: LinkEndType
       )doc" )
             .def_property_readonly( "number_of_observables",
-                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE,
-                                                                TIME_TYPE >::getNumberOfObservables,
+                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getNumberOfObservables,
                                     R"doc(No documentation found.)doc" )
-            .def_property_readonly(
-                    "single_observable_size",
-                    &tom::SingleObservationSet< STATE_SCALAR_TYPE,
-                                                TIME_TYPE >::getSingleObservableSize,
-                    R"doc(No documentation found.)doc" )
-            .def_property_readonly(
-                    "total_observation_set_size",
-                    &tom::SingleObservationSet< STATE_SCALAR_TYPE,
-                                                TIME_TYPE >::getTotalObservationSetSize,
-                    R"doc(No documentation found.)doc" )
-            .def_property_readonly(
-                    "time_bounds",
-                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getTimeBounds,
-                    R"doc(No documentation found.)doc" )
-            .def_property_readonly(
-                    "list_of_observations",
-                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getObservations,
-                    R"doc(
+            .def_property_readonly( "single_observable_size",
+                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getSingleObservableSize,
+                                    R"doc(No documentation found.)doc" )
+            .def_property_readonly( "total_observation_set_size",
+                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getTotalObservationSetSize,
+                                    R"doc(No documentation found.)doc" )
+            .def_property_readonly( "time_bounds",
+                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getTimeBounds,
+                                    R"doc(No documentation found.)doc" )
+            .def_property_readonly( "list_of_observations",
+                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getObservations,
+                                    R"doc(
 
          **read-only**
 
@@ -201,10 +197,9 @@ void expose_observations( py::module& m )
 
          :type: list[ numpy.ndarray[numpy.float64[m, 1]] ]
       )doc" )
-            .def_property_readonly(
-                    "observation_times",
-                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getObservationTimes,
-                    R"doc(
+            .def_property_readonly( "observation_times",
+                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getObservationTimes,
+                                    R"doc(
 
          **read-only**
 
@@ -213,8 +208,7 @@ void expose_observations( py::module& m )
          :type: list[ float]
       )doc" )
             .def_property_readonly( "concatenated_observations",
-                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE,
-                                                                TIME_TYPE >::getObservationsVector,
+                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getObservationsVector,
                                     R"doc(
 
          **read-only**
@@ -223,55 +217,38 @@ void expose_observations( py::module& m )
 
          :type: numpy.ndarray[numpy.float64[m, 1]]
       )doc" )
+            .def_property_readonly( "computed_observations",
+                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getComputedObservations,
+                                    R"doc(No documentation found.)doc" )
+            .def_property_readonly( "concatenated_computed_observations",
+                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getComputedObservationsVector,
+                                    R"doc(No documentation found.)doc" )
+            .def_property_readonly( "residuals",
+                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getResiduals,
+                                    R"doc(No documentation found.)doc" )
+            .def_property_readonly( "concatenated_residuals",
+                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getResidualsVector,
+                                    R"doc(No documentation found.)doc" )
+            .def_property_readonly( "rms_residuals",
+                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getRmsResiduals,
+                                    R"doc(No documentation found.)doc" )
+            .def_property_readonly( "mean_residuals",
+                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getMeanResiduals,
+                                    R"doc(No documentation found.)doc" )
             .def_property_readonly(
-                    "computed_observations",
-                    &tom::SingleObservationSet< STATE_SCALAR_TYPE,
-                                                TIME_TYPE >::getComputedObservations,
-                    R"doc(No documentation found.)doc" )
-            .def_property_readonly(
-                    "concatenated_computed_observations",
-                    &tom::SingleObservationSet< STATE_SCALAR_TYPE,
-                                                TIME_TYPE >::getComputedObservationsVector,
-                    R"doc(No documentation found.)doc" )
-            .def_property_readonly(
-                    "residuals",
-                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getResiduals,
-                    R"doc(No documentation found.)doc" )
-            .def_property_readonly(
-                    "concatenated_residuals",
-                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getResidualsVector,
-                    R"doc(No documentation found.)doc" )
-            .def_property_readonly(
-                    "rms_residuals",
-                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getRmsResiduals,
-                    R"doc(No documentation found.)doc" )
-            .def_property_readonly(
-                    "mean_residuals",
-                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getMeanResiduals,
-                    R"doc(No documentation found.)doc" )
-            .def_property_readonly(
-                    "weights",
-                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getWeights,
-                    R"doc(No documentation found.)doc" )
-            .def_property_readonly(
-                    "concatenad_weights",
-                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getWeightsVector,
-                    R"doc(No documentation found.)doc" )
-            .def_property(
-                    "dependent_variables",
-                    &tom::SingleObservationSet< STATE_SCALAR_TYPE,
-                                                TIME_TYPE >::getObservationsDependentVariables,
-                    &tom::SingleObservationSet< STATE_SCALAR_TYPE,
-                                                TIME_TYPE >::setObservationsDependentVariables,
-                    R"doc(No documentation found.)doc" )
-            .def_property_readonly(
-                    "dependent_variables_history",
-                    &tom::SingleObservationSet< STATE_SCALAR_TYPE,
-                                                TIME_TYPE >::getDependentVariableHistory,
-                    R"doc(No documentation found.)doc" )
+                    "weights", &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getWeights, R"doc(No documentation found.)doc" )
+            .def_property_readonly( "concatenad_weights",
+                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getWeightsVector,
+                                    R"doc(No documentation found.)doc" )
+            .def_property( "dependent_variables",
+                           &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getObservationsDependentVariables,
+                           &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::setObservationsDependentVariables,
+                           R"doc(No documentation found.)doc" )
+            .def_property_readonly( "dependent_variables_history",
+                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getDependentVariableHistory,
+                                    R"doc(No documentation found.)doc" )
             .def_property_readonly( "observations_history",
-                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE,
-                                                                TIME_TYPE >::getObservationsHistory,
+                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getObservationsHistory,
                                     R"doc(
 
          **read-only**
@@ -281,8 +258,7 @@ void expose_observations( py::module& m )
          :type: dict[ float, numpy.ndarray[numpy.float64[m, 1]] ]
       )doc" )
             .def_property_readonly( "ancilliary_settings",
-                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE,
-                                                                TIME_TYPE >::getAncilliarySettings,
+                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getAncilliarySettings,
                                     R"doc(
 
          **read-only**
@@ -291,44 +267,33 @@ void expose_observations( py::module& m )
 
          :type: ObservationAncilliarySimulationSettings
       )doc" )
-            .def_property(
-                    "weights_vector",
-                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getWeightsVector,
-                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::setTabulatedWeights,
-                    R"doc(No documentation found.)doc" )
-            .def_property_readonly(
-                    "filtered_observation_set",
-                    &tom::SingleObservationSet< STATE_SCALAR_TYPE,
-                                                TIME_TYPE >::getFilteredObservationSet,
-                    R"doc(No documentation found.)doc" )
-            .def_property_readonly(
-                    "number_filtered_observations",
-                    &tom::SingleObservationSet< STATE_SCALAR_TYPE,
-                                                TIME_TYPE >::getNumberOfFilteredObservations,
-                    R"doc(No documentation found.)doc" )
+            .def_property( "weights_vector",
+                           &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getWeightsVector,
+                           &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::setTabulatedWeights,
+                           R"doc(No documentation found.)doc" )
+            .def_property_readonly( "filtered_observation_set",
+                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getFilteredObservationSet,
+                                    R"doc(No documentation found.)doc" )
+            .def_property_readonly( "number_filtered_observations",
+                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getNumberOfFilteredObservations,
+                                    R"doc(No documentation found.)doc" )
             .def( "single_dependent_variable",
-                  py::overload_cast< std::shared_ptr< tss::ObservationDependentVariableSettings >,
-                                     const bool >(
-                          &tom::SingleObservationSet< STATE_SCALAR_TYPE,
-                                                      TIME_TYPE >::getSingleDependentVariable ),
+                  py::overload_cast< std::shared_ptr< tss::ObservationDependentVariableSettings >, const bool >(
+                          &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getSingleDependentVariable ),
                   py::arg( "dependent_variable_settings" ),
                   py::arg( "return_first_compatible_settings" ) = false,
                   R"doc(No documentation found.)doc" )
             .def( "compatible_dependent_variable_settings",
-                  &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::
-                          getCompatibleDependentVariablesSettingsList,
+                  &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getCompatibleDependentVariablesSettingsList,
                   R"doc(No documentation found.)doc" )
             .def( "compatible_dependent_variables_list",
-                  &tom::SingleObservationSet< STATE_SCALAR_TYPE,
-                                              TIME_TYPE >::getAllCompatibleDependentVariables,
+                  &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getAllCompatibleDependentVariables,
                   R"doc(No documentation found.)doc" )
             .def( "single_dependent_variable_history",
-                  &tom::SingleObservationSet< STATE_SCALAR_TYPE,
-                                              TIME_TYPE >::getSingleDependentVariableHistory,
+                  &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getSingleDependentVariableHistory,
                   R"doc(No documentation found.)doc" )
             .def_property_readonly( "dependent_variables_matrix",
-                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::
-                                            getObservationsDependentVariablesMatrix,
+                                    &tom::SingleObservationSet< STATE_SCALAR_TYPE, TIME_TYPE >::getObservationsDependentVariablesMatrix,
                                     R"doc(No documentation found.)doc" );
 
     m.def( "single_observation_set",
@@ -892,8 +857,7 @@ observation_parser : ObservationCollectionParser
            &tss::mergeObservationCollections< STATE_SCALAR_TYPE, TIME_TYPE >,
            py::arg( "observation_collection_list" ) );
 
-
-    // The following functions create a new ObservationCollection object from an existing one 
+    // The following functions create a new ObservationCollection object from an existing one
 
     m.def( "create_filtered_observation_collection",
            py::overload_cast<

--- a/src/tudatpy/estimation/observations_setup/observations_wrapper/expose_observations_wrapper.cpp
+++ b/src/tudatpy/estimation/observations_setup/observations_wrapper/expose_observations_wrapper.cpp
@@ -31,6 +31,8 @@ namespace observations_wrapper
 
 void expose_observations_wrapper( py::module& m )
 {
+    py::module_::import( "tudatpy.estimation.observations" ).attr( "ObservationCollection" );
+
     // Create wrapper function
     py::cpp_function getDsnDefaultTurnaroundRatios_wrapper = []( tudat::observation_models::FrequencyBands band1,
                                                                  tudat::observation_models::FrequencyBands band2 ) {

--- a/src/tudatpy/math/interpolators/expose_interpolators.cpp
+++ b/src/tudatpy/math/interpolators/expose_interpolators.cpp
@@ -191,9 +191,13 @@ The program will terminate and throw a :class:`~tudatpy.exceptions.LagrangeInter
                 std::shared_ptr< ti::InterpolatorGenerationSettings< tudat::Time > > >(
             m, "InterpolatorGenerationSettingsTimeObject", R"doc(No documentation found.)doc" );
 
-    py::class_< ti::InterpolatorGenerationSettings< double >,
-                std::shared_ptr< ti::InterpolatorGenerationSettings< double > > >(
-            m, "InterpolatorGenerationSettings", R"doc(No documentation found.)doc" );
+    py::class_< ti::InterpolatorGenerationSettings< double >, std::shared_ptr< ti::InterpolatorGenerationSettings< double > > >(
+            m, "InterpolatorGenerationSettings", R"doc(No documentation found.)doc" )
+            .def( py::init< const std::shared_ptr< ti::InterpolatorSettings >, const double, const double, const double >( ),
+                  py::arg( "interpolator_settings" ),
+                  py::arg( "initial_time" ),
+                  py::arg( "final_time" ),
+                  py::arg( "time_step" ) );
 
     py::class_< ti::LagrangeInterpolatorSettings,
                 std::shared_ptr< ti::LagrangeInterpolatorSettings >,
@@ -493,11 +497,12 @@ The program will terminate and throw a :class:`~tudatpy.exceptions.LagrangeInter
          list[float]
              Dependent variable values used by the interpolator
          )doc" );
-    
+
     py::class_< ti::OneDimensionalInterpolator< Time, STATE_SCALAR_TYPE >,
-                std::shared_ptr< ti::OneDimensionalInterpolator< Time, STATE_SCALAR_TYPE > > >( m,
-                                                                                                     "OneDimensionalInterpolatorScalarTimeObject",
-                                                                                                     R"doc(
+                std::shared_ptr< ti::OneDimensionalInterpolator< Time, STATE_SCALAR_TYPE > > >(
+            m,
+            "OneDimensionalInterpolatorScalarTimeObject",
+            R"doc(
         Same as :func:`~OneDimensionalInterpolatorScalar`, but using the high-resolution :func:`~Time` type used as independent variable for interpolation; created using :func:`~create_one_dimensional_scalar_interpolator_time_object`
 
      )doc" )
@@ -517,7 +522,6 @@ The program will terminate and throw a :class:`~tudatpy.exceptions.LagrangeInter
         float
             Interpolated dependent variable value, using implemented algorithm at requested independent variable value
     )doc" );
-    
 
     py::class_< ti::OneDimensionalInterpolator< double, Eigen::VectorXd >,
                 std::shared_ptr< ti::OneDimensionalInterpolator< double, Eigen::VectorXd > > >(

--- a/src/tudatpy/numerical_simulation/__init__.py
+++ b/src/tudatpy/numerical_simulation/__init__.py
@@ -1,6 +1,6 @@
 import warnings
 warnings.warn(
-    "tudatpy.numerical_simulation is deprecated. Use tudatpy.dynamics and/or tudatpy.estimation.",
+    "tudatpy.numerical_simulation is deprecated as of v1.0 (see https://docs.tudat.space/en/latest/user-guide/project-updates/migration-guide.html). Use tudatpy.dynamics and/or tudatpy.estimation.",
     FutureWarning,
     stacklevel=1
 )

--- a/src/tudatpy/numerical_simulation/environment/__init__.py
+++ b/src/tudatpy/numerical_simulation/environment/__init__.py
@@ -1,6 +1,6 @@
 import warnings
 warnings.warn(
-    "tudatpy.numerical_simulation.environment is deprecated. Use tudatpy.dynamics.environment instead.",
+    "tudatpy.numerical_simulation.environment is deprecated as of v1.0 (see https://docs.tudat.space/en/latest/user-guide/project-updates/migration-guide.html). Use tudatpy.dynamics.environment instead.",
     FutureWarning,
     stacklevel=1
 )

--- a/src/tudatpy/numerical_simulation/environment_setup/__init__.py
+++ b/src/tudatpy/numerical_simulation/environment_setup/__init__.py
@@ -1,6 +1,6 @@
 import warnings
 warnings.warn(
-    "tudatpy.numerical_simulation.environment_setup is deprecated. Use tudatpy.dynamics.environment_setup instead.",
+    "tudatpy.numerical_simulation.environment_setup is deprecated as of v1.0 (see https://docs.tudat.space/en/latest/user-guide/project-updates/migration-guide.html). Use tudatpy.dynamics.environment_setup instead.",
     FutureWarning,
     stacklevel=1
 )

--- a/src/tudatpy/numerical_simulation/estimation/__init__.py
+++ b/src/tudatpy/numerical_simulation/estimation/__init__.py
@@ -1,6 +1,6 @@
 import warnings
 warnings.warn(
-    "tudatpy.numerical_simulation.estimation is deprecated. Use tudatpy.estimation.observations, tudatpy.estimation.observations_setup and/or tudatpy.estimation.estimation_analysis instead.",
+    "tudatpy.numerical_simulation.estimation is deprecated as of v1.0 (see https://docs.tudat.space/en/latest/user-guide/project-updates/migration-guide.html). Use tudatpy.estimation.observations, tudatpy.estimation.observations_setup and/or tudatpy.estimation.estimation_analysis instead.",
     FutureWarning,
     stacklevel=1
 )

--- a/src/tudatpy/numerical_simulation/estimation_setup/__init__.py
+++ b/src/tudatpy/numerical_simulation/estimation_setup/__init__.py
@@ -1,6 +1,6 @@
 import warnings
 warnings.warn(
-    "tudatpy.numerical_simulation.estimation_setup is deprecated.\nFeatures got distributed over:\n"
+    "tudatpy.numerical_simulation.estimation_setup is deprecated as of v1.0 (see https://docs.tudat.space/en/latest/user-guide/project-updates/migration-guide.html).\nFeatures got distributed over:\n"
     " tudatpy.estimation.observable_models_setup, \n" +
     " tudatpy.estimation.observable_models, \n" +
     " tudatpy.estimation.observations_setup, \n" +

--- a/src/tudatpy/numerical_simulation/estimation_setup/observation/__init__.py
+++ b/src/tudatpy/numerical_simulation/estimation_setup/observation/__init__.py
@@ -1,6 +1,6 @@
 import warnings
 warnings.warn(
-    "tudatpy.numerical_simulation.estimation_setup.observation is deprecated. Use tudatpy.estimation.observable_models_setup and/or tudatpy.estimation.observations_setup instead.",
+    "tudatpy.numerical_simulation.estimation_setup.observation is deprecated as of v1.0 (see https://docs.tudat.space/en/latest/user-guide/project-updates/migration-guide.html). Use tudatpy.estimation.observable_models_setup and/or tudatpy.estimation.observations_setup instead.",
     FutureWarning,
     stacklevel=1
 )

--- a/src/tudatpy/numerical_simulation/propagation/__init__.py
+++ b/src/tudatpy/numerical_simulation/propagation/__init__.py
@@ -1,6 +1,6 @@
 import warnings
 warnings.warn(
-    "tudatpy.numerical_simulation.propagation is deprecated. Use tudatpy.dynamics.propagation instead.",
+    "tudatpy.numerical_simulation.propagation is deprecated as of v1.0 (see https://docs.tudat.space/en/latest/user-guide/project-updates/migration-guide.html). Use tudatpy.dynamics.propagation instead.",
     FutureWarning,
     stacklevel=1
 )

--- a/src/tudatpy/numerical_simulation/propagation_setup/__init__.py
+++ b/src/tudatpy/numerical_simulation/propagation_setup/__init__.py
@@ -1,6 +1,6 @@
 import warnings
 warnings.warn(
-    "tudatpy.numerical_simulation.propagation_setup is deprecated. Use tudatpy.dynamics.propagation_setup instead.",
+    "tudatpy.numerical_simulation.propagation_setup is deprecated as of v1.0 (see https://docs.tudat.space/en/latest/user-guide/project-updates/migration-guide.html). Use tudatpy.dynamics.propagation_setup instead.",
     FutureWarning,
     stacklevel=1
 )

--- a/tests/test_tudat/src/io/unitTestOdfFileReader.cpp
+++ b/tests/test_tudat/src/io/unitTestOdfFileReader.cpp
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE( testSingleOdfFileReader )
 
     std::shared_ptr< input_output::OdfDopplerDataBlock > dopplerDataBlock = std::dynamic_pointer_cast< input_output::OdfDopplerDataBlock >(
             rawOdfContents->getDataBlocks( ).at( 0 )->getObservableSpecificDataBlock( ) );
-    BOOST_CHECK_EQUAL( dopplerDataBlock->dataType_, 11 );
+    BOOST_CHECK_EQUAL( dopplerDataBlock->dataType_, input_output::OdfDataType::one_way_doppler );
     BOOST_CHECK_EQUAL( dopplerDataBlock->getReceiverChannel( ), 1 );
     BOOST_CHECK_EQUAL( dopplerDataBlock->getSpacecraftId( ), 236 );
     BOOST_CHECK_EQUAL( dopplerDataBlock->getReceiverExciterFlag( ), 1 );
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE( testSingleOdfFileReader )
 
     dopplerDataBlock = std::dynamic_pointer_cast< input_output::OdfDopplerDataBlock >(
             rawOdfContents->getDataBlocks( ).at( 19 )->getObservableSpecificDataBlock( ) );
-    BOOST_CHECK_EQUAL( dopplerDataBlock->dataType_, 12 );
+    BOOST_CHECK_EQUAL( dopplerDataBlock->dataType_, input_output::OdfDataType::two_way_doppler );
     BOOST_CHECK_EQUAL( dopplerDataBlock->getReceiverChannel( ), 1 );
     BOOST_CHECK_EQUAL( dopplerDataBlock->getSpacecraftId( ), 236 );
     BOOST_CHECK_EQUAL( dopplerDataBlock->getReceiverExciterFlag( ), 1 );
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE( testSingleOdfFileReader )
     std::shared_ptr< input_output::OdfSequentialRangeDataBlock > rangeDataBlock =
             std::dynamic_pointer_cast< input_output::OdfSequentialRangeDataBlock >(
                     rawOdfContents->getDataBlocks( ).at( 23 )->getObservableSpecificDataBlock( ) );
-    BOOST_CHECK_EQUAL( rangeDataBlock->dataType_, 37 );
+    BOOST_CHECK_EQUAL( rangeDataBlock->dataType_, input_output::OdfDataType::sra_planetary_operational_discrete_spectrum_range );
     BOOST_CHECK_EQUAL( rangeDataBlock->getLowestRangingComponent( ), 14 );
     BOOST_CHECK_EQUAL( rangeDataBlock->getSpacecraftId( ), 236 );
     // BOOST_CHECK_EQUAL ( rangeDataBlock->reservedBlock_, 1 );

--- a/tests/test_tudat/src/io/unitTestOdfFileReader.cpp
+++ b/tests/test_tudat/src/io/unitTestOdfFileReader.cpp
@@ -72,7 +72,8 @@ BOOST_AUTO_TEST_CASE( testSingleOdfFileReader )
 
     std::shared_ptr< input_output::OdfDopplerDataBlock > dopplerDataBlock = std::dynamic_pointer_cast< input_output::OdfDopplerDataBlock >(
             rawOdfContents->getDataBlocks( ).at( 0 )->getObservableSpecificDataBlock( ) );
-    BOOST_CHECK_EQUAL( dopplerDataBlock->dataType_, input_output::OdfDataType::one_way_doppler );
+    BOOST_CHECK_EQUAL( static_cast< int >( dopplerDataBlock->dataType_ ),
+                       static_cast< int >( input_output::OdfDataType::one_way_doppler ) );
     BOOST_CHECK_EQUAL( dopplerDataBlock->getReceiverChannel( ), 1 );
     BOOST_CHECK_EQUAL( dopplerDataBlock->getSpacecraftId( ), 236 );
     BOOST_CHECK_EQUAL( dopplerDataBlock->getReceiverExciterFlag( ), 1 );
@@ -97,7 +98,8 @@ BOOST_AUTO_TEST_CASE( testSingleOdfFileReader )
 
     dopplerDataBlock = std::dynamic_pointer_cast< input_output::OdfDopplerDataBlock >(
             rawOdfContents->getDataBlocks( ).at( 19 )->getObservableSpecificDataBlock( ) );
-    BOOST_CHECK_EQUAL( dopplerDataBlock->dataType_, input_output::OdfDataType::two_way_doppler );
+    BOOST_CHECK_EQUAL( static_cast< int >( dopplerDataBlock->dataType_ ),
+                       static_cast< int >( input_output::OdfDataType::two_way_doppler ) );
     BOOST_CHECK_EQUAL( dopplerDataBlock->getReceiverChannel( ), 1 );
     BOOST_CHECK_EQUAL( dopplerDataBlock->getSpacecraftId( ), 236 );
     BOOST_CHECK_EQUAL( dopplerDataBlock->getReceiverExciterFlag( ), 1 );
@@ -123,7 +125,8 @@ BOOST_AUTO_TEST_CASE( testSingleOdfFileReader )
     std::shared_ptr< input_output::OdfSequentialRangeDataBlock > rangeDataBlock =
             std::dynamic_pointer_cast< input_output::OdfSequentialRangeDataBlock >(
                     rawOdfContents->getDataBlocks( ).at( 23 )->getObservableSpecificDataBlock( ) );
-    BOOST_CHECK_EQUAL( rangeDataBlock->dataType_, input_output::OdfDataType::sra_planetary_operational_discrete_spectrum_range );
+    BOOST_CHECK_EQUAL( static_cast< int >( rangeDataBlock->dataType_ ),
+                       static_cast< int >( input_output::OdfDataType::sra_planetary_operational_discrete_spectrum_range ) );
     BOOST_CHECK_EQUAL( rangeDataBlock->getLowestRangingComponent( ), 14 );
     BOOST_CHECK_EQUAL( rangeDataBlock->getSpacecraftId( ), 236 );
     // BOOST_CHECK_EQUAL ( rangeDataBlock->reservedBlock_, 1 );


### PR DESCRIPTION
- Imported exposure of InterpolationSettings in expose_data.cpp to remove associated C++ objects from docstrings
- Added minimal docstring to VehicleSystems.set_default_transponder_turnaround_ratio_function
- Imported exposure of ObservationCollection in expose_observations_wrapper.cpp (same as above)
- Adjusted build order in expose_estimation remove C++ objects from docstrings
- Exposed constructor of InterpolatorGeneratorSettings to be able to initialize them directly from the object
- Updated build.py to display `Stubs generated successfully` at the end. Requested by @luigigisolfi  to make it clear that stubgen errors don't matter