### PR TITLE
Refactor deprecation functionality, add stubgen compatibility

### DIFF
--- a/build.py
+++ b/build.py
@@ -212,6 +212,10 @@ class StubGenerator:
         # Define the path to the stub directory
         self.stubs_dir = build_dir / "tudatpy-stubs"
 
+        # Function names used for deprecation assignments
+        self.deprecation_function_names = [stat.name for stat in self.__parse_script(self.python_source_dir / "_deprecation.py").body if isinstance(stat, ast.FunctionDef)]
+
+
         return None
 
     def __parse_script(self, stub_path: Path) -> ast.Module:
@@ -869,6 +873,10 @@ class StubGenerator:
                         stub_body.append(statement)
                     continue
 
+                # No type hints for deprecation module
+                if "tudatpy._deprecation" in statement.module:
+                    continue
+
                 # External import statement
                 stub_body.append(statement)
 
@@ -892,12 +900,22 @@ class StubGenerator:
                     stub_body.append(statement)
                     continue
 
+                # Deprecation function assignments
+                if any(func_name in ast.unparse(statement) for func_name in self.deprecation_function_names):
+                    continue
+
                 # Any other assign statement is unexpected
                 raise NotImplementedError(
                     f"Failed to generate {stub_path}: "
                     f"Unexpected assign statement: "
                     f"{ast.unparse(statement)}"
                 )
+
+            # Ignore expression statements, e.g. for deprecation warnings
+            if isinstance(statement, ast.Expr):
+                # Deprecation function expressions
+                if any(func_name in ast.unparse(statement) for func_name in self.deprecation_function_names):
+                    continue
 
             # Other statements (We add them without modification)
             stub_body.append(statement)

--- a/build.py
+++ b/build.py
@@ -177,7 +177,7 @@ class StubGenerator:
     indentation: str = " " * 4
 
     # Ignored modules and methods
-    ignored_modules: list[str] = ["temp", "io", "numerical_simulation"]
+    ignored_modules: list[str] = ["temp", "io", "numerical_simulation", "_deprecation.py"]
     ignored_methods: list[str] = ["_pybind11_conduit_v1_"]
 
     def __init__(self, build_dir: Path, mock_env: "Environment") -> None:

--- a/src/tudatpy/_deprecation.py
+++ b/src/tudatpy/_deprecation.py
@@ -1,77 +1,194 @@
 import functools
 import warnings
 from types import ModuleType
+from typing import Callable
 
 
-def object_deprecation_decorator(old_name: str, new_name: str):
+def deprecation_warning(old_name: str, new_name: str) -> None:
+    warnings.warn(
+        f"{old_name} is deprecated. Use {new_name} instead.",
+        stacklevel=3,
+    )
+
+def object_deprecation(old_name: str, new_name: str) -> Callable:
+    """
+    Decorator to throw a deprecation warning when calling the object (function or class).
+
+    Parameters
+    ----------
+    old_name : str
+        The name of the deprecated object.
+    new_name : str
+        The name of the new object to use instead of the deprecated one.
+
+    Returns
+    -------
+    Callable
+        A decorator that wraps the original object and issues a deprecation warning when called.
+
+    Example
+    -------
+
+    ```python
+    from tudatpy._deprecation import object_deprecation
+
+    @object_deprecation("old_function", "new_function")
+    def old_function():
+        pass
+        
+    old_function()  # This will issue a deprecation warning.
+    ```
+    """
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            warnings.warn(
-                f"{old_name} is deprecated. Use {new_name} instead.",
-                stacklevel=2,
-            )
+            deprecation_warning(old_name, new_name)
             return func(*args, **kwargs)
         return wrapper
     return decorator
 
 
