### PR TITLE
Fix TLE inclination parsing

### DIFF
--- a/docs/tudatpy/source/dynamics/environment.rst
+++ b/docs/tudatpy/source/dynamics/environment.rst
@@ -101,7 +101,7 @@ Classes
 .. autoclass:: tudatpy.dynamics.environment.Ephemeris
    :members:
 
-.. autoclass:: TleEphemeris
+.. autoclass:: tudatpy.dynamics.environment.TleEphemeris
    :members:
 
 .. autoclass:: tudatpy.dynamics.environment.Tle

--- a/docs/tudatpy/source/dynamics/environment.rst
+++ b/docs/tudatpy/source/dynamics/environment.rst
@@ -46,6 +46,10 @@ Classes
 
 
    Ephemeris
+
+   TleEphemeris
+
+   Tle
    
    RotationalEphemeris
 
@@ -96,6 +100,13 @@ Classes
    
 .. autoclass:: tudatpy.dynamics.environment.Ephemeris
    :members:
+
+.. autoclass:: TleEphemeris
+   :members:
+
+.. autoclass:: tudatpy.dynamics.environment.Tle
+   :members:
+   :special-members: __init__
 
 .. autoclass:: tudatpy.dynamics.environment.RotationalEphemeris
    :members:

--- a/src/tudat/astro/ephemerides/tleEphemeris.cpp
+++ b/src/tudat/astro/ephemerides/tleEphemeris.cpp
@@ -255,7 +255,7 @@ Tle::Tle( const std::string &lines )
     elementSetNumber_ = std::stoi( line1.substr( 64, 4 ) );
 
     // ---- Line 2: classical elements ----
-    inclination_ = unit_conversions::convertDegreesToRadians( std::stod( line2.substr( 8, 7 ) ) );
+    inclination_ = unit_conversions::convertDegreesToRadians( std::stod( line2.substr( 8, 8 ) ) );
     rightAscension_ = unit_conversions::convertDegreesToRadians( std::stod( line2.substr( 17, 8 ) ) );
 
     std::string eccentricityString = "0." + line2.substr( 26, 7 );

--- a/src/tudatpy/dynamics/environment/expose_environment.cpp
+++ b/src/tudatpy/dynamics/environment/expose_environment.cpp
@@ -290,15 +290,35 @@ void expose_environment( py::module& m )
                            py::overload_cast< const std::shared_ptr< ti::OneDimensionalInterpolator< double, Eigen::VectorXd > > >(
                                    &te::TabulatedCartesianEphemeris< double, double >::resetInterpolator ) );
 
-    py::class_< te::Tle, std::shared_ptr< te::Tle > >( m, "Tle" )
+    py::class_< te::Tle, std::shared_ptr< te::Tle > >( m, "Tle", R"doc(
+
+ Tle object containing the SGP/SDP model parameters as derived from the element set.
+
+ .. note::
+
+        This class is typically used together with the :class:`~TleEphemeris` class, which uses the TLE data to compute the state of a satellite at a given epoch.
+
+ )doc" )
             .def( py::init<  // ctor 1
                           const std::string& >( ),
-                  py::arg( "lines" ) )
+                  py::arg( "lines" ),
+                  R"doc(
+
+                Initialize TLE object from a single string containing the TLE data, delimited by a newline character.
+
+                :type: str
+                )doc" )
             .def( py::init<  // ctor 2
                           const std::string&,
                           const std::string& >( ),
                   py::arg( "line_1" ),
-                  py::arg( "line_2" ) )
+                  py::arg( "line_2" ),
+                  R"doc(
+
+                Initialize TLE object from separate strings for the first and second lines of the TLE.
+
+                :type: str
+                )doc" )
             .def_property_readonly( "reference_epoch",
                                     &te::Tle::getEpoch,
                                     R"doc(
@@ -501,7 +521,14 @@ void expose_environment( py::module& m )
                   py::arg( "frame_orientation" ) = "J2000",
                   py::arg( "tle" ) = nullptr,
                   py::arg( "use_sdp" ) = false )
