### PR TITLE
Fix API docs: unexpected section titles and pybind11 overload helpers

### DIFF
--- a/docs/tudatpy/source/conf.py
+++ b/docs/tudatpy/source/conf.py
@@ -20,6 +20,7 @@
 import os
 import sys
 import importlib
+import re
 from datetime import datetime
 
 sys.path.insert(0, os.path.abspath("."))
@@ -105,7 +106,6 @@ autodoc_member_order = "groupwise"
 
 autodoc_default_options = {
     "show-inheritance": True,
-    "exclude-members": "pybind11_detail_function_record_v1_system_libstdcpp_gxx_abi_1xxx_use_cxx11_abi_1",
 }
 
 bibtex_bibfiles = ["refs.bib"]
@@ -140,10 +140,6 @@ def process_constants_docstring(app, what, name, obj, options, lines):
     The function applies only to the modules specified in the modules_to_process list.
     """
 
-    if is_internal_pybind_record(name, obj):
-        lines[:] = ["Pybind11 overload helper record."]
-        return
-
     modules_to_process = ("tudatpy.constants",)
 
     attribute_module = name.rsplit(".", 1)[0]
@@ -153,9 +149,169 @@ def process_constants_docstring(app, what, name, obj, options, lines):
         lines.clear()
         # retrieve variable type directly from the object
         lines.append(f":type: {type(obj).__name__}")
-        
-import re
 
+
+NUMPY_DOCSTRING_SECTION_TITLES = {
+    "Parameters",
+    "Returns",
+    "Yields",
+    "Raises",
+    "Warns",
+    "Warnings",
+    "Examples",
+    "Notes",
+    "See Also",
+    "Attributes",
+    "Methods",
+    "References",
+}
+
+
+def _leading_whitespace_width(text: str) -> int:
+    """Return indentation width of a line in spaces."""
+    return len(text) - len(text.lstrip())
+
+
+def _is_dash_underline(text: str) -> bool:
+    """Return whether a line is a non-empty dash-only underline."""
+    stripped = text.strip()
+    return bool(stripped) and set(stripped) == {"-"}
+
+
+def _is_numpy_section_header(lines, index: int) -> bool:
+    """Check whether lines[index:index+2] form a NumPy-style section header.
+    
+    The section header consists of a title line (with text in NUMPY_DOCSTRING_SECTION_TITLES) followed by an underline line of dashes.
+    The title and underline must have the same indentation, and the underline must be at least as
+    long as the title.
+    """
+
+    if index + 1 >= len(lines):
+        return False
+
+    title_line = lines[index]
+    underline_line = lines[index + 1]
+    title = title_line.strip()
+
+    if title not in NUMPY_DOCSTRING_SECTION_TITLES:
+        return False
+
+    if not _is_dash_underline(underline_line):
+        return False
+
+    if _leading_whitespace_width(title_line) != _leading_whitespace_width(underline_line):
+        return False
+
+    if len(underline_line.strip()) < len(title):
+        return False
+
+    return True
+
+
+def _is_overloaded_pybind_docstring(lines) -> bool:
+    """Detect pybind-generated overloaded-function docstrings."""
+    return any(line.strip() == "Overloaded function." for line in lines[:3])
+
+
+def _rewrite_overloaded_list_items(lines):
+    """Rewrite numbered overload entries into labeled code-style signatures.
+    
+    This function detects lines of the form "   1. signature" in pybind-generated docstrings for overloaded functions and rewrites them into a more Sphinx-friendly format:
+         Overload 1:
+         ``signature``
+    This allows Sphinx to correctly parse the signatures and display them in the documentation, rather than treating them as plain text list items.
+    """
+
+    OVERLOAD_LIST_ITEM_PATTERN = re.compile(r"^(\s*)(\d+)\.\s+(.*)$")
+
+    rewritten_lines = []
+    for line in lines:
+        match = OVERLOAD_LIST_ITEM_PATTERN.match(line)
+        if match is None:
+            rewritten_lines.append(line)
+            continue
+
+        indent, index, signature = match.groups()
+        rewritten_lines.append(f"{indent}Overload {index}:")
+        rewritten_lines.append(f"{indent}``{signature}``")
+
+    return rewritten_lines
+
+
+def _dedent_to_numpy_headers(lines):
+    """Dedent all docstring lines to the minimum NumPy-section header indent.
+    
+    This function detects all NumPy-style section headers in the docstring and computes the minimum indentation among them. It then dedents all lines by that amount, ensuring that section headers are flush with the left margin and that relative indentation within sections is preserved.
+    """
+
+    header_indents = []
+
+    for i in range(len(lines) - 1):
+        title = lines[i].strip()
+        underline = lines[i + 1]
+
+        if (
+            title in NUMPY_DOCSTRING_SECTION_TITLES
+            and _is_dash_underline(underline)
+            and len(underline.strip()) >= len(title)
+        ):
+            header_indents.append(_leading_whitespace_width(lines[i]))
+
+    if not header_indents:
+        return lines
+
+    base_indent = min(header_indents)
+
+    return [
+        line[base_indent:]
+        if _leading_whitespace_width(line) >= base_indent
+        else line
+        for line in lines
+    ]
+
+
+def fix_docstring_section_title_spacing(app, what, name, obj, options, lines):
+    """Fix docstring section title spacing for Sphinx parsing.
+    
+    This function processes docstrings to ensure that NumPy-style section headers are correctly recognized by Sphinx. It detects section headers, ensures they are flush with the left margin, and that they are followed by an empty line if needed. This allows Sphinx to properly parse the sections and display them in the documentation.
+    This fixes `CRITICAL: Unexpected section title.` errors in the Sphinx build.
+    """
+
+    if not lines:
+        return
+
+    try:
+        working_lines = list(lines)
+
+        if _is_overloaded_pybind_docstring(working_lines):
+            working_lines = _rewrite_overloaded_list_items(working_lines)
+
+        working_lines = _dedent_to_numpy_headers(working_lines)
+
+        normalized_lines = []
+        i = 0
+
+        while i < len(working_lines):
+            if _is_numpy_section_header(working_lines, i):
+                normalized_lines.append(working_lines[i])
+                normalized_lines.append(working_lines[i + 1])
+
+                has_content_line = (i + 2) < len(working_lines)
+                missing_empty_line = has_content_line and working_lines[i + 2].strip() != ""
+                if missing_empty_line:
+                    empty_line = " " * _leading_whitespace_width(working_lines[i])
+                    normalized_lines.append(empty_line)
+
+                i += 2
+                continue
+
+            normalized_lines.append(working_lines[i])
+            i += 1
+
+        lines[:] = normalized_lines
+    except Exception:
+        return
+        
 def replace_annotated_nparrays(text: str) -> str:
     """
     Replace typing.Annotated[numpy.typing.ArrayLike, <dtype>, "[<shape>]"]