-def deprecate_object(destination_module: ModuleType, old_name: str, superseding_object):
-    interface = object_deprecation_decorator(old_name, superseding_object.__name__)(superseding_object)
+def register_deprecated_object(destination_module: ModuleType, old_name: str, superseding_object) -> None:
+    """
+    Register an object (function or class) under a deprecated name.
+
+    This function makes an object (function or class) available under a different, deprecated name with the same functionality. This is useful e.g. when fixing a typo, where only the corrected function name remains implemented, while they deprecated function should stay available for backwards compatibility purposes.
+
+    Parameters
+    ----------
+    destination_module : ModuleType
+        Module where the deprecated function should be registered.
+    old_name : str
+        Name under which the deprecated function should be registered.
+    superseding_object
+        Object that super-seeds the deprecated object. This can be a function or a class.
+    
+    Example
+    -------
+    This example registers a new function `new_function` under the deprecated name `old_function` in the module where the `register_deprecated_object` function is called.
+    ```python
+    import sys
+    from tudatpy._deprecation import register_deprecated_object
+    
+    def new_function():
+        pass
+        
+    register_deprecated_object(sys.modules[__name__], "old_function", new_function)
+    ```
+    """
+
+    interface = object_deprecation(old_name, superseding_object.__name__)(superseding_object)
     setattr(destination_module, old_name, interface)
 
-def keep_typo_backwards_compatible(destination_module: ModuleType, typo: str, correct: str):
+def keep_typo_backwards_compatible(destination_module: ModuleType, typo: str, correct_spelling: str) -> None:
+    """
+    .. warning::
+
+        This function makes rather strong assumptions and should be used with care.
+    
+    This is a convenience function to register functions _with_ typos to maintain backwards compatibility.
+
+    This function assumes that:
+    - the developer has fixed all typos in the function/class signatures of a module
+    - backwards compatibility should be maintained, i.e. the functions should be callable with typos
+    - all functions/classes that have the correct spelling had the wrong spelling previously.
+    
+    The function will search for all functions/classes in the given module that contain the correct spelling and register them under the name with the typo.
+
+    Parameters
+    ----------
+    destination_module : ModuleType
+        Module where the deprecated functions should be registered.
+    typo : str
+        Typo in the function/class name that should be registered as deprecated.
+    correct_spelling : str
+        Correct spelling of the function/class name.
+
+    Example
+    -------
+    This example registers all functions/classes in the `tudatpy.kernel.estimation.observations_setup.ancillary_settings` module that contain the correct spelling "ancillary" under the deprecated name with the typo "ancilliary".
+
+    ```python
+    from tudatpy.kernel.estimation.observations_setup.ancillary_settings import *
+    from tudatpy._deprecation import keep_typo_backwards_compatible
+
+    import sys
+    keep_typo_backwards_compatible(sys.modules[__name__], "ancilliary", "ancillary")
+    ```
+
+    """
+
+
     for argument in dir(destination_module):
-        if correct in argument:
-            old_name = argument.replace(correct, typo)
+        if correct_spelling in argument:
+            old_name = argument.replace(correct_spelling, typo)
             superseding_func = getattr(destination_module, argument)
-            deprecate_object(destination_module, old_name, superseding_func)
+            register_deprecated_object(destination_module, old_name, superseding_func)
 
-def deprecated_property(old_name: str, new_name: str, prop: property):
-    if not isinstance(prop, property):
-        raise TypeError("deprecated_property expects a property")
 
-    def warn():
-        warnings.warn(
-            f"{old_name} is deprecated. Use {new_name} instead.",
-            stacklevel=2,
-        )
 
-    def wrap_get(fget):
-        if fget is None:
-            return None
-        @functools.wraps(fget)
-        def getter(*args, **kwargs):
-            warn()
-            return fget(*args, **kwargs)
-        return getter
+def property_deprecation(old_name: str, new_name: str) -> Callable:
+    """
+    Wrap a property to issue a deprecation warning when accessed.
 
-    def wrap_set(fset):
-        if fset is None:
-            return None
-        @functools.wraps(fset)
-        def setter(*args, **kwargs):
-            warn()
-            return fset(*args, **kwargs)
-        return setter
+    Parameters
+    ----------
+    old_name : str
+        Deprecated name of the property.
+    new_name : str
+        New name of the property.
 
-    def wrap_del(fdel):
-        if fdel is None:
-            return None
-        @functools.wraps(fdel)
-        def deleter(*args, **kwargs):
-            warn()
-            return fdel(*args, **kwargs)
-        return deleter
+    Returns
+    -------
+    Callable
+        A decorator that wraps the property and issues a deprecation warning when accessed.
 
-    return property(
-        wrap_get(prop.fget),
-        wrap_set(prop.fset),
-        wrap_del(prop.fdel),
-        prop.__doc__,
-    )
+    Example
+    -------
+    In this example, a `ancilliary_settings` property is added to the `SingleObservationSet` class to maintain backwards compatibility, which wraps the `ancillary_settings` property and issues a deprecation warning when accessed.
 
-def property_deprecation_decorator(old_name: str, new_name: str):
+    ```python
+    from tudatpy._deprecation import property_deprecation_decorator
+    from tudatpy.kernel.estimation.observations import SingleObservationSet
+
+    SingleObservationSet.ancilliary_settings = property_deprecation_decorator("SingleObservationSet.ancilliary_settings", "SingleObservationSet.ancillary_settings")(SingleObservationSet.ancillary_settings)
+    ```
+    """
     def decorator(prop):
