### PR TITLE
Fix missing stubs for explicit kernel imports

### DIFF
--- a/build.py
+++ b/build.py
@@ -866,6 +866,11 @@ class StubGenerator:
                         )
                     else:
 
+                        # Import from extension instead of kernel
+                        if statement.module.split(".")[-1] == module_path.name:
+                            statement.module = "extension"
+                            statement.level = 1
+
                         # Add imported items to stub all
                         for item in statement.names:
                             stub_all.append(item.name)


### PR DESCRIPTION
The latest update to the build.py script introduced direct function imports from submodules of `tudatpy.kernel` in `__init__.py` files to prevent import instabilities. When modifying the stub generator to accomodate these new types of imports (only star imports from the kernel were supported before), I forgot to adjust the function that produces the stubs for the `__init__.py` files to make it replace `from tudatpy.kernel.<submodule> import <function>` with `from .extension import <function>`. As a result, stubs would be missing for all the functions and classes that are explicitly imported from the kernel in an `__init__.py`.

This commit introduces a patch to prevent this behavior. A more robust solution will be implemented in a coming version of the stub generator, independent from pybind11-stubgen and mypy.stubgen