### PR TITLE
Fix/eliminate biasparameter id degeneracy

### DIFF
--- a/include/tudat/astro/orbit_determination/estimatable_parameters/observationBiasParameter.h
+++ b/include/tudat/astro/orbit_determination/estimatable_parameters/observationBiasParameter.h
@@ -27,16 +27,28 @@ inline std::string createObsBiasSecondaryIdentifier(
     const observation_models::ObservableType observableType,
     const observation_models::LinkEnds& linkEnds )
 {
-    const std::string& transmitter =
-        linkEnds.at(observation_models::transmitter).stationName_;
+    std::string transmitterStr = "None";
+    std::string receiverStr    = "None";
 
-    const std::string& receiver =
-        linkEnds.at(observation_models::receiver).stationName_;
+    // Check if transmitter exists
+    auto transmitterIt = linkEnds.find( observation_models::transmitter );
+    if( transmitterIt != linkEnds.end( ) )
+    {
+        transmitterStr = transmitterIt->second.stationName_;
+    }
 
-    return transmitter + " --> " +
-           receiver + " , " +
-           observation_models::getObservableName(observableType);
+    // Check if receiver exists
+    auto receiverIt = linkEnds.find( observation_models::receiver );
+    if( receiverIt != linkEnds.end( ) )
+    {
+        receiverStr = receiverIt->second.stationName_;
+    }
+
+    return transmitterStr + " --> " +
+           receiverStr + " , " +
+           observation_models::getObservableName( observableType );
 }
+
 
 
 //! Interface class for the estimation of a constant absolute or relative observation bias.

--- a/include/tudat/astro/orbit_determination/estimatable_parameters/observationBiasParameter.h
+++ b/include/tudat/astro/orbit_determination/estimatable_parameters/observationBiasParameter.h
@@ -22,6 +22,23 @@ namespace tudat
 namespace estimatable_parameters
 {
 
+//! Utility function to create more precise secondary identification string of observation bias parameters.
+inline std::string createObsBiasSecondaryIdentifier(
+    const observation_models::ObservableType observableType,
+    const observation_models::LinkEnds& linkEnds )
+{
+    const std::string& transmitter =
+        linkEnds.at(observation_models::transmitter).stationName_;
+
+    const std::string& receiver =
+        linkEnds.at(observation_models::receiver).stationName_;
+
+    return transmitter + " --> " +
+           receiver + " , " +
+           observation_models::getObservableName(observableType);
+}
+
+
 //! Interface class for the estimation of a constant absolute or relative observation bias.
 /*!
  *  Interface class for the estimation of a constant absolute or relative observation bias (at given link ends and observable
@@ -48,7 +65,7 @@ public:
                                       const observation_models::ObservableType observableType,
                                       const bool biasIsAbsolute ):
         EstimatableParameter< Eigen::VectorXd >( biasIsAbsolute ? constant_additive_observation_bias : constant_relative_observation_bias,
-                                                 linkEnds.begin( )->second.bodyName_, linkEnds.begin( )->second.stationName_ ),
+                                                 linkEnds.begin( )->second.bodyName_, createObsBiasSecondaryIdentifier(observableType, linkEnds) ),
         getCurrentBias_( getCurrentBias ), resetCurrentBias_( resetCurrentBias ), linkEnds_( linkEnds ), observableType_( observableType )
     { }
 
@@ -208,7 +225,7 @@ public:
                                      const bool biasIsAbsolute ):
         EstimatableParameter< Eigen::VectorXd >(
                 biasIsAbsolute ? arcwise_constant_additive_observation_bias : arcwise_constant_relative_observation_bias,
-                linkEnds.begin( )->second.bodyName_, linkEnds.begin( )->second.stationName_ ),
+                linkEnds.begin( )->second.bodyName_, createObsBiasSecondaryIdentifier(observableType, linkEnds)  ),
         arcStartTimes_( arcStartTimes ), getBiasList_( getBiasList ), resetBiasList_( resetBiasList ), linkEndIndex_( linkEndIndex ),
         linkEnds_( linkEnds ), observableType_( observableType )
     {


### PR DESCRIPTION
Fixes issue https://github.com/tudat-team/tudatpy/issues/666 for ConstantObservationBiasParameter (as well as arcwise, additive and relative variants) by creating an extended string consisting of "{transmitter} --> {receiver} , {observable_type}". 
When linkdef does not contain a transmitter or receiver, field in string is filled by "None".

Example for tuple of first and secondary identfier strings: ('Earth', 'DSS-14 --> DSS-55 , DsnNWayAveragedDoppler')


Concerns about interference of this implementation with the closure of bias models and parameters were unfounded.