-        return deprecated_property(old_name, new_name, prop)
+        def property_deprecation(old_name: str, new_name: str, prop: property)-> property:
+
+            def wrap_get(fget):
+                if fget is None:
+                    return None
+                @functools.wraps(fget)
+                def getter(*args, **kwargs):
+                    deprecation_warning(old_name, new_name)
+                    return fget(*args, **kwargs)
+                return getter
+
+            def wrap_set(fset):
+                if fset is None:
+                    return None
+                @functools.wraps(fset)
+                def setter(*args, **kwargs):
+                    deprecation_warning(old_name, new_name)
+                    return fset(*args, **kwargs)
+                return setter
+
+            def wrap_del(fdel):
+                if fdel is None:
+                    return None
+                @functools.wraps(fdel)
+                def deleter(*args, **kwargs):
+                    deprecation_warning(old_name, new_name)
+                    return fdel(*args, **kwargs)
+                return deleter
+
+            return property(
+                wrap_get(prop.fget),
+                wrap_set(prop.fset),
+                wrap_del(prop.fdel),
+                prop.__doc__,
+            )
+        return property_deprecation(old_name, new_name, prop)
     return decorator

--- a/src/tudatpy/_deprecation.py
+++ b/src/tudatpy/_deprecation.py
@@ -1,0 +1,77 @@
+import functools
+import warnings
+from types import ModuleType
+
+
+def object_deprecation_decorator(old_name: str, new_name: str):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            warnings.warn(
+                f"{old_name} is deprecated. Use {new_name} instead.",
+                stacklevel=2,
+            )
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator
+
+
+def deprecate_object(destination_module: ModuleType, old_name: str, superseding_object):
+    interface = object_deprecation_decorator(old_name, superseding_object.__name__)(superseding_object)
+    setattr(destination_module, old_name, interface)
+
+def keep_typo_backwards_compatible(destination_module: ModuleType, typo: str, correct: str):
+    for argument in dir(destination_module):
+        if correct in argument:
+            old_name = argument.replace(correct, typo)
+            superseding_func = getattr(destination_module, argument)
+            deprecate_object(destination_module, old_name, superseding_func)
+
+def deprecated_property(old_name: str, new_name: str, prop: property):
+    if not isinstance(prop, property):
+        raise TypeError("deprecated_property expects a property")
+
+    def warn():
+        warnings.warn(
+            f"{old_name} is deprecated. Use {new_name} instead.",
+            stacklevel=2,
+        )
+
+    def wrap_get(fget):
+        if fget is None:
+            return None
+        @functools.wraps(fget)
+        def getter(*args, **kwargs):
+            warn()
+            return fget(*args, **kwargs)
+        return getter
+
+    def wrap_set(fset):
+        if fset is None:
+            return None
+        @functools.wraps(fset)
+        def setter(*args, **kwargs):
+            warn()
+            return fset(*args, **kwargs)
+        return setter
+
+    def wrap_del(fdel):
+        if fdel is None:
+            return None
+        @functools.wraps(fdel)
+        def deleter(*args, **kwargs):
+            warn()
+            return fdel(*args, **kwargs)
+        return deleter
+
+    return property(
+        wrap_get(prop.fget),
+        wrap_set(prop.fset),
+        wrap_del(prop.fdel),
+        prop.__doc__,
+    )
+
+def property_deprecation_decorator(old_name: str, new_name: str):
+    def decorator(prop):
+        return deprecated_property(old_name, new_name, prop)
+    return decorator

