### PR TITLE
Fix constant aerodynamic coefficient

### DIFF
--- a/include/tudat/astro/aerodynamics/aerodynamicAcceleration.h
+++ b/include/tudat/astro/aerodynamics/aerodynamicAcceleration.h
@@ -96,8 +96,6 @@ public:
         if( !( this->currentTime_ == currentTime ) )
         {
             currentTime_ = currentTime;
-            coefficientInterface_->setRotationToAerodynamicFrame( flightConditions_->getAerodynamicAngleCalculator()->getRotationQuaternionBetweenFrames(
-                aerodynamicCompleteCoefficientFrame_, reference_frames::aerodynamic_frame ) );
             currentForceCoefficients_ = coefficientInterface_->getCurrentForceCoefficients( );
             currentForceCoefficients_ = coefficientMultiplier_ *
                     ( flightConditions_->getAerodynamicAngleCalculator( )->getRotationQuaternionBetweenFrames(

--- a/include/tudat/astro/aerodynamics/aerodynamicCoefficientInterface.h
+++ b/include/tudat/astro/aerodynamics/aerodynamicCoefficientInterface.h
@@ -199,7 +199,6 @@ public:
     {
         numberOfIndependentVariables_ = static_cast< unsigned int >( independentVariableNames.size( ) );
         referenceLengths_ = Eigen::Vector3d::Constant( referenceLength_ );
-        rotationToAerodynamicFrame_ = Eigen::Quaterniond::Identity( );
     }
 
     //! Default destructor.
@@ -537,16 +536,6 @@ public:
         momentContributionInterface_ = momentContributionInterface;
     }
 
-    void setRotationToAerodynamicFrame( const Eigen::Quaterniond rotationToAerodynamicFrame )
-    {
-        rotationToAerodynamicFrame_ = rotationToAerodynamicFrame;
-    }
-
-    Eigen::Quaterniond getRotationToAerodynamicFrame( ) const
-    {
-        return rotationToAerodynamicFrame_;
-    }
-
 protected:
     //! Compute the aerodynamic coefficients for a single control surface, and add to full configuration coefficients.
     /*!
@@ -641,8 +630,6 @@ protected:
 
     //! Explicit list of control surface names, in same order as iterator over controlSurfaceIncrementInterfaces_
     std::vector< std::string > controlSurfaceNames_;
-
-    Eigen::Quaterniond rotationToAerodynamicFrame_;
 
 private:
 };

--- a/include/tudat/astro/orbit_determination/estimatable_parameters/constantDragCoefficient.h
+++ b/include/tudat/astro/orbit_determination/estimatable_parameters/constantDragCoefficient.h
@@ -33,13 +33,16 @@ public:
      * \param associatedBody Body for which the drag coefficient is considered.
      */
     ConstantDragCoefficient( const std::shared_ptr< aerodynamics::CustomAerodynamicCoefficientInterface > coefficientInterface,
-                             const std::string& associatedBody ):
-        EstimatableParameter< double >( constant_drag_coefficient, associatedBody ), coefficientInterface_( coefficientInterface )
+                             const std::string& associatedBody,
+                             const std::shared_ptr< reference_frames::AerodynamicAngleCalculator > aerodynamicAngleCalculator ):
+        EstimatableParameter< double >( constant_drag_coefficient, associatedBody ), coefficientInterface_( coefficientInterface ),
+        aerodynamicAngleCalculator_( aerodynamicAngleCalculator )
     {
         if( coefficientInterface->getNumberOfIndependentVariables( ) != 0 )
         {
             throw std::runtime_error( "Error when making ConstantDragCoefficient, coefficient interface is inconsistent" );
         }
+        aerodynamicCompleteCoefficientFrame_ = getCompleteFrameForCoefficients( coefficientInterface_->getForceCoefficientsFrame( ) );
     }
 
     //! Destructor
@@ -52,7 +55,9 @@ public:
      */
     double getParameterValue( )
     {
-        return ( coefficientInterface_->getRotationToAerodynamicFrame( ) * 
+        rotationToAerodynamicFrame_ = aerodynamicAngleCalculator_->getRotationQuaternionBetweenFrames( 
+            aerodynamicCompleteCoefficientFrame_, reference_frames::aerodynamic_frame );
+        return ( rotationToAerodynamicFrame_ * 
                     coefficientInterface_->getConstantCoefficients( ).head<3>( ) )( 0 );
     }
 
@@ -64,9 +69,9 @@ public:
     void setParameterValue( double parameterValue )
     {
         Eigen::Vector6d currentCoefficientSet = coefficientInterface_->getCurrentAerodynamicCoefficients( );
-        Eigen::Vector3d currentForceCoefficientSet = coefficientInterface_->getRotationToAerodynamicFrame( ) * currentCoefficientSet.head<3>( );
+        Eigen::Vector3d currentForceCoefficientSet = rotationToAerodynamicFrame_ * currentCoefficientSet.head<3>( );
         currentForceCoefficientSet( 0 ) = parameterValue;
-        currentCoefficientSet.head<3>( ) = coefficientInterface_->getRotationToAerodynamicFrame( ).inverse( ) * currentForceCoefficientSet;
+        currentCoefficientSet.head<3>( ) = rotationToAerodynamicFrame_.inverse( ) * currentForceCoefficientSet;
         coefficientInterface_->resetConstantCoefficients( currentCoefficientSet );
     }
 
@@ -84,6 +89,12 @@ protected:
 private:
     //! Object that contains the aerodynamic coefficients
     std::shared_ptr< aerodynamics::CustomAerodynamicCoefficientInterface > coefficientInterface_;
+
+    std::shared_ptr< reference_frames::AerodynamicAngleCalculator > aerodynamicAngleCalculator_;
+
+    reference_frames::AerodynamicsReferenceFrames aerodynamicCompleteCoefficientFrame_;
+
+    Eigen::Quaterniond rotationToAerodynamicFrame_;
 };
 
 //! Interface class for the estimation of an arc-wise (piecewise constant) drag coefficient

--- a/include/tudat/simulation/estimation_setup/createEstimatableParameters.h
+++ b/include/tudat/simulation/estimation_setup/createEstimatableParameters.h
@@ -1122,12 +1122,25 @@ std::shared_ptr< estimatable_parameters::EstimatableParameter< double > > create
                             " has no custom coefficient interface, cannot estimate constant drag coefficient.";
                     throw std::runtime_error( errorMessage );
                 }
