### PR TITLE
fix copy/paste error on the single_arc_propagator_settings member of …

### DIFF
--- a/src/tudatpy/dynamics/propagation_setup/propagator/expose_propagator.cpp
+++ b/src/tudatpy/dynamics/propagation_setup/propagator/expose_propagator.cpp
@@ -725,7 +725,7 @@ Enumeration of available integrated state types.
 )doc" )
 
         .def_property_readonly( "single_arc_settings",
-                                &tp::MultiArcPropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE >::getInitialStateList,
+                                &tp::MultiArcPropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE >::getSingleArcSettings,
                                 R"doc(
             **read-only**
 


### PR DESCRIPTION
Found a bug (copy/paste error) in the exposure of the multi arc propagator settings attributes.