--- a/src/tudatpy/estimation/observations/__init__.py
+++ b/src/tudatpy/estimation/observations/__init__.py
@@ -1,4 +1,4 @@
-from tudatpy._deprecation import property_deprecation_decorator
+from tudatpy._deprecation import property_deprecation
 from tudatpy.kernel.estimation.observations import *
 
-SingleObservationSet.ancilliary_settings = property_deprecation_decorator("SingleObservationSet.ancilliary_settings", "SingleObservationSet.ancillary_settings")(SingleObservationSet.ancillary_settings)
+SingleObservationSet.ancilliary_settings = property_deprecation("SingleObservationSet.ancilliary_settings", "SingleObservationSet.ancillary_settings")(SingleObservationSet.ancillary_settings)

--- a/src/tudatpy/estimation/observations/__init__.py
+++ b/src/tudatpy/estimation/observations/__init__.py
@@ -1,18 +1,4 @@
+from tudatpy._deprecation import deprecated_property_alias
 from tudatpy.kernel.estimation.observations import *
-import warnings
 
-
-def with_deprecation_warning(old_name, new_name, function):
-
-    warnings.warn(
-        (f"Function {old_name} is deprecated" f". Use {new_name} instead"),
-    )
-
-    return function
-
-
-SingleObservationSet.ancilliary_settings = with_deprecation_warning(
-    "SingleObservationSet.ancilliary_settings",
-    "SingleObservationSet.ancillary_settings",
-    SingleObservationSet.ancillary_settings,
-)
+SingleObservationSet.ancilliary_settings = deprecated_property_alias("SingleObservationSet.ancilliary_settings", "SingleObservationSet.ancillary_settings")(SingleObservationSet.ancillary_settings)

--- a/src/tudatpy/estimation/observations/__init__.py
+++ b/src/tudatpy/estimation/observations/__init__.py
@@ -1,4 +1,4 @@
-from tudatpy._deprecation import deprecated_property_alias
+from tudatpy._deprecation import property_deprecation_decorator
 from tudatpy.kernel.estimation.observations import *
 
-SingleObservationSet.ancilliary_settings = deprecated_property_alias("SingleObservationSet.ancilliary_settings", "SingleObservationSet.ancillary_settings")(SingleObservationSet.ancillary_settings)
+SingleObservationSet.ancilliary_settings = property_deprecation_decorator("SingleObservationSet.ancilliary_settings", "SingleObservationSet.ancillary_settings")(SingleObservationSet.ancillary_settings)

--- a/src/tudatpy/estimation/observations_setup/ancillary_settings/__init__.py
+++ b/src/tudatpy/estimation/observations_setup/ancillary_settings/__init__.py
@@ -1,25 +1,5 @@
 from tudatpy.kernel.estimation.observations_setup.ancillary_settings import *
+from tudatpy._deprecation import keep_typo_backwards_compatible
+
 import sys
-import warnings
-
-
-def with_deprecation_warning(old_name, new_name, function):
-
-    warnings.warn(f"{old_name} is deprecated. Use {new_name} instead.")
-
-    return function
-
-
-mod = sys.modules[__name__]
-for argument in dir(mod):
-
-    if "ancillary" in argument:
-
-        old_name = argument.replace("ancillary", "ancilliary")
-        interface = with_deprecation_warning(
-            old_name, argument, getattr(mod, argument)
-        )
-        mod.__setattr__(old_name, interface)
-
-# dsn_n_way_doppler_ancillary_settings = dsn_n_way_doppler_ancilliary_settings
-# dsn_n_way_range_ancillary_settings = dsn_n_way_range_ancilliary_settings
+keep_typo_backwards_compatible(sys.modules[__name__], "ancilliary", "ancillary")


### PR DESCRIPTION
This PR:
- refactors the functionality to deprecate functions/properties in a backwards compatible manner to a separate module (`tudatpy._deprecation`)
- uses decorators to print deprecation warnings on invocation of the function/property instead of on import from the module
- adds compatibility to the stub generator for deprecation declarations in the `__init__.py` files

If an expression or assignment is detected during the stub generation in an `__init__.py` file, it is checked if the expression/assignment contains any of the deprecation function signatures. If that's the case, the expression/assignment is ignored and stub generation continues, thereby ignoring the deprecated functionality.