+                else if( currentBody->getFlightConditions( ) == nullptr )
+                {
+                    std::string errorMessage = "Error, body " + currentBodyName +
+                            " has no flight conditions defined, cannot estimate constant drag coefficient.";
+                    throw std::runtime_error( errorMessage );
+                }
+                else if( currentBody->getFlightConditions( )->getAerodynamicAngleCalculator( ) == nullptr )
+                {
+                    std::string errorMessage = "Error, body " + currentBodyName +
+                            " has no aerodynamic angle calculator defined, cannot estimate constant drag coefficient.";
+                    throw std::runtime_error( errorMessage );
+                }
                 else
                 {
                     doubleParameterToEstimate = std::make_shared< ConstantDragCoefficient >(
                             std::dynamic_pointer_cast< aerodynamics::CustomAerodynamicCoefficientInterface >(
                                     currentBody->getAerodynamicCoefficientInterface( ) ),
-                            currentBodyName );
+                            currentBodyName,
+                            currentBody->getFlightConditions( )->getAerodynamicAngleCalculator( ) );
                 }
                 break;
             }

--- a/tests/test_tudat/src/astro/orbit_determination/acceleration_partials/unitTestAccelerationPartials.cpp
+++ b/tests/test_tudat/src/astro/orbit_determination/acceleration_partials/unitTestAccelerationPartials.cpp
@@ -818,7 +818,8 @@ BOOST_AUTO_TEST_CASE( testAerodynamicAccelerationPartials )
     std::shared_ptr< EstimatableParameter< double > > dragCoefficientParameter =
             std::make_shared< ConstantDragCoefficient >( std::dynamic_pointer_cast< aerodynamics::CustomAerodynamicCoefficientInterface >(
                                                                  bodies.at( "Vehicle" )->getAerodynamicCoefficientInterface( ) ),
-                                                         "Vehicle" );
+                                                         "Vehicle",
+                                                          bodies.at( "Vehicle" )->getFlightConditions( )->getAerodynamicAngleCalculator( ) );
 
     // drag/side/lift direction scaling parameters
     auto aeroAccelerationModel = std::dynamic_pointer_cast< aerodynamics::AerodynamicAcceleration >( accelerationModel );


### PR DESCRIPTION
This PR closes #486.

The fix involves rotating the set of coefficients specified by the user in the chosen frame to the aerodynamic frame, where the first entry corresponds to the drag coefficient. This allows for the correct estimation of Cd.

For simplicity, for the arcwise parameter, the fix is to throw an error in case the chosen frame is different from the default negative aerodynamic frame.