### PR TITLE
Add MPC stations from Project Pluto, assuming no motion.

### DIFF
--- a/include/tudat/simulation/environment_setup/defaultBodies.h
+++ b/include/tudat/simulation/environment_setup/defaultBodies.h
@@ -295,6 +295,8 @@ std::vector< std::shared_ptr< GroundStationSettings > > getDsnStationSettings( )
 
 std::vector< std::shared_ptr< GroundStationSettings > > getEvnStationSettings( );
 
+std::vector< std::shared_ptr< GroundStationSettings > > getMPCStationSettings( );
+
 std::vector< std::shared_ptr< GroundStationSettings > > getRadioTelescopeStationSettings( );
 
 }  // namespace simulation_setup

--- a/src/tudat/simulation/environment_setup/defaultBodies.cpp
+++ b/src/tudat/simulation/environment_setup/defaultBodies.cpp
@@ -565,6 +565,9 @@ Eigen::Vector3d getApproximateGroundStationPosition( std::string stationName )
 const static std::string pysctrackGroundStationPosFile = tudat::paths::getStationLocationDataPath( ) + "/glo.sit";
 const static std::string pysctrackGroundStationVelFile = tudat::paths::getStationLocationDataPath( ) + "/glo.vel";
 const static std::string pysctrackGroundStationCodesFile = tudat::paths::getStationLocationDataPath( ) + "/ns_codes.dat";
+const static std::string MPCGroundStationPosFile = tudat::paths::getStationLocationDataPath( ) + "/mpc.sit";
+const static std::string MPCGroundStationVelFile = tudat::paths::getStationLocationDataPath( ) + "/mpc.vel";
+const static std::string MPCGroundStationCodesFile = tudat::paths::getStationLocationDataPath( ) + "/mpc_codes.dat";
 
 const static std::map< std::string, Eigen::Vector3d > approximateGroundStationPositionsFromFile =
         utilities::getMapFromFile< std::string, Eigen::Vector3d >( pysctrackGroundStationPosFile, '$', " \t" );
@@ -593,6 +596,20 @@ std::map< std::string, Eigen::Vector3d >& getVlbiStationVelocities( )
 {
     static std::map< std::string, Eigen::Vector3d > stationVelocities =
             utilities::getMapFromFile< std::string, Eigen::Vector3d >( pysctrackGroundStationVelFile, '$', " \t" );
+    return stationVelocities;
+}
+
+std::map< std::string, Eigen::Vector3d >& getMPCStationPositions( )
+{
+    static std::map< std::string, Eigen::Vector3d > stationPositions =
+            utilities::getMapFromFile< std::string, Eigen::Vector3d >( MPCGroundStationPosFile, '$', " \t" );
+    return stationPositions;
+}
+
+std::map< std::string, Eigen::Vector3d >& getMPCStationVelocities( )
+{
+    static std::map< std::string, Eigen::Vector3d > stationVelocities =
+            utilities::getMapFromFile< std::string, Eigen::Vector3d >( MPCGroundStationVelFile, '$', " \t" );
     return stationVelocities;
 }
 
@@ -735,6 +752,35 @@ std::vector< std::shared_ptr< GroundStationSettings > > getEvnStationSettings( )
     return stationSettingsList;
 }
 
