### PR TITLE
Refactor stub generation for python scripts

### DIFF
--- a/src/tudatpy/dynamics/environment_setup/expose_environment_setup.cpp
+++ b/src/tudatpy/dynamics/environment_setup/expose_environment_setup.cpp
@@ -101,6 +101,7 @@ void expose_environment_setup( py::module& m )
          :class:`BodyListSettings` object.
 
       )doc" )
+            .def( py::init<>( ) )
             .def_readwrite( "constant_mass", &tss::BodySettings::constantMass, R"doc(
 
          Mass that gets assigned to the vehicle. This mass does *not* automatically define a gravity field
@@ -190,9 +191,7 @@ void expose_environment_setup( py::module& m )
 
          :type: list[BodyDeformationSettings]
       )doc" )
-            .def_readwrite( "ground_station_settings",
-                            &tss::BodySettings::groundStationSettings,
-                            R"doc(No documentation found.)doc" )
+            .def_readwrite( "ground_station_settings", &tss::BodySettings::groundStationSettings, R"doc(No documentation found.)doc" )
             .def_readwrite( "rigid_body_settings",
                             &tss::BodySettings::rigidBodyPropertiesSettings,
                             R"doc(
@@ -224,8 +223,7 @@ void expose_environment_setup( py::module& m )
 
          :type: RadiationSourceModelSettings
       )doc" )
