### PR TITLE
Remove deprecated functions from `environment_setup/__init__.py`

### DIFF
--- a/src/tudatpy/dynamics/environment_setup/__init__.py
+++ b/src/tudatpy/dynamics/environment_setup/__init__.py
@@ -16,7 +16,6 @@ from tudatpy.kernel.dynamics.environment_setup import (
     get_safe_interpolation_interval,
     add_aerodynamic_coefficient_interface,
     create_aerodynamic_coefficient_interface,
-    add_radiation_pressure_interface,
     add_radiation_pressure_target_model,
     add_rotation_model,
     add_gravity_field_model,
@@ -29,9 +28,6 @@ from tudatpy.kernel.dynamics.environment_setup import (
     add_ground_station,
     create_radiation_pressure_interface,
     get_ground_station_list,
-    set_aerodynamic_guidance,
-    set_aerodynamic_orientation_functions,
-    set_constant_aerodynamic_orientation,
 )
 from . import (
     aerodynamic_coefficients,


### PR DESCRIPTION
PR #525 removed four deprecated functions from the `environment_setup` submodule of the kernel. However, these functions were still listed in the import statement in `environment_setup/__init__.py`, causing an error when trying to import this module from a python script.

This (single-commit) PR fixes this by removing `set_aerodynamic_guidance`, `set_aerodynamic_orientation_functions`, and `set_constant_aerodynamic_orientation` from the import statement in `environment_setup/__init__.py`.