-            .def_property_readonly( "tle", &te::TleEphemeris::getTle );
+            .def_property_readonly( "tle", &te::TleEphemeris::getTle, R"doc(
+
+                **read-only**
+
+                Tle object which holds the properties of the TLE set.
+
+                :type: Tle
+                )doc" );
 
     /*!
      **************   END EPHEMERIDES  ******************

--- a/src/tudatpy/interface/spice/expose_spice.cpp
+++ b/src/tudatpy/interface/spice/expose_spice.cpp
@@ -324,7 +324,7 @@ void expose_spice( py::module &m )
  ----------
  epoch : float
      Time in seconds since J2000 at which the state is to be retrieved.
- tle : Tle
+ tle : :class:`~tudatpy.dynamics.environment.Tle`
      Tle object containing the SGP/SDP model parameters as derived from the element set.
  Returns
  -------

--- a/src/tudatpy/interface/spice/expose_spice.cpp
+++ b/src/tudatpy/interface/spice/expose_spice.cpp
@@ -324,8 +324,8 @@ void expose_spice( py::module &m )
  ----------
  epoch : float
      Time in seconds since J2000 at which the state is to be retrieved.
- tle : :class:`~tudatpy.kernel.astro.ephemerides.Tle`
-     Shared pointer to a Tle object containing the SGP/SDP model parameters as derived from the element set.
+ tle : Tle
+     Tle object containing the SGP/SDP model parameters as derived from the element set.
  Returns
  -------
  cartesian_state_vector : numpy.ndarray[6,]    Cartesian state vector (x,y,z, position+velocity).

--- a/tests/test_tudat/src/astro/ephemerides/unitTestTwoLineElementsEphemeris.cpp
+++ b/tests/test_tudat/src/astro/ephemerides/unitTestTwoLineElementsEphemeris.cpp
@@ -12,6 +12,7 @@
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MAIN
 
+#include <vector>
 #include <boost/test/tools/floating_point_comparison.hpp>
 #include <boost/test/unit_test.hpp>
 
@@ -177,6 +178,65 @@ BOOST_AUTO_TEST_CASE( testTwoLineElementsEphemerisLangbroek )
         // Check if difference within tolerances
         BOOST_CHECK_SMALL( ( currentState - referenceState ).segment( 0, 3 ).norm( ), 1.0 );
         BOOST_CHECK_SMALL( ( currentState - referenceState ).segment( 3, 3 ).norm( ), 0.2 );
+    }
+}
+
+BOOST_AUTO_TEST_CASE( testTwoLineElementsParsing )
+{
+    using namespace tudat;
+    using namespace tudat::ephemerides;
+
+    spice_interface::loadStandardSpiceKernels( );
+
+    struct TleFixture {
+        std::string line1;
+        std::string line2;
+    };
+    // Two line element set from https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_docs_N0067/C/cspice/getelm_c.html
+    const std::vector< TleFixture > tleSets = { { "1 43908U 18111AJ  20146.60805006  .00000806  00000-0  34965-4 0  9999",
+                                                  "2 43908  97.2676  47.2136 0020001 220.6050 139.3698 15.24999521 78544" },
+                                                { "1 18123U 87 53  A 87324.61041692 -.00000023  00000-0 -75103-5 0 00675",
+                                                  "2 18123  98.8296 152.0074 0014950 168.7820 191.3688 14.12912554 21686" } };
+
+    const std::vector< double > tleTolerances = { 1e-10, 1e-6, 1e-7, 1e-6, 1e-6, 1e-9, 1e-6, 1e-6, 1e-10, 1e-13 };
+
+    for( const auto& tleSet : tleSets )
+    {
+        const std::string combined = tleSet.line1 + "\n" + tleSet.line2;
+
+        SpiceChar lines[ 2 ][ 70 ] = { { 0 }, { 0 } };
+        std::strcpy( lines[ 0 ], tleSet.line1.c_str( ) );
+        std::strcpy( lines[ 1 ], tleSet.line2.c_str( ) );
+        SpiceDouble epoch = 0.0;
+        SpiceDouble elems[ 10 ] = { 0.0 };
+        getelm_c( 1957, 70, lines, &epoch, elems );
+
+        auto tleFromCombined = std::make_shared< Tle >( combined );
+
+        // Tle element implicitly uses the same units as spice
+        BOOST_CHECK_CLOSE_FRACTION( tleFromCombined->getMeanMotionFirstDerivative( ), elems[ 0 ], tleTolerances[ 0 ] );
+        BOOST_CHECK_CLOSE_FRACTION( tleFromCombined->getMeanMotionSecondDerivative( ), elems[ 1 ], tleTolerances[ 1 ] );
+        BOOST_CHECK_CLOSE_FRACTION( tleFromCombined->getBStar( ), elems[ 2 ], tleTolerances[ 2 ] );
+        BOOST_CHECK_CLOSE_FRACTION( tleFromCombined->getInclination( ), elems[ 3 ], tleTolerances[ 3 ] );
+        BOOST_CHECK_CLOSE_FRACTION( tleFromCombined->getRightAscension( ), elems[ 4 ], tleTolerances[ 4 ] );
+        BOOST_CHECK_CLOSE_FRACTION( tleFromCombined->getEccentricity( ), elems[ 5 ], tleTolerances[ 5 ] );
+        BOOST_CHECK_CLOSE_FRACTION( tleFromCombined->getArgOfPerigee( ), elems[ 6 ], tleTolerances[ 6 ] );
+        BOOST_CHECK_CLOSE_FRACTION( tleFromCombined->getMeanAnomaly( ), elems[ 7 ], tleTolerances[ 7 ] );
+        BOOST_CHECK_CLOSE_FRACTION( tleFromCombined->getMeanMotion( ), elems[ 8 ], tleTolerances[ 8 ] );
+        BOOST_CHECK_CLOSE_FRACTION( tleFromCombined->getEpoch( ), elems[ 9 ], tleTolerances[ 9 ] );
+
+        auto tleFromSeparateLines = std::make_shared< Tle >( tleSet.line1, tleSet.line2 );
+
+        BOOST_CHECK_CLOSE_FRACTION( tleFromSeparateLines->getMeanMotionFirstDerivative( ), elems[ 0 ], tleTolerances[ 0 ] );
+        BOOST_CHECK_CLOSE_FRACTION( tleFromSeparateLines->getMeanMotionSecondDerivative( ), elems[ 1 ], tleTolerances[ 1 ] );
+        BOOST_CHECK_CLOSE_FRACTION( tleFromSeparateLines->getBStar( ), elems[ 2 ], tleTolerances[ 2 ] );
+        BOOST_CHECK_CLOSE_FRACTION( tleFromSeparateLines->getInclination( ), elems[ 3 ], tleTolerances[ 3 ] );
+        BOOST_CHECK_CLOSE_FRACTION( tleFromSeparateLines->getRightAscension( ), elems[ 4 ], tleTolerances[ 4 ] );
+        BOOST_CHECK_CLOSE_FRACTION( tleFromSeparateLines->getEccentricity( ), elems[ 5 ], tleTolerances[ 5 ] );
+        BOOST_CHECK_CLOSE_FRACTION( tleFromSeparateLines->getArgOfPerigee( ), elems[ 6 ], tleTolerances[ 6 ] );
+        BOOST_CHECK_CLOSE_FRACTION( tleFromSeparateLines->getMeanAnomaly( ), elems[ 7 ], tleTolerances[ 7 ] );
+        BOOST_CHECK_CLOSE_FRACTION( tleFromSeparateLines->getMeanMotion( ), elems[ 8 ], tleTolerances[ 8 ] );
+        BOOST_CHECK_CLOSE_FRACTION( tleFromSeparateLines->getEpoch( ), elems[ 9 ], tleTolerances[ 9 ] );
     }
 }
 

--- a/tests/test_tudat/src/astro/ephemerides/unitTestTwoLineElementsEphemeris.cpp
+++ b/tests/test_tudat/src/astro/ephemerides/unitTestTwoLineElementsEphemeris.cpp
@@ -198,6 +198,7 @@ BOOST_AUTO_TEST_CASE( testTwoLineElementsParsing )
                                                 { "1 18123U 87 53  A 87324.61041692 -.00000023  00000-0 -75103-5 0 00675",
                                                   "2 18123  98.8296 152.0074 0014950 168.7820 191.3688 14.12912554 21686" } };
 
+    // Tolerances in the same order as the elements returned by getelm_c
     const std::vector< double > tleTolerances = { 1e-10, 1e-6, 1e-7, 1e-6, 1e-6, 1e-9, 1e-6, 1e-6, 1e-10, 1e-13 };
 
     for( const auto& tleSet : tleSets )

--- a/tests/test_tudat/src/interface/spice/CMakeLists.txt
+++ b/tests/test_tudat/src/interface/spice/CMakeLists.txt
@@ -14,6 +14,7 @@ TUDAT_ADD_TEST_CASE(SpiceInterface
         tudat_basic_mathematics
         tudat_spice_interface
         tudat_basic_astrodynamics
+        tudat_sofa_interface
         )
 
 TUDAT_ADD_TEST_CASE(SpiceException

--- a/tests/test_tudat/src/interface/spice/unitTestSpiceInterface.cpp
+++ b/tests/test_tudat/src/interface/spice/unitTestSpiceInterface.cpp
@@ -477,6 +477,8 @@ BOOST_AUTO_TEST_CASE( testSpiceWrappers_8 )
 {
     spice_interface::loadStandardSpiceKernels( );
 
+    // TLE, query epoch and expected states taken from
+    // https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_docs_N0067/C/cspice/evsgp4_c.html#Examples
     const std::string tleLine1 = "1 43908U 18111AJ  20146.60805006  .00000806  00000-0  34965-4 0  9999";
     const std::string tleLine2 = "2 43908  97.2676  47.2136 0020001 220.6050 139.3698 15.24999521 78544";
 

--- a/tests/test_tudat/src/interface/spice/unitTestSpiceInterface.cpp
+++ b/tests/test_tudat/src/interface/spice/unitTestSpiceInterface.cpp
@@ -39,6 +39,8 @@
 #include "tudat/interface/spice/spiceException.h"
 #include "tudat/interface/spice/spiceInterface.h"
 #include "tudat/interface/spice/spiceRotationalEphemeris.h"
+#include "tudat/astro/basic_astro/unitConversions.h"
+#include "tudat/astro/ephemerides/tleEphemeris.h"
 
 #include <limits>
 #include <stdexcept>
@@ -468,6 +470,29 @@ BOOST_AUTO_TEST_CASE( testSpiceWrappers_7 )
 
     // Loaded kernels should be 0.
     BOOST_CHECK_EQUAL( spiceKernelsLoaded, 0 );
+}
+
+// Test 8: Cartesian state from TLE at epoch
+BOOST_AUTO_TEST_CASE( testSpiceWrappers_8 )
+{
+    spice_interface::loadStandardSpiceKernels( );
+
+    const std::string tleLine1 = "1 43908U 18111AJ  20146.60805006  .00000806  00000-0  34965-4 0  9999";
+    const std::string tleLine2 = "2 43908  97.2676  47.2136 0020001 220.6050 139.3698 15.24999521 78544";
+
+    const double queryEpoch = spice_interface::convertDateStringToEphemerisTime( "2020-05-26 02:25:00" );
+
+    auto tle = std::make_shared< ephemerides::Tle >( tleLine1, tleLine2 );
+    auto cartesianStateFromTle = spice_interface::getCartesianStateFromTleAtEpoch( queryEpoch, tle );
+
+    const Eigen::Vector6d expectedStateFromSpice = unit_conversions::convertKilometersToMeters(
+            ( Eigen::Vector6d( ) << -4644.60403398, -5038.95025539, -337.27141116, -0.45719025, 0.92884817, -7.55917355 ).finished( ) );
+
+    for( unsigned int i = 0; i < 3; i++ )
+    {
+        BOOST_CHECK_SMALL( std::fabs( cartesianStateFromTle( i ) - expectedStateFromSpice( i ) ), 1.0E0 );
+        BOOST_CHECK_SMALL( std::fabs( cartesianStateFromTle( i + 3 ) - expectedStateFromSpice( i + 3 ) ), 1.0E-4 );
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END( )


### PR DESCRIPTION
This PR

- corrects the parsing of the inclination from a TLE: the TLE field has a length of 8 instead of 7 characters (see e.g. https://celestrak.org/NORAD/documentation/tle-fmt.php, https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_docs_N0067/C/cspice/getelm_c.html#Particulars)
- adds unit tests for the parsing of a TLE from a single string/two separate strings by comparing the orbital elements to the output of the `getelm` spice function
- adds a unit test for the `getCartesianStateFromTleAtEpoch` function by comparing the output against the `evsgp4` docs
- add `Tle` to the API docs

Closes #722 