-            .def_readwrite(
-                    "vehicle_shape_settings", &tss::BodySettings::bodyExteriorPanelSettings_, R"doc(
+            .def_readwrite( "vehicle_shape_settings", &tss::BodySettings::bodyExteriorPanelSettings_, R"doc(
 
          Object that defines the settings of an exterior panelled vehicle shape that is to be created. A variable of this type is typically
          assigned by using a function from the :ref:`vehicle_systems` module.
@@ -244,8 +242,7 @@ void expose_environment_setup( py::module& m )
 
       )doc" );
 
-    py::class_< tss::BodyListSettings, std::shared_ptr< tss::BodyListSettings > >(
-            m, "BodyListSettings", R"doc(
+    py::class_< tss::BodyListSettings, std::shared_ptr< tss::BodyListSettings > >( m, "BodyListSettings", R"doc(
 
          Class for defining settings for the creation of a system of bodies.
 
@@ -300,8 +297,7 @@ void expose_environment_setup( py::module& m )
 
      )doc" )
             .def( "add_settings",
-                  py::overload_cast< std::shared_ptr< tss::BodySettings >, const std::string >(
-                          &tss::BodyListSettings::addSettings ),
+                  py::overload_cast< std::shared_ptr< tss::BodySettings >, const std::string >( &tss::BodyListSettings::addSettings ),
                   py::arg( "settings_to_add" ),
                   py::arg( "body_name" ),
                   R"doc(
@@ -355,8 +351,7 @@ void expose_environment_setup( py::module& m )
 
          :type: str
       )doc" )
-            .def_property_readonly(
-                    "frame_orientation", &tss::BodyListSettings::getFrameOrientation, R"doc(
+            .def_property_readonly( "frame_orientation", &tss::BodyListSettings::getFrameOrientation, R"doc(
 
          **read-only**
 
@@ -366,9 +361,7 @@ void expose_environment_setup( py::module& m )
       )doc" );
 
     m.def( "get_default_body_settings",
-           py::overload_cast< const std::vector< std::string > &,
-                              const std::string,
-                              const std::string >( &tss::getDefaultBodySettings ),
+           py::overload_cast< const std::vector< std::string >&, const std::string, const std::string >( &tss::getDefaultBodySettings ),
            py::arg( "bodies" ),
            py::arg( "base_frame_origin" ) = "SSB",
            py::arg( "base_frame_orientation" ) = "ECLIPJ2000",
@@ -408,7 +401,7 @@ void expose_environment_setup( py::module& m )
      )doc" );
 
     m.def( "get_default_body_settings_time_limited",
-           py::overload_cast< const std::vector< std::string > &,
+           py::overload_cast< const std::vector< std::string >&,
                               const double,
                               const double,
                               const std::string,
@@ -456,8 +449,7 @@ void expose_environment_setup( py::module& m )
      )doc" );
 
     m.def( "get_default_single_body_settings",
-           py::overload_cast< const std::string &, const std::string & >(
-                   &tss::getDefaultSingleBodySettings ),
+           py::overload_cast< const std::string&, const std::string& >( &tss::getDefaultSingleBodySettings ),
            py::arg( "body_name" ),
            py::arg( "base_frame_orientation" ) = "ECLIPJ2000",
            R"doc(
@@ -486,11 +478,8 @@ void expose_environment_setup( py::module& m )
      )doc" );
 
     m.def( "get_default_single_body_settings_time_limited",
-           py::overload_cast< const std::string &,
-                              const double,
-                              const double,
-                              const std::string &,
-                              const double >( &tss::getDefaultSingleBodySettings ),
+           py::overload_cast< const std::string&, const double, const double, const std::string&, const double >(
+                   &tss::getDefaultSingleBodySettings ),
            py::arg( "body_name" ),
            py::arg( "initial_time" ),
            py::arg( "final_time" ),
@@ -528,7 +517,7 @@ void expose_environment_setup( py::module& m )
      )doc" );
 
     m.def( "get_default_single_alternate_body_settings",
-           py::overload_cast< const std::string &, const std::string &, const std::string & >(
+           py::overload_cast< const std::string&, const std::string&, const std::string& >(
                    &tss::getDefaultSingleAlternateNameBodySettings ),
            py::arg( "body_name" ),
            py::arg( "source_body_name" ),
@@ -564,12 +553,8 @@ void expose_environment_setup( py::module& m )
      )doc" );
 
     m.def( "get_default_single_alternate_body_settings_time_limited",
-           py::overload_cast< const std::string &,
-                              const std::string &,
-                              const double,
-                              const double,
-                              const std::string &,
-                              const double >( &tss::getDefaultSingleAlternateNameBodySettings ),
+           py::overload_cast< const std::string&, const std::string&, const double, const double, const std::string&, const double >(
+                   &tss::getDefaultSingleAlternateNameBodySettings ),
            py::arg( "body_name" ),
            py::arg( "source_body_name" ),
            py::arg( "initial_time" ),
@@ -684,8 +669,7 @@ void expose_environment_setup( py::module& m )
            py::arg( "time_step" ),
            py::arg( "observer_name" ),
            py::arg( "reference_frame_name" ),
-           py::arg( "interpolator_settings" ) =
-                   std::make_shared< tudat::interpolators::LagrangeInterpolatorSettings >( 8 ) );
+           py::arg( "interpolator_settings" ) = std::make_shared< tudat::interpolators::LagrangeInterpolatorSettings >( 8 ) );
 
     m.def( "create_body_ephemeris",
            &tss::createBodyEphemeris< STATE_SCALAR_TYPE, TIME_TYPE >,
@@ -718,16 +702,12 @@ void expose_environment_setup( py::module& m )
      )doc" );
 
     m.def( "create_ground_station_ephemeris",
-           py::overload_cast< const std::shared_ptr< tss::Body >,
-                              const std::string &,
-                              const tss::SystemOfBodies & >(
+           py::overload_cast< const std::shared_ptr< tss::Body >, const std::string&, const tss::SystemOfBodies& >(
                    &tss::createReferencePointEphemerisFromId< TIME_TYPE, STATE_SCALAR_TYPE > ),
            "body_with_ground_station",
            "station_name" );
 
-    m.def( "get_safe_interpolation_interval",
-           &tss::getSafeInterpolationInterval,
-           py::arg( "ephemeris_model" ) );
+    m.def( "get_safe_interpolation_interval", &tss::getSafeInterpolationInterval, py::arg( "ephemeris_model" ) );
 
     m.def( "add_aerodynamic_coefficient_interface",
            &tss::addAerodynamicCoefficientInterface,
@@ -850,8 +830,7 @@ void expose_environment_setup( py::module& m )
            py::arg( "bodies" ),
            py::arg( "body_name" ),
            py::arg( "gravity_field_settings" ),
-           py::arg( "gravity_field_variation_settings" ) =
-                   std::vector< std::shared_ptr< tss::GravityFieldVariationSettings > >( ),
+           py::arg( "gravity_field_variation_settings" ) = std::vector< std::shared_ptr< tss::GravityFieldVariationSettings > >( ),
            R"doc(No documentation found.)doc" );
 
     m.def( "add_mass_properties_model",
@@ -1006,23 +985,19 @@ void expose_environment_setup( py::module& m )
            R"doc(No documentation found.)doc" );
 
     m.def( "add_ground_station",
-           py::overload_cast<
-                   const std::shared_ptr< tss::Body >,
-                   const std::string,
-                   const Eigen::Vector3d,
-                   const tcc::PositionElementTypes,
-                   const std::vector< std::shared_ptr< tss::GroundStationMotionSettings > > >(
-                   &tss::createGroundStation ),
+           py::overload_cast< const std::shared_ptr< tss::Body >,
+                              const std::string,
+                              const Eigen::Vector3d,
+                              const tcc::PositionElementTypes,
+                              const std::vector< std::shared_ptr< tss::GroundStationMotionSettings > > >( &tss::createGroundStation ),
            py::arg( "body" ),
            py::arg( "ground_station_name" ),
            py::arg( "ground_station_position" ),
            py::arg( "position_type" ) = tcc::cartesian_position,
-           py::arg( "station_motion_settings" ) =
-                   std::vector< std::shared_ptr< tss::GroundStationMotionSettings > >( ) );
+           py::arg( "station_motion_settings" ) = std::vector< std::shared_ptr< tss::GroundStationMotionSettings > >( ) );
 
     m.def( "add_ground_station",
-           py::overload_cast< const std::shared_ptr< tss::Body >,
-                              const std::shared_ptr< tss::GroundStationSettings > >(
+           py::overload_cast< const std::shared_ptr< tss::Body >, const std::shared_ptr< tss::GroundStationSettings > >(
                    &tss::createGroundStation ),
            py::arg( "body" ),
            py::arg( "ground_station_settings" ),
@@ -1043,17 +1018,14 @@ void expose_environment_setup( py::module& m )
     //              py::arg( "station_name" ),
     //              py::arg( "times" ) );
 
-
-
     //        auto system_model_setup =
     //        m.def_submodule("system_models");
     //        gravity_field_variation::expose_system_model_setup(system_model_setup);
 
     // Function removed; error is shown
     m.def( "set_aerodynamic_guidance",
-           py::overload_cast< const std::shared_ptr< ta::AerodynamicGuidance >,
-                              const std::shared_ptr< tss::Body >,
-                              const bool >( &tss::setGuidanceAnglesFunctions ),
+           py::overload_cast< const std::shared_ptr< ta::AerodynamicGuidance >, const std::shared_ptr< tss::Body >, const bool >(
+                   &tss::setGuidanceAnglesFunctions ),
            py::arg( "aerodynamic_guidance" ),
            py::arg( "body" ),
            py::arg( "silence_warnings" ) = false );
@@ -1075,7 +1047,6 @@ void expose_environment_setup( py::module& m )
            py::arg( "sideslip_angle" ),
            py::arg( "bank_angle" ),
            py::arg( "silence_warnings" ) = false );
-
 }
 
 }  // namespace environment_setup

--- a/src/tudatpy/dynamics/propagation_setup/propagator/expose_propagator.cpp
+++ b/src/tudatpy/dynamics/propagation_setup/propagator/expose_propagator.cpp
@@ -45,7 +45,7 @@ std::shared_ptr< tudat::propagators::MultiArcPropagatorProcessingSettings > mult
     return std::make_shared< tudat::propagators::MultiArcPropagatorProcessingSettings >( );
 }
 
-void expose_propagator_setup( py::module &m )
+void expose_propagator_setup( py::module& m )
 {
     ///////////////////////////////////////////////////////////////////////////////////////
 
@@ -713,9 +713,9 @@ Enumeration of available integrated state types.
             :type: MultiArcPropagatorProcessingSettings
 
 )doc" )
-        .def_property_readonly( "initial_state_list",
-                                &tp::MultiArcPropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE >::getInitialStateList,
-                                R"doc(
+            .def_property_readonly( "initial_state_list",
+                                    &tp::MultiArcPropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE >::getInitialStateList,
+                                    R"doc(
             **read-only**
 
             List of initial states per arc (e.g. entry j of this list is the initial state for arc j).
@@ -724,9 +724,9 @@ Enumeration of available integrated state types.
 
 )doc" )
 
-        .def_property_readonly( "single_arc_settings",
-                                &tp::MultiArcPropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE >::getInitialStateList,
-                                R"doc(
+            .def_property_readonly( "single_arc_settings",
+                                    &tp::MultiArcPropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE >::getInitialStateList,
+                                    R"doc(
             **read-only**
 
             List of single arc settings (e.g. entry j of this list is the single-arc propagator setting for arc j).
@@ -734,10 +734,6 @@ Enumeration of available integrated state types.
             :type: list[SingleArcPropagatorSettings]
 
 )doc" );
-
-
-
-
 
     py::class_< tp::HybridArcPropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE >,
                 std::shared_ptr< tp::HybridArcPropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE > >,
@@ -825,7 +821,42 @@ Enumeration of available integrated state types.
          `SingleArcPropagatorSettings`-derived class to define settings for single-arc translational dynamics.
 
       )doc" )
+            .def( py::init< const std::vector< std::string >,
+                            const tba::AccelerationMap,
+                            const std::vector< std::string >,
+                            const Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 >,
+                            const TIME_TYPE,
+                            const std::shared_ptr< tni::IntegratorSettings< TIME_TYPE > >,
+                            const std::shared_ptr< tp::PropagationTerminationSettings >,
+                            const tp::TranslationalPropagatorType,
+                            const std::vector< std::shared_ptr< tp::SingleDependentVariableSaveSettings > >,
+                            const std::shared_ptr< tp::SingleArcPropagatorProcessingSettings > >( ),
+                  py::arg( "central_bodies" ),
+                  py::arg( "acceleration_models" ),
+                  py::arg( "bodies_to_propagate" ),
+                  py::arg( "initial_body_states" ),
+                  py::arg( "initial_time" ),
+                  py::arg( "integrator_settings" ),
+                  py::arg( "termination_settings" ),
+                  py::arg( "propagator" ) = tp::TranslationalPropagatorType::cowell,
+                  py::arg( "dependent_variable_settings" ) = std::vector< std::shared_ptr< tp::SingleDependentVariableSaveSettings > >( ),
+                  py::arg( "output_settings" ) = std::make_shared< tp::SingleArcPropagatorProcessingSettings >( ),
+                  R"doc(Settings for single-arc translational propagator
 
+                  In the description of the parameters, n represents the number of bodies that are propagated, and the brackets at the end of each line provide information about the expected shape of the input.
+
+                  :param central_bodies: List of central bodies [n,]
+                  :param acceleration_models: Acceleration models per body to propagate, generally obtained from the `create_acceleration_models` function.
+                  :param bodies_to_propagate: List of bodies to propagate [n,]
+                  :param initial_body_states: State of the bodies to propagate at the initial epoch [n, 6]
+                  :param initial_time: The initial epoch for the propagation
+                  :param integrator_settings: Settings for the numerical integrator, generally obtained from one of the functions in `propagation_setup.integrator`
+                  :param termination_settings: Settings for the termination condition, generally obtained from functions in `propagation_setup.propagator`
+                  :param propagator: The way in which the state of the bodies is represented during propagation (e.g. Cowell, Keplerian elements, USM)
+                  :param dependent_variable_settings: List of dependent variables to save
+                  :param output_settings: Settings for output processing and printing to stdout during propagation
+                  :return propagator_settings: Settings object to be used as input for `create_dynamics_simulator`
+                  )doc" )
             .def( "get_propagated_state_size",
                   &tp::TranslationalStatePropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE >::getPropagatedStateSize )
             .def( "reset_and_recreate_acceleration_models",
@@ -984,13 +1015,13 @@ Enumeration of available integrated state types.
     ///////////////////////////////////////////////////////////////////////////////////////
 
     m.def( "translational",
-           py::overload_cast< const std::vector< std::string > &,
-                              const tba::AccelerationMap &,
-                              const std::vector< std::string > &,
-                              const Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 > &,
+           py::overload_cast< const std::vector< std::string >&,
+                              const tba::AccelerationMap&,
+                              const std::vector< std::string >&,
+                              const Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 >&,
                               const std::shared_ptr< tp::PropagationTerminationSettings >,
                               const tp::TranslationalPropagatorType,
-                              const std::vector< std::shared_ptr< tp::SingleDependentVariableSaveSettings > > &,
+                              const std::vector< std::shared_ptr< tp::SingleDependentVariableSaveSettings > >&,
                               const double >( &tp::translationalStatePropagatorSettingsDeprecated< STATE_SCALAR_TYPE, TIME_TYPE > ),
            py::arg( "central_bodies" ),
            py::arg( "acceleration_models" ),
@@ -1064,9 +1095,9 @@ TranslationalStatePropagatorSettings
      )doc" );
 
     m.def( "rotational",
-           py::overload_cast< const tba::TorqueModelMap &,
-                              const std::vector< std::string > &,
-                              const Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 > &,
+           py::overload_cast< const tba::TorqueModelMap&,
+                              const std::vector< std::string >&,
+                              const Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 >&,
                               const std::shared_ptr< tp::PropagationTerminationSettings >,
                               const tp::RotationalPropagatorType,
                               const std::vector< std::shared_ptr< tp::SingleDependentVariableSaveSettings > >,
@@ -1118,10 +1149,10 @@ initial_time : astro.time_representation.Time
 integrator_settings : IntegratorSettings
     Settings defining the numerical integrator that is to be used for the propagation
 
-    .. note:: 
-    
+    .. note::
+
         The sign of the initial time step in the integrator settings defines whether the propagation will be forward or backward in time
-    
+
 termination_settings : PropagationTerminationSettings
     Generic termination settings object to check whether the propagation should be ended.
 propagator : RotationalPropagatorType, default=quaternions
@@ -1146,8 +1177,8 @@ RotationalStatePropagatorSettings
 
     m.def( "mass",
            py::overload_cast< const std::vector< std::string >,
-                              const std::map< std::string, std::vector< std::shared_ptr< tba::MassRateModel > > > &,
-                              const Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 > &,
+                              const std::map< std::string, std::vector< std::shared_ptr< tba::MassRateModel > > >&,
+                              const Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 >&,
                               const std::shared_ptr< tp::PropagationTerminationSettings >,
                               const std::vector< std::shared_ptr< tp::SingleDependentVariableSaveSettings > >,
                               const double >( &tp::massPropagatorSettingsDeprecated< STATE_SCALAR_TYPE, TIME_TYPE > ),
@@ -1776,7 +1807,7 @@ HybridArcPropagatorSettings
 
      )doc" );
 
-     m.def( "get_integrated_type_and_body_list",
+    m.def( "get_integrated_type_and_body_list",
            &tp::getIntegratedTypeAndBodyList< STATE_SCALAR_TYPE, TIME_TYPE >,
            py::arg( "propagator_settings" ) );
 

--- a/src/tudatpy/util/_dse_functions.py
+++ b/src/tudatpy/util/_dse_functions.py
@@ -1,11 +1,11 @@
 import numpy as np
 from itertools import combinations as comb
 
-def get_orthogonal_array(no_of_factors : int, 
-                no_of_levels : int) -> np.ndarray:
-    """ 
+
+def get_orthogonal_array(no_of_factors: int, no_of_levels: int) -> np.ndarray:
+    """
     Create orthogonal arrays from Latin Square in 4 successive steps:
-    
+
     0) Take the column from the smaller array to create 2 new
        columns and 2x new rows,
     1) block 1 (1/2 rows): take old values 2x for new columns,
@@ -27,13 +27,13 @@ def get_orthogonal_array(no_of_factors : int,
 
     """
     # TODO: merge the no_of_levels = 2 and no_of_levels = 3 parts of the code (instead of two separate if statements
-                                                                               # with a lot of overlap
+    # with a lot of overlap
 
     assert no_of_levels >= 2
     assert no_of_factors >= 1
 
-    row_number = lambda icount, no_of_levels : no_of_levels**(icount+1)
-    col_number = lambda row_number : row_number-1
+    row_number = lambda icount, no_of_levels: no_of_levels ** (icount + 1)
+    col_number = lambda row_number: row_number - 1
 
     if no_of_levels == 2:
 
@@ -54,39 +54,41 @@ def get_orthogonal_array(no_of_factors : int,
         elif no_of_factors >= 128 and no_of_factors <= 255:
             icount = 7
         else:
-            raise RuntimeError("The number of factors provided is not implemented. Provide a value between 1 and 255")
+            raise RuntimeError(
+                "The number of factors provided is not implemented. Provide a value between 1 and 255"
+            )
 
         Lxrow = row_number(icount, no_of_levels)
         Lxcol = col_number(Lxrow)
-        Lx = np.zeros((Lxrow,Lxcol), dtype='int')
+        Lx = np.zeros((Lxrow, Lxcol), dtype="int")
         iaux = Lx.copy()
-        
+
         # Define the 2-level Latin Square
         index_list = [0, 1]
         two_level = [-1, 1]
-        LS = np.zeros((2,2), dtype='int')
-        LS[0,0] = -1
-        LS[0,1] =  1
-        LS[1,0] =  1
-        LS[1,1] = -1
-        
+        LS = np.zeros((2, 2), dtype="int")
+        LS[0, 0] = -1
+        LS[0, 1] = 1
+        LS[1, 0] = 1
+        LS[1, 1] = -1
+
         # In case of only one factor, copy the first Latin Square and leave the subroutine.
         if icount == 0:
-            Lx[0,0] = LS[0,0]
-            Lx[1,0] = LS[0,1]
+            Lx[0, 0] = LS[0, 0]
+            Lx[1, 0] = LS[0, 1]
             return Lx
-        
-        iaux[0,0] = -1
-        iaux[1,0] =  1
+
+        iaux[0, 0] = -1
+        iaux[1, 0] = 1
         irow = 2
         icol = 1
 
         # Algorithm in Matlab starts from index 1
         Lx = np.hstack((np.zeros((len(Lx), 1)), Lx))
-        Lx = np.vstack((np.zeros((1, len(Lx[0,:]))), Lx))
+        Lx = np.vstack((np.zeros((1, len(Lx[0, :]))), Lx))
         iaux = np.hstack((np.zeros((len(iaux), 1)), iaux))
-        iaux = np.vstack((np.zeros((1, len(iaux[0,:]))), iaux))
-        
+        iaux = np.vstack((np.zeros((1, len(iaux[0, :]))), iaux))
+
         # Fill in orthogonal array
         for i1 in range(1, icount + 1):
             for i2 in range(1, irow + 1):
@@ -96,14 +98,18 @@ def get_orthogonal_array(no_of_factors : int,
                             for r in range(2):
 
                                 # Block 1.
-                                if iaux[i2,i3] == two_level[q] and p == 0:
-                                    Lx[i2,i3*2 + index_list[r]] = two_level[q] 
+                                if iaux[i2, i3] == two_level[q] and p == 0:
+                                    Lx[i2, i3 * 2 + index_list[r]] = two_level[
+                                        q
+                                    ]
 
                                 # Block 2
-                                if iaux[i2,i3] == two_level[q] and p == 1:
-                                    Lx[i2 + irow,i3*2 + index_list[r]] = LS[index_list[q], index_list[r]]
+                                if iaux[i2, i3] == two_level[q] and p == 1:
+                                    Lx[i2 + irow, i3 * 2 + index_list[r]] = LS[
+                                        index_list[q], index_list[r]
+                                    ]
 
-                        Lx[i2 + irow*p,1] = two_level[p]
+                        Lx[i2 + irow * p, 1] = two_level[p]
 
             if i1 == icount:
                 # Deleting extra row from Matlab artifact
@@ -111,11 +117,11 @@ def get_orthogonal_array(no_of_factors : int,
                 Lx = np.delete(Lx, 0, 1)
                 return Lx
 
-            irow = 2*irow
-            icol = 2*icol+1
+            irow = 2 * irow
+            icol = 2 * icol + 1
             for i2 in range(1, irow + 1):
                 for i3 in range(1, icol + 1):
-                    iaux[i2,i3] = Lx[i2,i3]
+                    iaux[i2, i3] = Lx[i2, i3]
 
     elif no_of_levels == 3:
 
@@ -130,49 +136,51 @@ def get_orthogonal_array(no_of_factors : int,
         elif no_of_factors >= 41 and no_of_factors <= 121:
             icount = 4
         else:
-            raise RuntimeError("The number of factors provided is not implemented. Provide a value between 0 and 255")
+            raise RuntimeError(
+                "The number of factors provided is not implemented. Provide a value between 0 and 255"
+            )
 
         Lxrow = row_number(icount, no_of_levels)
         Lxcol = col_number(Lxrow) // 2
-        Lx = np.zeros((Lxrow,Lxcol))
+        Lx = np.zeros((Lxrow, Lxcol))
         iaux = Lx.copy()
-        
+
         # Define Latin Square 1
         index_list = [0, 1, 2]
-        
-        LS1 = np.zeros((3,3))
+
+        LS1 = np.zeros((3, 3))
         three_level = [-1, 0, 1]
         for i in range(3):
             for j in range(3):
-                LS1[i,index_list[j]] = three_level[(j+i)%3];
+                LS1[i, index_list[j]] = three_level[(j + i) % 3]
 
         # Define Latin Square 2
-        LS2 = np.zeros((3,3))
+        LS2 = np.zeros((3, 3))
         three_level_2 = [-1, 1, 0]
         for i in range(3):
             for j in range(3):
-                LS2[i, index_list[j]] = three_level_2[j-i]
-     
+                LS2[i, index_list[j]] = three_level_2[j - i]
+
         # In case of only one factor, copy the first Latin Square and leave the subroutine
         if icount == 0:
-           Lx[0,0] = LS1[0,0];
-           Lx[1,0] = LS1[0,1];
-           Lx[2,0] = LS1[0,2];
-           return Lx
+            Lx[0, 0] = LS1[0, 0]
+            Lx[1, 0] = LS1[0, 1]
+            Lx[2, 0] = LS1[0, 2]
+            return Lx
 
         # Define iaux for loops
-        iaux[0,0] = -1
-        iaux[1,0] = 0
-        iaux[2,0] =  1
+        iaux[0, 0] = -1
+        iaux[1, 0] = 0
+        iaux[2, 0] = 1
         irow = 3
         icol = 1
 
         # Algorithm in Matlab starts from index 1
         Lx = np.hstack((np.zeros((len(Lx), 1)), Lx))
-        Lx = np.vstack((np.zeros((1, len(Lx[0,:]))), Lx))
+        Lx = np.vstack((np.zeros((1, len(Lx[0, :]))), Lx))
         iaux = np.hstack((np.zeros((len(iaux), 1)), iaux))
-        iaux = np.vstack((np.zeros((1, len(iaux[0,:]))), iaux))
-        
+        iaux = np.vstack((np.zeros((1, len(iaux[0, :]))), iaux))
+
         # Filling in Lx
         for i1 in range(1, icount + 1):
             for i2 in range(1, irow + 1):
@@ -181,19 +189,25 @@ def get_orthogonal_array(no_of_factors : int,
                         for q in range(3):
                             for r in range(3):
 
-                                #Block 1.
-                                if iaux[i2,i3] == three_level[q] and p == 0:
-                                    Lx[i2 + irow*p,i3*3 + three_level[r]] = three_level[q] 
+                                # Block 1.
+                                if iaux[i2, i3] == three_level[q] and p == 0:
+                                    Lx[
+                                        i2 + irow * p, i3 * 3 + three_level[r]
+                                    ] = three_level[q]
 
-                                #Block 2.
-                                if iaux[i2,i3] == three_level[q] and p == 1:
-                                    Lx[i2 + irow*p,i3*3 + three_level[r]] = LS1[index_list[q], index_list[r]]
+                                # Block 2.
+                                if iaux[i2, i3] == three_level[q] and p == 1:
+                                    Lx[
+                                        i2 + irow * p, i3 * 3 + three_level[r]
+                                    ] = LS1[index_list[q], index_list[r]]
 
-                                #Block 3.
-                                if iaux[i2,i3] == three_level[q] and p == 2:
-                                    Lx[i2 + irow*p,i3*3 + three_level[r]] = LS2[index_list[q], index_list[r]]
+                                # Block 3.
+                                if iaux[i2, i3] == three_level[q] and p == 2:
+                                    Lx[
+                                        i2 + irow * p, i3 * 3 + three_level[r]
+                                    ] = LS2[index_list[q], index_list[r]]
 
-                        Lx[i2 + irow*p,1] = three_level[p]
+                        Lx[i2 + irow * p, 1] = three_level[p]
 
             if i1 == icount:
                 # Deleting extra row from Matlab artifact
@@ -201,16 +215,18 @@ def get_orthogonal_array(no_of_factors : int,
                 Lx = np.delete(Lx, 0, 1)
                 return Lx
 
-            irow = 3*irow
-            icol = 3*icol+1
+            irow = 3 * irow
+            icol = 3 * icol + 1
             for i2 in range(1, irow + 1):
                 for i3 in range(1, icol + 1):
-                        iaux[i2,i3] = Lx[i2,i3]
+                    iaux[i2, i3] = Lx[i2, i3]
     else:
-        raise RuntimeError("These levels are not implemented yet. (You may wonder whether you need them)")
+        raise RuntimeError(
+            "These levels are not implemented yet. (You may wonder whether you need them)"
+        )
 
-def get_yates_array(no_of_factors : int, 
-                        no_of_levels : int) -> np.ndarray:
+
+def get_yates_array(no_of_factors: int, no_of_levels: int) -> np.ndarray:
     """
     Function that creates a Yates array according to Yates algorithm
 
@@ -230,30 +246,41 @@ def get_yates_array(no_of_factors : int,
     assert no_of_factors >= 1
     assert no_of_levels >= 2
 
-    if no_of_levels == 2: #for the ANOVA analysis with interactions
+    if no_of_levels == 2:  # for the ANOVA analysis with interactions
         levels = [-1, 1]
     elif no_of_levels == 3:
         levels = [-1, 0, 1]
-    elif no_of_levels == 7: #for the response surfaces
+    elif no_of_levels == 7:  # for the response surfaces
         levels = [-3, -2, -1, 0, 1, 2, 3]
     else:
-        raise RuntimeError("The number of levels you have requested is not implemented")
+        raise RuntimeError(
+            "The number of levels you have requested is not implemented"
+        )
 
     n_rows = no_of_levels**no_of_factors
     n_cols = no_of_factors
-    yates_array = np.zeros((n_rows, n_cols), dtype='int')
+    yates_array = np.zeros((n_rows, n_cols), dtype="int")
 
     row_seg = n_rows
     for col in range(n_cols):
-        repetition_amount = no_of_levels**col # Number of times to repeat the row segment to fill the array
-        row_seg = row_seg // no_of_levels # Get row segment divided by number of levels
+        repetition_amount = (
+            no_of_levels**col
+        )  # Number of times to repeat the row segment to fill the array
+        row_seg = (
+            row_seg // no_of_levels
+        )  # Get row segment divided by number of levels
 
         for j in range(repetition_amount):
             for it, level in enumerate(levels):
                 # fill in from position i to position i + no_of_levels
-                yates_array[(it*row_seg + j*row_seg*no_of_levels):((it+1)*row_seg +
-                j*row_seg*no_of_levels), col] = levels[it] 
-    return yates_array 
+                yates_array[
+                    (it * row_seg + j * row_seg * no_of_levels) : (
+                        (it + 1) * row_seg + j * row_seg * no_of_levels
+                    ),
+                    col,
+                ] = levels[it]
+    return yates_array
+
 
 # ANOVA short explanation
 # After some definitions, we iterate through yates array, depending on the value being -1 or 1, we add the occurrence
@@ -261,19 +288,22 @@ def get_yates_array(no_of_factors : int,
 # variable to an objective value. This iteration is done for individual, linear, and quadratic effects, thereby
 # determing the contribution of all interactions.
 
-def anova_analysis(objective_values, 
-                   factorial_design_array : np.ndarray, 
-                   no_of_factors : int, 
-                   no_of_levels : int,
-                   level_of_interactions=2) -> tuple:
+
+def anova_analysis(
+    objective_values,
+    factorial_design_array: np.ndarray,
+    no_of_factors: int,
+    no_of_levels: int,
+    level_of_interactions=2,
+) -> tuple:
     """
-    Function that performs an Analysis of Variance (ANOVA) for no_of_levels levels and no_of_factors factors. 
+    Function that performs an Analysis of Variance (ANOVA) for no_of_levels levels and no_of_factors factors.
 
     Parameters
     ----------
-    objective_values : list 
+    objective_values : list
         List of objective function values following from the factorial design array.
-    factorial_design_array : np.array 
+    factorial_design_array : np.array
         An array compatible with factorial design, generally a Yates array.
     no_of_factors : int
         Integer representing the number of design variables.
@@ -296,42 +326,50 @@ def anova_analysis(objective_values,
 
     """
 
-    assert len(objective_values) == len(factorial_design_array) # Quick check for validity of data
+    assert len(objective_values) == len(
+        factorial_design_array
+    )  # Quick check for validity of data
 
-    number_of_simulations = no_of_levels ** no_of_factors
+    number_of_simulations = no_of_levels**no_of_factors
 
     #########################
     ### Array definitions ###
     #########################
 
     # Lambda function to determine number of interaction columns
-    interactions = lambda iterable, k : [i for i in comb(range(iterable), k)]
-    no_of_interactions_2 = interactions(no_of_factors, 2) # number of 2-level interactions
-    no_of_interactions_3 = interactions(no_of_factors, 3) # number of 3-level interactions
+    interactions = lambda iterable, k: [i for i in comb(range(iterable), k)]
+    no_of_interactions_2 = interactions(
+        no_of_factors, 2
+    )  # number of 2-level interactions
+    no_of_interactions_3 = interactions(
+        no_of_factors, 3
+    )  # number of 3-level interactions
 
     # Arrays for individual, 2, and 3 level interactions - sum of squares
     sum_of_squares_i = np.zeros(no_of_factors)
     sum_of_squares_ij = np.zeros(len(no_of_interactions_2))
     sum_of_squares_ijk = np.zeros(len(no_of_interactions_3))
 
-    #Arrays for individual, 2, and 3 level interactions - percentage contribution
+    # Arrays for individual, 2, and 3 level interactions - percentage contribution
     percentage_contribution_i = np.zeros(no_of_factors)
     percentage_contribution_ij = np.zeros(len(no_of_interactions_2))
     percentage_contribution_ijk = np.zeros(len(no_of_interactions_3))
 
     # Sum of objective values and mean of parameters
     sum_of_objective = np.sum(objective_values)
-    mean_of_param = sum_of_objective/number_of_simulations
+    mean_of_param = sum_of_objective / number_of_simulations
 
     # Variance and standard deviation of data
     variance_per_run = np.zeros(number_of_simulations)
     objective_values_squared = np.zeros(number_of_simulations)
     for i in range(len(factorial_design_array)):
-        variance_per_run[i] = (objective_values[i] - mean_of_param)**2 / (number_of_simulations-1)
-        objective_values_squared[i] = objective_values[i]**2
+        variance_per_run[i] = (objective_values[i] - mean_of_param) ** 2 / (
+            number_of_simulations - 1
+        )
+        objective_values_squared[i] = objective_values[i] ** 2
     variance = np.sum(variance_per_run)
     standard_deviation = np.sqrt(variance)
-    
+
     # Square of sums
     CF = sum_of_objective * mean_of_param
     # Difference square of sums and sum of squares
@@ -344,19 +382,24 @@ def anova_analysis(objective_values,
     ### Linear effects ###
     # Container for appearance of minimum/maximum value
     Saux = np.zeros((no_of_factors, no_of_levels))
-    number_of_appearanes = number_of_simulations/no_of_levels
+    number_of_appearanes = number_of_simulations / no_of_levels
     for j in range(number_of_simulations):
         for i in range(no_of_factors):
-            if factorial_design_array[j,i] == -1:
+            if factorial_design_array[j, i] == -1:
                 Saux[i, 0] += objective_values[j]
             else:
                 Saux[i, 1] += objective_values[j]
 
-
-    if sum_of_deviation > 1e-6: # If there is a deviation, then there is a contribution.
+    if (
+        sum_of_deviation > 1e-6
+    ):  # If there is a deviation, then there is a contribution.
         for i in range(no_of_factors):
-            sum_of_squares_i[i] = (1/2)*(Saux[i, 1] - Saux[i, 0])**2/number_of_appearanes
-            percentage_contribution_i[i] = 100 * sum_of_squares_i[i]/sum_of_deviation
+            sum_of_squares_i[i] = (
+                (1 / 2) * (Saux[i, 1] - Saux[i, 0]) ** 2 / number_of_appearanes
+            )
+            percentage_contribution_i[i] = (
+                100 * sum_of_squares_i[i] / sum_of_deviation
+            )
 
     ### 2-level interaction ###
     # Container for appearance of minimum/maximum value
@@ -365,17 +408,25 @@ def anova_analysis(objective_values,
         for i in range(len(no_of_interactions_2)):
             # Interaction sequence of all possible 2-level interactions is created by multiplying the
             # two respective elements from yates array
-            interaction = factorial_design_array[j, no_of_interactions_2[i][0]] * \
-                            factorial_design_array[j, no_of_interactions_2[i][1]]
+            interaction = (
+                factorial_design_array[j, no_of_interactions_2[i][0]]
+                * factorial_design_array[j, no_of_interactions_2[i][1]]
+            )
             if interaction == -1:
                 Saux[i, 0] += objective_values[j]
             else:
                 Saux[i, 1] += objective_values[j]
 
-    if sum_of_deviation > 1e-6: # If there is a deviation, then there is a contribution.
+    if (
+        sum_of_deviation > 1e-6
+    ):  # If there is a deviation, then there is a contribution.
         for i in range(len(no_of_interactions_2)):
-            sum_of_squares_ij[i] = (1/2)*(Saux[i, 1] - Saux[i, 0])**2/number_of_appearanes
-            percentage_contribution_ij[i] = 100 * sum_of_squares_ij[i]/sum_of_deviation
+            sum_of_squares_ij[i] = (
+                (1 / 2) * (Saux[i, 1] - Saux[i, 0]) ** 2 / number_of_appearanes
+            )
+            percentage_contribution_ij[i] = (
+                100 * sum_of_squares_ij[i] / sum_of_deviation
+            )
 
     ### 3-level interaction ###
     # Container for appearance of minimum/maximum value
@@ -384,27 +435,46 @@ def anova_analysis(objective_values,
         for i in range(len(no_of_interactions_3)):
             # Interaction sequence of all possible 3-level interactions is created by multiplying the
             # three respective elements from yates array
-            interaction = factorial_design_array[j, no_of_interactions_3[i][0]] * \
-                            factorial_design_array[j, no_of_interactions_3[i][1]] * \
-                              factorial_design_array[j, no_of_interactions_3[i][2]]
+            interaction = (
+                factorial_design_array[j, no_of_interactions_3[i][0]]
+                * factorial_design_array[j, no_of_interactions_3[i][1]]
+                * factorial_design_array[j, no_of_interactions_3[i][2]]
+            )
             if interaction == -1:
                 Saux[i, 0] += objective_values[j]
             else:
                 Saux[i, 1] += objective_values[j]
 
-    if sum_of_deviation > 1e-6: # If there is a deviation, then there is a contribution.
+    if (
+        sum_of_deviation > 1e-6
+    ):  # If there is a deviation, then there is a contribution.
         for i in range(len(no_of_interactions_3)):
-            sum_of_squares_ijk[i] = (1/2)*(Saux[i, 1] - Saux[i, 0])**2/number_of_appearanes
-            percentage_contribution_ijk[i] = 100 * sum_of_squares_ijk[i]/sum_of_deviation
+            sum_of_squares_ijk[i] = (
+                (1 / 2) * (Saux[i, 1] - Saux[i, 0]) ** 2 / number_of_appearanes
+            )
+            percentage_contribution_ijk[i] = (
+                100 * sum_of_squares_ijk[i] / sum_of_deviation
+            )
 
     ### Error contribution ###
-    sum_of_squares_error = sum_of_deviation - np.sum(sum_of_squares_i) - \
-    np.sum(sum_of_squares_ij) - np.sum(sum_of_squares_ijk)
+    sum_of_squares_error = (
+        sum_of_deviation
+        - np.sum(sum_of_squares_i)
+        - np.sum(sum_of_squares_ij)
+        - np.sum(sum_of_squares_ijk)
+    )
 
     percentage_contribution_error = 0
-    if sum_of_deviation > 1e-6: # If there is a deviation, then there is a contribution.
-        percentage_contribution_error = 100 * sum_of_squares_error / sum_of_deviation
+    if (
+        sum_of_deviation > 1e-6
+    ):  # If there is a deviation, then there is a contribution.
+        percentage_contribution_error = (
+            100 * sum_of_squares_error / sum_of_deviation
+        )
 
-    return percentage_contribution_i, percentage_contribution_ij, \
-    percentage_contribution_ijk, percentage_contribution_error
-
+    return (
+        percentage_contribution_i,
+        percentage_contribution_ij,
+        percentage_contribution_ijk,
+        percentage_contribution_error,
+    )


### PR DESCRIPTION
- Replace `mypy.stubgen` with a custom stub generator: makes stub generation much faster, the implementation is simpler, and it gives us more control over how the stubs are produced.
- Replace the `print` statements in `build.py` with a logger: makes it possible to hide all the `pybind11-stubgen` "errors" from users, while keeping them accessible for us (with the `--debug` flag of `build.py`)
- Expose and document the constructor of `TranslationalStatePropagatorSettings`
- Expose the default constructor of `BodySettings` to be able to create empty settings without adding them to a `BodyListSettings` object
- Fix incorrect indentation in docstrings

All the code is backwards compatible and it does not introduce new dependencies