### PR TITLE
Fixed redundant code, type hinting and added timeout to spacetrack and discos

### DIFF
--- a/src/tudatpy/data/discos/discos.py
+++ b/src/tudatpy/data/discos/discos.py
@@ -1,10 +1,8 @@
 import requests
+from typing import Any
 
 class DiscosQuery:
-    def __init__(self, token, url="https://discosweb.esoc.esa.int"):
-        """
-        Initializes the DiscosQuery object with the provided token and base URL.
-        """
+    def __init__(self, token: str, timeout: int | None = 10, url: str = "https://discosweb.esoc.esa.int"):
         self.token = token
         self.url = url
         self.api_version = '2'
@@ -12,55 +10,38 @@ class DiscosQuery:
             'Authorization': f'Bearer {self.token}',
             'DiscosWeb-Api-Version': self.api_version,
         }
+        self.timeout = timeout
 
-    def query_object(self, sat_id, is_discos_id=False, verbose=True) -> dict[str] | None:
-        """
-        Queries the DISCOS database using either a NORAD ID (default) or DISCOS ID.
-
-        Parameters
-        ----------
-        sat_id: str
-            The ID of the satellite to query.
-        is_discos_id: bool
-            If True, treats sat_id as an internal DISCOS ID.
-            If False (default), treats sat_id as a NORAD ID (satno).
-
-        verbose: bool
-            Whether to print the results (default True).
-
-        Returns
-        ----------
-        dict[str] | None
-            The attributes of the queried object.
-        """
-
+    def query_object(self, sat_id: str | int, is_discos_id: bool = False, verbose: bool = True) -> dict[str, Any] | None:
         if is_discos_id:
             query_url = f'{self.url}/api/objects/{sat_id}'
         else:
             query_url = f'{self.url}/api/objects?filter=eq(satno,{sat_id})'
 
-        response = requests.get(query_url, headers=self.headers)
-
-        if response.ok:
+        try:
+            response = requests.get(query_url, headers=self.headers, timeout=self.timeout)
+            response.raise_for_status()
             data = response.json().get('data')
 
-            # Handle API response structure:
-            if isinstance(data, list):
-                if not data:
-                    if verbose: print(f"No object found for queried satellite.")
-                    return None
-                attributes = data[0]['attributes']
-            else:
-                attributes = data['attributes']
+            if not data:
+                if verbose: print(f"No object found for satellite {sat_id}.")
+                return None
+
+            # Handle response structure (List vs Single Object)
+            attributes = data[0]['attributes'] if isinstance(data, list) else data['attributes']
 
             if verbose:
-                print(attributes)
+                print(f"Successfully retrieved data for {sat_id}")
 
             return attributes
 
-        else:
-            # Handle API Errors
-            errors = response.json().get('errors', 'Unknown error')
-            if verbose:
-                print(f"API Error: {errors}")
+        except requests.exceptions.Timeout:
+            if verbose: print(f"Timeout Error: The request for {sat_id} took too long.")
+            return None
+        except requests.exceptions.RequestException as e:
+            # Catches ConnectionErrors, HTTP Errors, etc.
+            if verbose: print(f"Network Error for {sat_id}: {e}")
+            return None
+        except (KeyError, TypeError) as e:
+            if verbose: print(f"Data Parsing Error: API response structure changed. {e}")
             return None

--- a/src/tudatpy/data/discos/discos.py
+++ b/src/tudatpy/data/discos/discos.py
@@ -2,7 +2,22 @@ import requests
 from typing import Any
 
 class DiscosQuery:
+    """
+    A class to query the ESA DISCOS (Database and Information System Characterising Objects in Space) API.
+    """
     def __init__(self, token: str, timeout: int | None = 10, url: str = "https://discosweb.esoc.esa.int"):
+        """
+        Initialize the DiscosQuery client.
+
+        Parameters
+        ----------
+        token : str
+            API authentication token from DISCOS.
+        timeout : int, optional
+            Request timeout in seconds. Defaults to 10.
+        url : str, optional
+            Base URL for the DISCOS API. Defaults to "https://discosweb.esoc.esa.int".
+        """
         self.token = token
         self.url = url
         self.api_version = '2'