+std::vector< std::shared_ptr< GroundStationSettings > > getMPCStationSettings( )
+{
+    std::vector< std::shared_ptr< GroundStationSettings > > stationSettingsList;
+
+    std::map< std::string, Eigen::Vector3d > stationPositions = getMPCStationPositions( );
+    std::map< std::string, Eigen::Vector3d > stationVelocities = getMPCStationVelocities( );
+
+    std::vector< std::string > commonStationNames;
+    for( auto it: stationPositions )
+    {
+        if( stationVelocities.count( it.first ) > 0 )
+        {
+            commonStationNames.push_back( it.first );
+        }
+    }
+
+    for( unsigned int i = 0; i < commonStationNames.size( ); i++ )
+    {
+        std::shared_ptr< GroundStationMotionSettings > stationMotion = std::make_shared< LinearGroundStationMotionSettings >(
+                stationVelocities.at( commonStationNames.at( i ) ) * 1.0E-3 / physical_constants::JULIAN_YEAR, 0.0 );
+
+        std::shared_ptr< GroundStationSettings > stationSettings =
+                std::make_shared< GroundStationSettings >( commonStationNames.at( i ), stationPositions.at( commonStationNames.at( i ) ) );
+        stationSettings->addStationMotionSettings( stationMotion );
+        stationSettingsList.push_back( stationSettings );
+    }
+    return stationSettingsList;
+}
+
 std::vector< std::shared_ptr< GroundStationSettings > > getRadioTelescopeStationSettings( )
 {
     std::vector< std::shared_ptr< GroundStationSettings > > stations = getEvnStationSettings( );
@@ -742,6 +788,7 @@ std::vector< std::shared_ptr< GroundStationSettings > > getRadioTelescopeStation
     stations.insert( stations.begin( ), dsnStations.begin( ), dsnStations.end( ) );
     return stations;
 }
+
 }  // namespace simulation_setup
 
 }  // namespace tudat

--- a/src/tudatpy/dynamics/environment_setup/ground_station/expose_ground_station.cpp
+++ b/src/tudatpy/dynamics/environment_setup/ground_station/expose_ground_station.cpp
@@ -300,6 +300,24 @@ void expose_ground_station_setup( py::module& m )
 
      )doc" );
 
+     m.def( "optical_telescope_stations",
+           &tss::getMPCStationSettings,
+           R"doc(
+
+ Function for creating settings for existing MPC stations.
+ Observatories cartesian coordinates were converted using parallax info (rho_cos_phi, rho_sin_phi)
+ from Project Pluto's list: https://www.projectpluto.com/mpc_stat.txt,
+ which has them in geodetic cordinates. Some station positions (e.g. amateur observatories positions) might lack accuracy,
+ especially in altitude, as it is sometimes not clear whether their altitude has to be intended as a geodetic or ellipsoidal altitude.
+ For more info and insights, please check the following discussion: https://www.projectpluto.com/mpc_stat.htm.
+
+ Returns
+ -------
+ list[ GroundStationSettings ]
+     List of settings to create MPC stations
+
+     )doc" );
+
     m.def( "linear_station_motion",
            &tss::linearGroundStationMotionSettings,
            py::arg( "linear_velocity" ),


### PR DESCRIPTION
This PR adds Tudat support for optical observatories [listed on Project Pluto](https://www.projectpluto.com/mpc_stat.txt).
Project Pluto provides geodetic positions and parallax measurements (`rho_cos_phi`, `rho_sin_phi`). These were converted to Cartesian Coordinates via a standalone code that implements the following: 

```
            x = EARTH_RADIUS * rho_cos_phi * math.cos(lon_rad)
            y = EARTH_RADIUS * rho_cos_phi * math.sin(lon_rad)
            z = EARTH_RADIUS_* rho_sin_phi
```

Since no velocities are directly available for those observatories, I created a corresponding velocities files containing all zeros in its columns. 

Both positions and velocities are then saved to the `mpc.sit` and `mpc.vel` files, which needs to be added to the `resources` folder, where also `glo.sit` is found (same applies for `mpc.vel` and `mpc_codes.dat`). 

Converting back the results from the `mpc.sit` file (`cartesian -> geodetic`) returns Project Pluto's latitudes and longitudes up to `~1e-5 deg` for most stations, while altitude differences wrt to Project Pluto are typically `~10 meters`, although some might be bigger because of ambiguous/erroneous ellipsoidal/geodetic definition (see this [discussion] (https://www.projectpluto.com/mpc_stat.htm)). These differences are acceptable as they should not matter much in routine SSA analysis.