@@ -199,19 +355,6 @@ def replace_annotated_nparrays(text: str) -> str:
     return text
 
 
-def is_internal_pybind_record(name, obj):
-    """Detect pybind overload helper records exposed to Python."""
-    marker = "pybind11_detail_function_record"
-    if marker in name:
-        return True
-
-    for attr in ("__qualname__", "__name__", "__module__"):
-        value = getattr(obj, attr, "")
-        if isinstance(value, str) and marker in value:
-            return True
-
-    return False
-
 def simplify_signature_types(app, what, name, obj, options, signature, return_annotation):
 
 
@@ -244,16 +387,11 @@ def simplify_signature_types(app, what, name, obj, options, signature, return_an
     return signature, return_annotation
 
 
-def skip_internal_pybind_members(app, what, name, obj, would_skip, options):
-    """Suppress pybind-internal helper records from autodoc output."""
-    if is_internal_pybind_record(name, obj):
-        return True
-    return would_skip
-    
 def setup(app):
     app.connect('autodoc-process-docstring', process_constants_docstring)
+    # priority=200 to run after napoleon processes the docstring and before Sphinx parses it for section headers
+    app.connect("autodoc-process-docstring", fix_docstring_section_title_spacing, priority=200)
     app.connect("autodoc-process-signature", simplify_signature_types)
-    app.connect("autodoc-skip-member", skip_internal_pybind_members)
     app.connect("source-read", filter_mcd_docs)
     
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/tudatpy/source/conf.py
+++ b/docs/tudatpy/source/conf.py
@@ -23,6 +23,9 @@ import importlib
 import re
 from datetime import datetime
 
+from sphinx.util import logging as sphinx_logging
+LOGGER = sphinx_logging.getLogger(__name__)
+
 sys.path.insert(0, os.path.abspath("."))
 
 # When the docs are being built on ReadTheDocs, the binaries are in the tudatpy conda package installed in site-packages directory.
@@ -309,7 +312,13 @@ def fix_docstring_section_title_spacing(app, what, name, obj, options, lines):
             i += 1
 
         lines[:] = normalized_lines
-    except Exception:
+
+    except Exception as exc:
+
+        LOGGER.warning(
+            f"Docstring preprocessing failed for {{{name}}} ({what}): {exc}. Leaving original docstring unchanged.",
+            exc_info=True,
+        )
         return
         
 def replace_annotated_nparrays(text: str) -> str:
@@ -389,7 +398,7 @@ def simplify_signature_types(app, what, name, obj, options, signature, return_an
 
 def setup(app):
     app.connect('autodoc-process-docstring', process_constants_docstring)
-    # priority=200 to run after napoleon processes the docstring and before Sphinx parses it for section headers
+    # run before default-priority (500) docstring processors
     app.connect("autodoc-process-docstring", fix_docstring_section_title_spacing, priority=200)
     app.connect("autodoc-process-signature", simplify_signature_types)
     app.connect("source-read", filter_mcd_docs)


### PR DESCRIPTION
This PR fixes #706 to correctly show the docstring entries by removing the call to `is_internal_pybind_record` in the `process_constants_docstring` function:

<img width="920" height="666" alt="image" src="https://github.com/user-attachments/assets/bbdf28a0-d1aa-4f18-9a08-fb62dab301b6" />

Additionally, the `CRITICAL: Unexpected section title.` sphinx errors are fixed by manually pre-processing the function docstrings. If a title according to the numpy docstring format is detected (e.g. Parameters, Returns, ...) with a corresponding title delimiting line (`----------`) but without a blank line afterwards, the blank line is inserted.
Lastly, the overload formatting is slightly improved in the function body to have the same formatting as non-overloaded functions:

<img width="931" height="869" alt="image" src="https://github.com/user-attachments/assets/625e5471-9844-405b-a126-363e95c8ba79" />

This is for the lack of better solution (at least that I'm aware of), as the function signature is still not formatted nicely.