@@ -13,6 +28,23 @@ class DiscosQuery:
         self.timeout = timeout
 
     def query_object(self, sat_id: str | int, is_discos_id: bool = False, verbose: bool = True) -> dict[str, Any] | None:
+        """
+        Query object information from DISCOS using either a NORAD ID or a DISCOS ID.
+
+        Parameters
+        ----------
+        sat_id : str | int
+            The satellite identifier (NORAD ID or DISCOS ID).
+        is_discos_id : bool, optional
+            If True, treats sat_id as a DISCOS internal ID. If False, treats it as a NORAD ID. Defaults to False.
+        verbose : bool, optional
+            If True, prints status and error messages to the console. Defaults to True.
+
+        Returns
+        -------
+        dict[str, Any] | None
+            A dictionary containing object attributes if successful, None otherwise.
+        """
         if is_discos_id:
             query_url = f'{self.url}/api/objects/{sat_id}'
         else:

--- a/src/tudatpy/data/spacetrack/spacetrack.py
+++ b/src/tudatpy/data/spacetrack/spacetrack.py
@@ -75,6 +75,7 @@ class SpaceTrackQuery:
 
         Parameters
         ----------
+        
         password : str
             Plaintext password. Never stored on the instance.
 
@@ -113,12 +114,36 @@ class SpaceTrackQuery:
     # ------------------------------------------------------------------
 
     def _build_url(self, *path_parts: str) -> str:
-        """Joins path segments onto the base URL, safe on all platforms."""
+        """
+        Joins path segments onto the base URL, safe on all platforms.
+
+        Parameters
+        ----------
+        *path_parts : str
+            URL path segments to join.
+
+        Returns
+        -------
+        str
+            The full URL.
+        """
         path = "/".join(part.strip("/") for part in path_parts)
         return urljoin(self.spacetrack_url.rstrip("/") + "/", path)
 
     def _fetch_json(self, url: str) -> list:
-        """GET a URL and return the body as a list."""
+        """
+        GET a URL and return the body as a list.
+
+        Parameters
+        ----------
+        url : str
+            The URL to fetch.
+
+        Returns
+        -------
+        list
+            The JSON response body as a list.
+        """
         response = self.session.get(url, timeout=self.timeout)
         response.raise_for_status()
         data = response.json()
@@ -176,6 +201,17 @@ class SpaceTrackQuery:
         File structure on disk::
 
             {"last_api_hit": "<ISO datetime>", "data": [...]}
