### PR TITLE
Expose constructors of BodySettings and TranslationalStatePropagatorSettings

### DIFF
--- a/src/tudatpy/dynamics/environment_setup/expose_environment_setup.cpp
+++ b/src/tudatpy/dynamics/environment_setup/expose_environment_setup.cpp
@@ -101,6 +101,7 @@ void expose_environment_setup( py::module& m )
          :class:`BodyListSettings` object.
 
       )doc" )
+            .def( py::init<>( ) )
             .def_readwrite( "constant_mass", &tss::BodySettings::constantMass, R"doc(
 
          Mass that gets assigned to the vehicle. This mass does *not* automatically define a gravity field
@@ -232,8 +233,7 @@ void expose_environment_setup( py::module& m )
 
          :type: RadiationSourceModelSettings
       )doc" )
-            .def_readwrite(
-                    "vehicle_shape_settings", &tss::BodySettings::bodyExteriorPanelSettings_, R"doc(
+            .def_readwrite( "vehicle_shape_settings", &tss::BodySettings::bodyExteriorPanelSettings_, R"doc(
 
          Object that defines the settings of an exterior panelled vehicle shape that is to be created. A variable of this type is typically
          assigned by using a function from the :ref:`vehicle_systems` module.
@@ -252,8 +252,7 @@ void expose_environment_setup( py::module& m )
 
       )doc" );
 
-    py::class_< tss::BodyListSettings, std::shared_ptr< tss::BodyListSettings > >(
-            m, "BodyListSettings", R"doc(
+    py::class_< tss::BodyListSettings, std::shared_ptr< tss::BodyListSettings > >( m, "BodyListSettings", R"doc(
 
          Class for defining settings for the creation of a system of bodies.
 
@@ -308,8 +307,7 @@ void expose_environment_setup( py::module& m )
 
      )doc" )
             .def( "add_settings",
-                  py::overload_cast< std::shared_ptr< tss::BodySettings >, const std::string >(
-                          &tss::BodyListSettings::addSettings ),
+                  py::overload_cast< std::shared_ptr< tss::BodySettings >, const std::string >( &tss::BodyListSettings::addSettings ),
                   py::arg( "settings_to_add" ),
                   py::arg( "body_name" ),
                   R"doc(
@@ -363,8 +361,7 @@ void expose_environment_setup( py::module& m )
 
          :type: str
       )doc" )
-            .def_property_readonly(
-                    "frame_orientation", &tss::BodyListSettings::getFrameOrientation, R"doc(
+            .def_property_readonly( "frame_orientation", &tss::BodyListSettings::getFrameOrientation, R"doc(
 
          **read-only**
 
@@ -374,9 +371,7 @@ void expose_environment_setup( py::module& m )
       )doc" );
 
     m.def( "get_default_body_settings",
-           py::overload_cast< const std::vector< std::string > &,
-                              const std::string,
-                              const std::string >( &tss::getDefaultBodySettings ),
+           py::overload_cast< const std::vector< std::string >&, const std::string, const std::string >( &tss::getDefaultBodySettings ),
            py::arg( "bodies" ),
            py::arg( "base_frame_origin" ) = "SSB",
            py::arg( "base_frame_orientation" ) = "ECLIPJ2000",
@@ -416,7 +411,7 @@ void expose_environment_setup( py::module& m )
      )doc" );
 
     m.def( "get_default_body_settings_time_limited",
-           py::overload_cast< const std::vector< std::string > &,
+           py::overload_cast< const std::vector< std::string >&,
                               const double,
                               const double,
                               const std::string,
@@ -464,8 +459,7 @@ void expose_environment_setup( py::module& m )
      )doc" );
 
     m.def( "get_default_single_body_settings",
-           py::overload_cast< const std::string &, const std::string & >(
-                   &tss::getDefaultSingleBodySettings ),
+           py::overload_cast< const std::string&, const std::string& >( &tss::getDefaultSingleBodySettings ),
            py::arg( "body_name" ),
            py::arg( "base_frame_orientation" ) = "ECLIPJ2000",
            R"doc(
@@ -494,11 +488,8 @@ void expose_environment_setup( py::module& m )
      )doc" );
 
     m.def( "get_default_single_body_settings_time_limited",
-           py::overload_cast< const std::string &,
-                              const double,
-                              const double,
-                              const std::string &,
-                              const double >( &tss::getDefaultSingleBodySettings ),
+           py::overload_cast< const std::string&, const double, const double, const std::string&, const double >(
+                   &tss::getDefaultSingleBodySettings ),
            py::arg( "body_name" ),
            py::arg( "initial_time" ),
            py::arg( "final_time" ),
@@ -536,7 +527,7 @@ void expose_environment_setup( py::module& m )
      )doc" );
 
     m.def( "get_default_single_alternate_body_settings",
-           py::overload_cast< const std::string &, const std::string &, const std::string & >(
+           py::overload_cast< const std::string&, const std::string&, const std::string& >(
                    &tss::getDefaultSingleAlternateNameBodySettings ),
            py::arg( "body_name" ),
            py::arg( "source_body_name" ),
@@ -572,12 +563,8 @@ void expose_environment_setup( py::module& m )
      )doc" );
 
     m.def( "get_default_single_alternate_body_settings_time_limited",
-           py::overload_cast< const std::string &,
-                              const std::string &,
-                              const double,
-                              const double,
-                              const std::string &,
-                              const double >( &tss::getDefaultSingleAlternateNameBodySettings ),
+           py::overload_cast< const std::string&, const std::string&, const double, const double, const std::string&, const double >(
+                   &tss::getDefaultSingleAlternateNameBodySettings ),
            py::arg( "body_name" ),
            py::arg( "source_body_name" ),
            py::arg( "initial_time" ),
@@ -692,8 +679,7 @@ void expose_environment_setup( py::module& m )
            py::arg( "time_step" ),
            py::arg( "observer_name" ),
            py::arg( "reference_frame_name" ),
-           py::arg( "interpolator_settings" ) =
-                   std::make_shared< tudat::interpolators::LagrangeInterpolatorSettings >( 8 ) );
+           py::arg( "interpolator_settings" ) = std::make_shared< tudat::interpolators::LagrangeInterpolatorSettings >( 8 ) );
 
     m.def( "create_body_ephemeris",
            &tss::createBodyEphemeris< STATE_SCALAR_TYPE, TIME_TYPE >,
@@ -726,16 +712,12 @@ void expose_environment_setup( py::module& m )
      )doc" );
 
     m.def( "create_ground_station_ephemeris",
-           py::overload_cast< const std::shared_ptr< tss::Body >,
-                              const std::string &,
-                              const tss::SystemOfBodies & >(
+           py::overload_cast< const std::shared_ptr< tss::Body >, const std::string&, const tss::SystemOfBodies& >(
                    &tss::createReferencePointEphemerisFromId< TIME_TYPE, STATE_SCALAR_TYPE > ),
            "body_with_ground_station",
            "station_name" );
 
-    m.def( "get_safe_interpolation_interval",
-           &tss::getSafeInterpolationInterval,
-           py::arg( "ephemeris_model" ) );
+    m.def( "get_safe_interpolation_interval", &tss::getSafeInterpolationInterval, py::arg( "ephemeris_model" ) );
 
     m.def( "add_aerodynamic_coefficient_interface",
            &tss::addAerodynamicCoefficientInterface,
@@ -858,8 +840,7 @@ void expose_environment_setup( py::module& m )
            py::arg( "bodies" ),
            py::arg( "body_name" ),
            py::arg( "gravity_field_settings" ),
-           py::arg( "gravity_field_variation_settings" ) =
-                   std::vector< std::shared_ptr< tss::GravityFieldVariationSettings > >( ),
+           py::arg( "gravity_field_variation_settings" ) = std::vector< std::shared_ptr< tss::GravityFieldVariationSettings > >( ),
            R"doc(No documentation found.)doc" );
 
     m.def( "add_mass_properties_model",
@@ -1014,23 +995,19 @@ void expose_environment_setup( py::module& m )
            R"doc(No documentation found.)doc" );
 
     m.def( "add_ground_station",
-           py::overload_cast<
-                   const std::shared_ptr< tss::Body >,
-                   const std::string,
-                   const Eigen::Vector3d,
-                   const tcc::PositionElementTypes,
-                   const std::vector< std::shared_ptr< tss::GroundStationMotionSettings > > >(
-                   &tss::createGroundStation ),
+           py::overload_cast< const std::shared_ptr< tss::Body >,
+                              const std::string,
+                              const Eigen::Vector3d,
+                              const tcc::PositionElementTypes,
+                              const std::vector< std::shared_ptr< tss::GroundStationMotionSettings > > >( &tss::createGroundStation ),
            py::arg( "body" ),
            py::arg( "ground_station_name" ),
            py::arg( "ground_station_position" ),
            py::arg( "position_type" ) = tcc::cartesian_position,
-           py::arg( "station_motion_settings" ) =
-                   std::vector< std::shared_ptr< tss::GroundStationMotionSettings > >( ) );
+           py::arg( "station_motion_settings" ) = std::vector< std::shared_ptr< tss::GroundStationMotionSettings > >( ) );
 
     m.def( "add_ground_station",
-           py::overload_cast< const std::shared_ptr< tss::Body >,
-                              const std::shared_ptr< tss::GroundStationSettings > >(
+           py::overload_cast< const std::shared_ptr< tss::Body >, const std::shared_ptr< tss::GroundStationSettings > >(
                    &tss::createGroundStation ),
            py::arg( "body" ),
            py::arg( "ground_station_settings" ),
@@ -1051,17 +1028,14 @@ void expose_environment_setup( py::module& m )
     //              py::arg( "station_name" ),
     //              py::arg( "times" ) );
 
-
-
     //        auto system_model_setup =
     //        m.def_submodule("system_models");
     //        gravity_field_variation::expose_system_model_setup(system_model_setup);
 
     // Function removed; error is shown
     m.def( "set_aerodynamic_guidance",
-           py::overload_cast< const std::shared_ptr< ta::AerodynamicGuidance >,
-                              const std::shared_ptr< tss::Body >,
-                              const bool >( &tss::setGuidanceAnglesFunctions ),
+           py::overload_cast< const std::shared_ptr< ta::AerodynamicGuidance >, const std::shared_ptr< tss::Body >, const bool >(
+                   &tss::setGuidanceAnglesFunctions ),
            py::arg( "aerodynamic_guidance" ),
            py::arg( "body" ),
            py::arg( "silence_warnings" ) = false );
@@ -1083,7 +1057,6 @@ void expose_environment_setup( py::module& m )
            py::arg( "sideslip_angle" ),
            py::arg( "bank_angle" ),
            py::arg( "silence_warnings" ) = false );
-
 }
 
 }  // namespace environment_setup

--- a/src/tudatpy/dynamics/propagation_setup/propagator/expose_propagator.cpp
+++ b/src/tudatpy/dynamics/propagation_setup/propagator/expose_propagator.cpp
@@ -45,7 +45,7 @@ std::shared_ptr< tudat::propagators::MultiArcPropagatorProcessingSettings > mult
     return std::make_shared< tudat::propagators::MultiArcPropagatorProcessingSettings >( );
 }
 
-void expose_propagator_setup( py::module &m )
+void expose_propagator_setup( py::module& m )
 {
     ///////////////////////////////////////////////////////////////////////////////////////
 
@@ -713,9 +713,9 @@ Enumeration of available integrated state types.
             :type: MultiArcPropagatorProcessingSettings
 
 )doc" )
-        .def_property_readonly( "initial_state_list",
-                                &tp::MultiArcPropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE >::getInitialStateList,
-                                R"doc(
+            .def_property_readonly( "initial_state_list",
+                                    &tp::MultiArcPropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE >::getInitialStateList,
+                                    R"doc(
             **read-only**
 
             List of initial states per arc (e.g. entry j of this list is the initial state for arc j).
@@ -724,9 +724,9 @@ Enumeration of available integrated state types.
 
 )doc" )
 
-        .def_property_readonly( "single_arc_settings",
-                                &tp::MultiArcPropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE >::getSingleArcSettings,
-                                R"doc(
+            .def_property_readonly( "single_arc_settings",
+                                    &tp::MultiArcPropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE >::getSingleArcSettings,
+                                    R"doc(
             **read-only**
 
             List of single arc settings (e.g. entry j of this list is the single-arc propagator setting for arc j).
@@ -734,10 +734,6 @@ Enumeration of available integrated state types.
             :type: list[SingleArcPropagatorSettings]
 
 )doc" );
-
-
-
-
 
     py::class_< tp::HybridArcPropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE >,
                 std::shared_ptr< tp::HybridArcPropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE > >,
@@ -825,7 +821,42 @@ Enumeration of available integrated state types.
          `SingleArcPropagatorSettings`-derived class to define settings for single-arc translational dynamics.
 
       )doc" )
+            .def( py::init< const std::vector< std::string >,
+                            const tba::AccelerationMap,
+                            const std::vector< std::string >,
+                            const Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 >,
+                            const TIME_TYPE,
+                            const std::shared_ptr< tni::IntegratorSettings< TIME_TYPE > >,
+                            const std::shared_ptr< tp::PropagationTerminationSettings >,
+                            const tp::TranslationalPropagatorType,
+                            const std::vector< std::shared_ptr< tp::SingleDependentVariableSaveSettings > >,
+                            const std::shared_ptr< tp::SingleArcPropagatorProcessingSettings > >( ),
+                  py::arg( "central_bodies" ),
+                  py::arg( "acceleration_models" ),
+                  py::arg( "bodies_to_propagate" ),
+                  py::arg( "initial_body_states" ),
+                  py::arg( "initial_time" ),
+                  py::arg( "integrator_settings" ),
+                  py::arg( "termination_settings" ),
+                  py::arg( "propagator" ) = tp::TranslationalPropagatorType::cowell,
+                  py::arg( "dependent_variable_settings" ) = std::vector< std::shared_ptr< tp::SingleDependentVariableSaveSettings > >( ),
+                  py::arg( "output_settings" ) = std::make_shared< tp::SingleArcPropagatorProcessingSettings >( ),
+                  R"doc(Settings for single-arc translational propagator
 
+                  In the description of the parameters, n represents the number of bodies that are propagated, and the brackets at the end of each line provide information about the expected shape of the input.
+
+                  :param central_bodies: List of central bodies [n,]
+                  :param acceleration_models: Acceleration models per body to propagate, generally obtained from the `create_acceleration_models` function.
+                  :param bodies_to_propagate: List of bodies to propagate [n,]
+                  :param initial_body_states: State of the bodies to propagate at the initial epoch [n, 6]
+                  :param initial_time: The initial epoch for the propagation
+                  :param integrator_settings: Settings for the numerical integrator, generally obtained from one of the functions in `propagation_setup.integrator`
+                  :param termination_settings: Settings for the termination condition, generally obtained from functions in `propagation_setup.propagator`
+                  :param propagator: The way in which the state of the bodies is represented during propagation (e.g. Cowell, Keplerian elements, USM)
+                  :param dependent_variable_settings: List of dependent variables to save
+                  :param output_settings: Settings for output processing and printing to stdout during propagation
+                  :return propagator_settings: Settings object to be used as input for `create_dynamics_simulator`
+                  )doc" )
             .def( "get_propagated_state_size",
                   &tp::TranslationalStatePropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE >::getPropagatedStateSize )
             .def( "reset_and_recreate_acceleration_models",
@@ -984,13 +1015,13 @@ Enumeration of available integrated state types.
     ///////////////////////////////////////////////////////////////////////////////////////
 
     m.def( "translational",
-           py::overload_cast< const std::vector< std::string > &,
-                              const tba::AccelerationMap &,
-                              const std::vector< std::string > &,
-                              const Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 > &,
+           py::overload_cast< const std::vector< std::string >&,
+                              const tba::AccelerationMap&,
+                              const std::vector< std::string >&,
+                              const Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 >&,
                               const std::shared_ptr< tp::PropagationTerminationSettings >,
                               const tp::TranslationalPropagatorType,
-                              const std::vector< std::shared_ptr< tp::SingleDependentVariableSaveSettings > > &,
+                              const std::vector< std::shared_ptr< tp::SingleDependentVariableSaveSettings > >&,
                               const double >( &tp::translationalStatePropagatorSettingsDeprecated< STATE_SCALAR_TYPE, TIME_TYPE > ),
            py::arg( "central_bodies" ),
            py::arg( "acceleration_models" ),
@@ -1064,9 +1095,9 @@ TranslationalStatePropagatorSettings
      )doc" );
 
     m.def( "rotational",
-           py::overload_cast< const tba::TorqueModelMap &,
-                              const std::vector< std::string > &,
-                              const Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 > &,
+           py::overload_cast< const tba::TorqueModelMap&,
+                              const std::vector< std::string >&,
+                              const Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 >&,
                               const std::shared_ptr< tp::PropagationTerminationSettings >,
                               const tp::RotationalPropagatorType,
                               const std::vector< std::shared_ptr< tp::SingleDependentVariableSaveSettings > >,
@@ -1118,10 +1149,10 @@ initial_time : astro.time_representation.Time
 integrator_settings : IntegratorSettings
     Settings defining the numerical integrator that is to be used for the propagation
 
-    .. note:: 
-    
+    .. note::
+
         The sign of the initial time step in the integrator settings defines whether the propagation will be forward or backward in time
-    
+
 termination_settings : PropagationTerminationSettings
     Generic termination settings object to check whether the propagation should be ended.
 propagator : RotationalPropagatorType, default=quaternions
@@ -1146,8 +1177,8 @@ RotationalStatePropagatorSettings
 
     m.def( "mass",
            py::overload_cast< const std::vector< std::string >,
-                              const std::map< std::string, std::vector< std::shared_ptr< tba::MassRateModel > > > &,
-                              const Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 > &,
+                              const std::map< std::string, std::vector< std::shared_ptr< tba::MassRateModel > > >&,
+                              const Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 >&,
                               const std::shared_ptr< tp::PropagationTerminationSettings >,
                               const std::vector< std::shared_ptr< tp::SingleDependentVariableSaveSettings > >,
                               const double >( &tp::massPropagatorSettingsDeprecated< STATE_SCALAR_TYPE, TIME_TYPE > ),
@@ -1776,7 +1807,7 @@ HybridArcPropagatorSettings
 
      )doc" );
 
-     m.def( "get_integrated_type_and_body_list",
+    m.def( "get_integrated_type_and_body_list",
            &tp::getIntegratedTypeAndBodyList< STATE_SCALAR_TYPE, TIME_TYPE >,
            py::arg( "propagator_settings" ) );
 


### PR DESCRIPTION
- Exposed default constructor of BodySettings to allow creating empty body settings without need for a BodyListSettings object
- Exposed constructor of TranslationalStatePropagatorSettings to allow bypassing factory function

Don't trust the commit history, I am reorganizing code that was spread over multiple branches. The only changes are the ones I list above.