### PR TITLE
CODEOWNERS file 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Codeowners file for the tudatpy repository
+
+# These owners will be the default owners for everything in the repo. 
+# Unless a later match takes precedence, they will be requested for 
+# review when someone opens a pull request.
+* @DominicDirkx
+
+# Protect the entire .github folder (and specifically this file)
+/.github/ @DominicDirkx


### PR DESCRIPTION
This PR closes #637. 

For now I have added only @DominicDirkx as codeowner.

To nicely extend this file with other file-specific owners, I suggest creating teams (https://docs.github.com/en/organizations/organizing-members-into-teams/about-teams, to be discussed if this is actually helpful).