### PR TITLE
Expose stm interface attribute

### DIFF
--- a/src/tudatpy/astro/gravitation/expose_gravitation.cpp
+++ b/src/tudatpy/astro/gravitation/expose_gravitation.cpp
@@ -100,7 +100,7 @@ void expose_gravitation( py::module& m )
 
  Function to normalize spherical harmonic coefficients
 
- Function to normalize spherical harmonic coefficients, using the equations provided in the :func:`~tudatpy.gravitation.astro.legendre_normalization_factor` function.
+ Function to normalize spherical harmonic coefficients, using the equations provided in the :func:`~tudatpy.astro.gravitation.legendre_normalization_factor` function.
 
  Parameters
  ----------

--- a/src/tudatpy/dynamics/simulator/expose_simulator.cpp
+++ b/src/tudatpy/dynamics/simulator/expose_simulator.cpp
@@ -440,13 +440,26 @@ void expose_simulator( py::module& m )
 
          Base class for variational equations propagation.
          Derived classes :class:`~SingleArcVariationalSimulator`, :class:`~MultiArcVariationalSimulator` and
-         :class:`~HybridArcVariationalSimulator` implement single-, multi- and hybrid-arc functionality, respectively."
+         :class:`~HybridArcVariationalSimulator` implement single-, multi- and hybrid-arc functionality, respectively.
 
+      )doc" )
+      .def_property_readonly(
+                    "state_transition_interface",
+                    &tp::VariationalEquationsSolver< STATE_SCALAR_TYPE, TIME_TYPE >::
+                            getStateTransitionMatrixInterface,
+                    R"doc(
+
+         **read-only**
+
+         State transition interface that includes the state transition and sensitivity matrices, which can be used for instance to propagate a covariance, see :func:`~tudatpy.estimation.estimation_analysis.propagate_covariance`.
+
+
+         :type: CombinedStateTransitionAndSensitivityMatrixInterface
       )doc" );
 
     py::class_< tp::SingleArcVariationalEquationsSolver< STATE_SCALAR_TYPE, TIME_TYPE >,
                 std::shared_ptr<
