### PR TITLE
Cleanup and simplify CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -91,14 +91,12 @@ jobs:
            activate-environment: tudat
            auto-activate-base: false
 
-
-    - name: Get date
-      # Get the current date and time in UTC format. This step is used to create a unique cache key for the conda environment cache by appending the date to the cache key.
-      # GitHub cache action doucmentation recommends refreshing the cache every 24 hours to avoid inconsistencies of package versions between the CI pipeline and local installations. This is ensured by appending the date to the cache key.See https://github.com/marketplace/actions/setup-miniconda#caching-environments for more detail.
-      id: get-date
-      run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
-      shell: bash
-
+    # - name: Get date
+    #   # Get the current date and time in UTC format. This step is used to create a unique cache key for the conda environment cache by appending the date to the cache key.
+    #   # GitHub cache action doucmentation recommends refreshing the cache every 24 hours to avoid inconsistencies of package versions between the CI pipeline and local installations. This is ensured by appending the date to the cache key.See https://github.com/marketplace/actions/setup-miniconda#caching-environments for more detail.
+    #   id: get-date
+    #   shell: bash
+    #   run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
 
     # - name: Cache conda environment
     #   # Cache the conda environment to avoid re-installing the same packages every time the workflow runs. The cache key is based on the environment.yml file, the operating system, and the date. The cache is restored if the cache key matches the cache key of the previous run.
@@ -141,13 +139,11 @@ jobs:
     #   if: runner.os == 'Windows' && steps.cache.outputs.cache-hit == 'true'
     #   run: cmd /c "curl -fsSL https://raw.githubusercontent.com/tudat-team/tudat-resources-feedstock/master/recipe/post-link.bat | cmd"
 
-
-    #- name: Restore cached compilation results
-    #  # This third party action will setup ccache on the runner and restore any previously saved cache. Caches are saved automatically by the action after a build.
-    #  uses: hendrikmuhs/ccache-action@v1.2.12
-    #  with:
-    #    key: ${{ matrix.platform.os }}-${{ matrix.build_type }}
-
+    # - name: Restore cached compilation results
+    #   # This third party action will setup ccache on the runner and restore any previously saved cache. Caches are saved automatically by the action after a build.
+    #   uses: hendrikmuhs/ccache-action@v1.2.12
+    #   with:
+    #     key: ${{ matrix.platform.os }}-${{ matrix.build_type }}
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,29 +28,48 @@ jobs:
       # building under conda.  This invites version clashes with
       # dependencies that are also installed system-wide.
       #
+      # Compiler meta-packages provides the platform specific packages:
       # - Linux: gcc
-      # - Windows: gcc (?)
+      # - Windows: gcc
       # - OSX: clang
       #
-      # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
+      # If you want to add a config that can vary for a given
+      # platform, add it as a top-level key under matrix, however if
+      # it is a property of the platform, you should create a key
+      # under "platform:".
+      #
+      # E.g. to add more build types (Release, Debug, RelWithDebInfo,
+      # etc.) customize the build_type: list, it will be added to all
+      # platforms.  However, if you want to add a build type for a
+      # subset of platforms, you should use include: (see commented
+      # out example below) or use exclude: along with adding to
+      # "build_type:".
+      #
+      # The precendence rules used by GH to generate matrix values is
+      # non-intuitive.  You can review the rules here:
+      # https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/run-job-variations
       matrix:
         platform:
           - os: ubuntu-latest
             label: linux-64
             path_conda_env: /usr/share/miniconda/envs/tudat
             build_jobs: 3
-            build_type: Release
+            ccache: ON
           - os: windows-latest
             label: win-64
             path_conda_env: C:\Miniconda\envs\tudat
             build_jobs: 2
-            build_type: Release
+            ccache: OFF
           - os: macos-latest
             label: osx-64
             path_conda_env: /Users/runner/miniconda3/envs/tudat
             build_jobs: 2
-            build_type: Release
+            ccache: ON
+        build_type: [Release]
         compilers: [{c: gcc, cxx: g++}, {c: clang, cxx: clang++}]
+        # include:
+        #   - platform: {os: windows-latest}
+        #     build_type: [Release, Debug]
         exclude:
           - platform: {os: windows-latest}
             compilers: {c: clang, cxx: clang++}