+
+        Parameters
+        ----------
+        filepath : str
+            Path to the JSON cache file.
+        new_data : list[dict]
+            New OMM records to merge.
+
+        Returns
+        -------
+        None
         """
         existing: list[dict] = []
         if os.path.exists(filepath):
@@ -292,6 +328,11 @@ class SpaceTrackQuery:
             ``True`` → merge into existing file. ``False`` → overwrite.
         filename : str | None
             Optional filename override. Defaults to ``'latest_on_orbit.json'``.
+
+        Returns
+        -------
+        list | None
+            List of OMM records or None if the request failed.
         """
         url = self._build_url(
             "basicspacedata/query/class/gp/OBJECT_TYPE/PAYLOAD"
@@ -316,6 +357,11 @@ class SpaceTrackQuery:
             ``True`` → merge. ``False`` → overwrite.
         filename : str | None
             Optional filename override.
+
+        Returns
+        -------
+        list | None
+            List of OMM records or None if the request failed.
         """
         if filename:
             json_name = filename
@@ -356,6 +402,11 @@ class SpaceTrackQuery:
             ``True`` → merge. ``False`` → overwrite.
         filename : str | None
             Force a specific cache filename.
+
+        Returns
+        -------
+        list | None
+            List of OMM records or None if the request failed.
         """
         if not isinstance(norad_ids, (list, tuple, set)):
             norad_ids = [norad_ids]
@@ -407,6 +458,11 @@ class SpaceTrackQuery:
             Cache filename.
         update_existing : bool
             ``True`` → merge. ``False`` → overwrite.
+
+        Returns
+        -------
+        list | None
+            List of OMM records or None if the request failed.
         """
         parts = ["basicspacedata/query/class/gp/OBJECT_TYPE/PAYLOAD"]
         for oe, bounds in filter_oe_dict.items():
@@ -621,7 +677,7 @@ class OMMUtils:
 
         Returns
         -------
-        environment.TleEphemeris
+        environment.Tle
             Configured TleEphemeris object.
         """
         return environment.TleEphemeris(
@@ -644,7 +700,7 @@ class OMMUtils:
 
         Returns
         -------
-        environment.TleEphemeris
+        environment.Tle
             Tle object.
         """
         return environment.Tle(tle_line_1, tle_line_2)
@@ -662,6 +718,10 @@ class OMMUtils:
         ----------
         filepath : str
             Absolute path to the cache file.
+
+        Returns
+        -------
+        None
         """
         if not os.path.exists(filepath):
             print(f"File not found: {filepath}")

--- a/src/tudatpy/data/spacetrack/spacetrack.py
+++ b/src/tudatpy/data/spacetrack/spacetrack.py
@@ -25,6 +25,7 @@ class SpaceTrackQuery:
             password: str | None = None,
             spacetrack_url: str = "https://www.space-track.org",
             tle_data_folder: str = get_resource_path() + "/tle_data",
+            timeout: int = 60,
     ) -> None:
         """
         Parameters
@@ -50,6 +51,7 @@ class SpaceTrackQuery:
         os.makedirs(self.tle_data_folder, exist_ok=True)
 
         self.session: requests.Session = requests.Session()
+        self.timeout = timeout
         self._login(password)
         del password  # do not keep the plaintext password on the instance
 
@@ -85,7 +87,7 @@ class SpaceTrackQuery:
         try:
             response = self.session.post(
                 urljoin(self.spacetrack_url, "/ajaxauth/login"),
-                json={"identity": self.username, "password": password},
+                json={"identity": self.username, "password": password}, timeout=self.timeout
             )
             response.raise_for_status()
             print("Login successful.")
@@ -98,7 +100,8 @@ class SpaceTrackQuery:
         Logs out and closes the session. Safe to call multiple times.
         """
         try:
-            self.session.get(urljoin(self.spacetrack_url, "/ajaxauth/logout"))
+            self.session.get(urljoin(self.spacetrack_url, "/ajaxauth/logout"),
+                             timeout = self.timeout)
             print("Logged out of Space-Track.")
         except requests.exceptions.RequestException as e:
             print(f"Logout request failed (session may already be expired): {e}")
@@ -116,7 +119,7 @@ class SpaceTrackQuery:
 
     def _fetch_json(self, url: str) -> list:
         """GET a URL and return the body as a list."""
-        response = self.session.get(url)
+        response = self.session.get(url, timeout=self.timeout)
         response.raise_for_status()
         data = response.json()
         return data if isinstance(data, list) else [data]
@@ -547,9 +550,6 @@ class OMMUtils:
         if isinstance(json_data, dict):
             json_data = [json_data]
 
-        if json_data and isinstance(json_data, list):
-            pass
-
         final_dict = defaultdict(list)
 
         for entry in json_data:
@@ -608,7 +608,7 @@ class OMMUtils:
     @staticmethod
     def tle_to_TleEphemeris_object(
             tle_line_1: str, tle_line_2: str
-    ) -> environment.TleEphemeris:
+    ) -> environment.Tle:
         """
         Converts a TLE line pair into a Tudat ``TleEphemeris`` object.
 


### PR DESCRIPTION
This PR adds a `timeout` parameter (in seconds) to both `discos` and `spacetrack`, to allow for users to skip a query if it is taking longer than `timeout`. This can be used, for instance, in pipelines for which speed is important.