-                        tp::SingleArcVariationalEquationsSolver< STATE_SCALAR_TYPE, TIME_TYPE > > >(
+                        tp::SingleArcVariationalEquationsSolver< STATE_SCALAR_TYPE, TIME_TYPE > >, tp::VariationalEquationsSolver< STATE_SCALAR_TYPE, TIME_TYPE > >(
             m,
             "SingleArcVariationalSimulator",
             R"doc(

--- a/src/tudatpy/estimation/estimation_analysis/expose_estimation_analysis.cpp
+++ b/src/tudatpy/estimation/estimation_analysis/expose_estimation_analysis.cpp
@@ -593,7 +593,7 @@ void expose_estimation_analysis( py::module& m )
 
          **read-only**
 
-         (Unnormalized) estimation covariance matrix :math:`\mathbf{P}`.
+         (Unnormalized) estimation covariance matrix :math:`\mathbf{P}`. Note: if the :class:`~tudatpy.estimation.estimation_analysis.CovarianceAnalysisInput` includes consider parameters, this matrix does not include their contribution.
 
          :type: numpy.ndarray[numpy.float64[m, m]]
       )doc" )
@@ -695,24 +695,71 @@ void expose_estimation_analysis( py::module& m )
                     "consider_covariance_contribution",
                     &tss::CovarianceAnalysisOutput< STATE_SCALAR_TYPE,
                                                     TIME_TYPE >::getConsiderCovarianceContribution,
-                    R"doc(No documentation found.)doc" )
+                    R"doc(
+
+         **read-only**
+
+         Contribution of the consider parameters to the consider covariance matrix, equal to :math:`(\mathbf{P} \mathbf{H}^{T} \mathbf{W}) (\mathbf{H}_c \mathbf{C} \mathbf{H}^{T}_c) (\mathbf{P} \mathbf{H}^{T} \mathbf{W})^{T}`
+
+         :type: numpy.ndarray[numpy.float64[m, n]]
+      )doc" )
             .def_property_readonly( "normalized_covariance_with_consider_parameters",
                                     &tss::CovarianceAnalysisOutput< STATE_SCALAR_TYPE, TIME_TYPE >::
                                             getNormalizedCovarianceWithConsiderParameters,
-                                    R"doc(No documentation found.)doc" )
+                                    R"doc(
+
+         **read-only**
+
+         Normalized consider covariance matrix :math:`\tilde{\mathbf{P}}_c`, with entries :math:`\tilde{P}_{c,ij}=P_{c,ij}\nu_{i}\nu_{j}`, where :math:`\nu_{i},\nu_{j}` are the normalization terms as given by the :attr:`~tudatpy.estimation.estimation_analysis.CovarianceAnalysisOutput.normalization_terms` attribute.
+
+         :type: numpy.ndarray[numpy.float64[m, n]]
+      )doc" )
             .def_property_readonly( "unnormalized_covariance_with_consider_parameters",
                                     &tss::CovarianceAnalysisOutput< STATE_SCALAR_TYPE, TIME_TYPE >::
                                             getUnnormalizedCovarianceWithConsiderParameters,
-                                    R"doc(No documentation found.)doc" )
+                                    R"doc(
+
+         **read-only**
+
+         Consider covariance matrix :math:`\mathbf{P}_c`, equal to the sum of the :attr:`~tudatpy.estimation.estimation_analysis.CovarianceAnalysisOutput.covariance` matrix and the :attr:`~tudatpy.estimation.estimation_analysis.CovarianceAnalysisOutput.consider_covariance_contribution` matrix.
+
+
+         :type: numpy.ndarray[numpy.float64[m, n]]
+      )doc" )
+            .def_property_readonly( "unnormalized_design_matrix_consider_parameters",
+                            &tss::CovarianceAnalysisOutput< STATE_SCALAR_TYPE, TIME_TYPE >::
+                                    getUnnormalizedDesignMatrixConsiderParameters,
+                            R"doc(
+
+         **read-only**
+
+         Matrix of unnormalized partial derivatives for consider parameters :math:`\mathbf{H}_c=\frac{\partial\mathbf{h}}{\partial\mathbf{c}}`.
+
+         :type: numpy.ndarray[numpy.float64[m, n]]
+      )doc" )
             .def_property_readonly( "normalized_design_matrix_consider_parameters",
                                     &tss::CovarianceAnalysisOutput< STATE_SCALAR_TYPE, TIME_TYPE >::
                                             getNormalizedDesignMatrixConsiderParameters,
-                                    R"doc(No documentation found.)doc" )
+                                    R"doc(
+
+         **read-only**
+
+         Matrix of normalized partial derivatives for consider parameters :math:`\tilde{\mathbf{H}_c}`.
+
+         :type: numpy.ndarray[numpy.float64[m, n]]
+      )doc" )
             .def_property_readonly(
                     "consider_normalization_factors",
                     &tss::CovarianceAnalysisOutput< STATE_SCALAR_TYPE,
                                                     TIME_TYPE >::getConsiderNormalizationFactors,
-                    R"doc(No documentation found.)doc" )
+                    R"doc(
+
+         **read-only**
+
+         Vector of normalization terms used for consider covariance and consider design matrix
+
+         :type: numpy.ndarray[numpy.float64[m, 1]]
+      )doc" )
             .def_readonly( "normalization_terms",
                            &tss::CovarianceAnalysisOutput< STATE_SCALAR_TYPE, TIME_TYPE >::
                                    designMatrixTransformationDiagonal_,


### PR DESCRIPTION
- Expose `state_transition_interface` attribute in `VariationalSimulator` base class
- Add docs for remaining `CovarianceAnalysisOutput` attributes, expose `unnormalized_design_matrix_consider_parameters`