### PR TITLE
Fix bug in createCompressedDopplerCollection with low compression ratios

### DIFF
--- a/include/tudat/simulation/estimation_setup/processOdfFile.h
+++ b/include/tudat/simulation/estimation_setup/processOdfFile.h
@@ -1357,7 +1357,7 @@ std::shared_ptr< observation_models::SingleObservationSet< ObservationScalarType
 
     for( unsigned int i = 0; i < originalObservations.size( ); i += compressionRatio )
     {
-        if( originalObservations.size( ) - i > compressionRatio )
+        if( originalObservations.size( ) - i >= compressionRatio )
         {
             Eigen::Matrix< ObservationScalarType, Eigen::Dynamic, 1 > newObservable = originalObservations.at( i );
             TimeType newTime = originalObservationTimesUtc.at( i );
@@ -1424,13 +1424,13 @@ template< typename ObservationScalarType = double, typename TimeType = double >
 std::shared_ptr< observation_models::ObservationCollection< ObservationScalarType, TimeType > > createCompressedDopplerCollection(
         const std::shared_ptr< observation_models::ObservationCollection< ObservationScalarType, TimeType > > originalDopplerData,
         const unsigned int compressionRatio,
-        const unsigned int minNumberObservations = 10 )
+        const unsigned int minNumberObservations = 10,
+        const double maxArcGap = 300.0 )
 {
     // Split Doppler observation sets into arcs
-    double compressionRatioFloat = mathematical_constants::getFloatingInteger< double >( compressionRatio );
     std::shared_ptr< observation_models::ObservationCollection< ObservationScalarType, TimeType > > compressedData =
             splitObservationSets( originalDopplerData,
-                                  observationSetSplitter( time_interval_splitter, compressionRatioFloat, minNumberObservations ),
+                                  observationSetSplitter( time_interval_splitter, maxArcGap, minNumberObservations ),
                                   observationParser( dsn_n_way_averaged_doppler ) );
 
     std::map< LinkEnds, std::vector< std::shared_ptr< observation_models::SingleObservationSet< ObservationScalarType, TimeType > > > >

--- a/include/tudat/simulation/estimation_setup/processOdfFile.h
+++ b/include/tudat/simulation/estimation_setup/processOdfFile.h
@@ -1365,8 +1365,8 @@ std::shared_ptr< observation_models::SingleObservationSet< ObservationScalarType
             bool skipObservation = false;
             for( unsigned int j = 1; ( j < compressionRatio && !skipObservation ); j++ )
             {
-                if( ( originalObservationTimesUtc.at( i + j ) - originalObservationTimesUtc.at( i + j - 1 ) - currentCompressionTime ) <
-                    10.0 * std::numeric_limits< double >::epsilon( ) * static_cast< double >( originalObservationTimesUtc.at( i + j ) ) )
+                if( std::fabs( static_cast< double >( originalObservationTimesUtc.at( i + j ) - originalObservationTimesUtc.at( i + j - 1 ) ) - currentCompressionTime ) <
+                    0.01 )
                 {
                     newObservable += originalObservations.at( i + j );
                     newTime += originalObservationTimesUtc.at( i + j );

--- a/src/tudatpy/estimation/observations_setup/observations_wrapper/expose_observations_wrapper.cpp
+++ b/src/tudatpy/estimation/observations_setup/observations_wrapper/expose_observations_wrapper.cpp
@@ -381,6 +381,7 @@ void expose_observations_wrapper( py::module &m )
            py::arg( "original_observation_collection" ),
            py::arg( "compression_ratio" ),
            py::arg( "minimum_number_of_observations" ) = 10,
+           py::arg( "max_arc_gap" ) = 300.0,
            R"doc(
         Create a compressed Doppler observation collection.
 
@@ -394,6 +395,8 @@ void expose_observations_wrapper( py::module &m )
             The number of observations to average into a single compressed observation.
         minimum_number_of_observations : int, optional
             The minimum number of observations required in an arc to be considered for compression, by default 10.
+        max_arc_gap : float, optional
+            Maximum time gap (in seconds) between consecutive observations before splitting into a new arc, by default 300.0.
 
         Returns
         -------


### PR DESCRIPTION
## Summary
-  Fixed  #615 
 - Fixed off-by-one error in boundary check that skipped last batch of observations
 - Added `maxArcGap` parameter to decouple arc splitting from compression ratio
 - Updated Python bindings with new `max_arc_gap` parameter (default: 300.0s)

 ## Problem
 When using low compression ratios (e.g., 5) with data sampled at longer intervals (e.g., 10s), the function produced no compressed
 observations because:
 1. The arc splitter used `compressionRatio` as the gap threshold (5s < 10s interval → split every observation into separate arc)
 2. Boundary check `>` instead of `>=` skipped the last batch

 ## Solution
 - Change boundary check from `>` to `>=` to include last batch
 - Add explicit `maxArcGap` parameter (default 300s) for arc splitting
 - This decouples arc splitting behavior from compression ratio

## Additional Fixes:
- Fixed #617 