@@ -61,28 +80,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-
-    - name: Resolve build type
-      id: resolve_build_type
-      shell: bash -l {0}
-      run: |
-        if [ "${{ runner.os }}" = "Windows" ]; then
-          echo "value=Release" >> "$GITHUB_OUTPUT"
-        else
-          echo "value=${{ matrix.platform.build_type }}" >> "$GITHUB_OUTPUT"
-        fi
-
-    - name: Resolve CI ccache mode
-      id: resolve_ci_ccache_mode
-      shell: bash -l {0}
-      run: |
-        if [ "${{ runner.os }}" = "Windows" ]; then
-          # Avoid MSVC + ccache wrapper path: can crash cl.exe with missing entrypoint errors.
-          echo "value=OFF" >> "$GITHUB_OUTPUT"
-        else
-          echo "value=ON" >> "$GITHUB_OUTPUT"
-        fi
-
 
     - name: Setup conda environment
       # This step creates an empty conda environment with the name 'tudat' and activates it. Use latest conda version.
@@ -106,12 +103,10 @@ jobs:
     #       key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment.yml') }}-${{steps.get-date.outputs.today}}
     #   id: cache
 
-
     - name: Create conda environment from environment.yml - ${{ matrix.platform.os }}
       # Update the tudat conda environment created using the environment.yml file if the cache is not restored
       # if: steps.cache.outputs.cache-hit != 'true'
       run: conda env update -n tudat -f environment.yaml
-
 
     - name: Show full conda package list
       shell: bash -l {0}
@@ -134,7 +129,6 @@ jobs:
     #   if: (runner.os == 'Linux' || runner.os == 'MacOS') && steps.cache.outputs.cache-hit == 'true'
     #   run: bash -c "$(curl -fsSL https://raw.githubusercontent.com/tudat-team/tudat-resources-feedstock/master/recipe/post-link.sh)"
 
-
     # - name: Download tudat-resources data files for Windows
     #   if: runner.os == 'Windows' && steps.cache.outputs.cache-hit == 'true'
     #   run: cmd /c "curl -fsSL https://raw.githubusercontent.com/tudat-team/tudat-resources-feedstock/master/recipe/post-link.bat | cmd"
@@ -152,10 +146,10 @@ jobs:
       run: |
         cmake -B "${{ github.workspace }}/build" \
           -S "${{ github.workspace }}" \
-          -DCMAKE_BUILD_TYPE=${{ steps.resolve_build_type.outputs.value }} \
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
           -DCMAKE_CXX_COMPILER=${{ matrix.compilers.cxx }} \
           -DCMAKE_C_COMPILER=${{ matrix.compilers.c }} \
-          -DTUDAT_BUILD_GITHUB_ACTIONS=${{ steps.resolve_ci_ccache_mode.outputs.value }} \
+          -DTUDAT_BUILD_GITHUB_ACTIONS=${{ matrix.platform.ccache }} \
           -DTUDAT_BUILD_WITH_TEST_PCH=ON \
           -DTUDAT_BUILD_WITH_PCH=ON \
           -DTUDAT_BUILD_FOR_REDUCED_COMPILE_TIME=ON \
@@ -169,11 +163,10 @@ jobs:
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator). Use multiple cpu cores available in the runner.
       shell: bash -l {0}
-      run: cmake --build "${{ github.workspace }}/build" --config "${{ steps.resolve_build_type.outputs.value }}" -j${{ matrix.platform.build_jobs }}
-
+      run: cmake --build "${{ github.workspace }}/build" --config "${{ matrix.build_type }}" -j${{ matrix.platform.build_jobs }}
 
     - name: Test
       working-directory: "${{ github.workspace }}/build"
       # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest --build-config ${{ steps.resolve_build_type.outputs.value }} --output-on-failure -j4
+      run: ctest --build-config ${{ matrix.build_type }} --output-on-failure -j4


### PR DESCRIPTION
AFAIU, the resolve build type, and CCACHE steps were redundant.  But I think I see why they were added initially.  So after cleanup, I added some instructions on how to modify the matrix in the future.  That way, there should be no need to add steps to handle any special cases in the future.