### PR TITLE
Minor ODF reader readability

### DIFF
--- a/include/tudat/io/readBinaryFile.h
+++ b/include/tudat/io/readBinaryFile.h
@@ -15,6 +15,8 @@
 #include <stdexcept>
 #include <vector>
 #include <istream>
+#include <cstdint>
+#include <string>
 
 namespace tudat
 {

--- a/include/tudat/io/readBinaryFile.h
+++ b/include/tudat/io/readBinaryFile.h
@@ -11,6 +11,11 @@
 #ifndef TUDAT_READBINARYFILE_H
 #define TUDAT_READBINARYFILE_H
 
+#include <bitset>
+#include <stdexcept>
+#include <vector>
+#include <istream>
+
 namespace tudat
 {
 namespace input_output

--- a/include/tudat/io/readOdfFile.h
+++ b/include/tudat/io/readOdfFile.h
@@ -22,11 +22,7 @@
 #include <map>
 #include <vector>
 
-#include "tudat/astro/basic_astro/timeConversions.h"
 #include "tudat/basics/timeType.h"
-#include "tudat/io/basicInputOutput.h"
-#include "tudat/io/readBinaryFile.h"
-#include "tudat/math/interpolators/lookupScheme.h"
 
 namespace tudat
 {

--- a/include/tudat/io/readOdfFile.h
+++ b/include/tudat/io/readOdfFile.h
@@ -205,10 +205,10 @@ public:
      * @param dataType_ Data type, specified according to section 3.2.4
      * of TRK-2-18 (2018).
      */
-    OdfDataSpecificBlock( OdfDataType dataType ): dataType_( dataType ) { }
+    OdfDataSpecificBlock( OdfDataType dataType ): dataType_( dataType ) {}
 
     // Destructor
-    virtual ~OdfDataSpecificBlock( ) { }
+    virtual ~OdfDataSpecificBlock( ) {}
 
     /*!
      * Virtual function printing the observable specific data block to
@@ -246,7 +246,7 @@ public:
     OdfDDodDataBlock( const std::bitset< 128 > specificDataBits, const OdfDataType dDodDataType );
 
     // Destructor
-    ~OdfDDodDataBlock( ) { }
+    ~OdfDDodDataBlock( ) {}
 
     int getSecondReceivingStationId( )
     {
@@ -317,7 +317,7 @@ public:
     OdfDDorDataBlock( const std::bitset< 128 > specificDataBits, const OdfDataType dDorDataType );
 
     // Destructor
-    ~OdfDDorDataBlock( ) { }
+    ~OdfDDorDataBlock( ) {}
 
     int getSecondReceivingStationId( )
     {
@@ -380,7 +380,7 @@ public:
     OdfDopplerDataBlock( const std::bitset< 128 > specificDataBits, const OdfDataType dopplerDataType );
 
     // Destructor
-    ~OdfDopplerDataBlock( ) { }
+    ~OdfDopplerDataBlock( ) {}
 
     int getReceiverChannel( )
     {
@@ -449,7 +449,7 @@ public:
     OdfSequentialRangeDataBlock( const std::bitset< 128 > dataBits );
 
     // Destructor
-    ~OdfSequentialRangeDataBlock( ) { }
+    ~OdfSequentialRangeDataBlock( ) {}
 
     int getSpacecraftId( )
     {
@@ -516,7 +516,7 @@ public:
     OdfToneRangeDataBlock( const std::bitset< 128 > specificDataBits );
 
     // Destructor
-    ~OdfToneRangeDataBlock( ) { }
+    ~OdfToneRangeDataBlock( ) {}
 
     int getSpacecraftId( )
     {
@@ -566,7 +566,7 @@ public:
     OdfAngleDataBlock( const std::bitset< 128 > specificDataBits, const OdfDataType angleDataType );
 
     // Destructor
-    ~OdfAngleDataBlock( ) { }
+    ~OdfAngleDataBlock( ) {}
 
     int getSpacecraftId( )
     {

--- a/include/tudat/simulation/estimation_setup/processOdfFile.h
+++ b/include/tudat/simulation/estimation_setup/processOdfFile.h
@@ -18,11 +18,12 @@
 #include "tudat/astro/basic_astro/timeConversions.h"
 #include "tudat/astro/earth_orientation/terrestrialTimeScaleConverter.h"
 #include "tudat/astro/ground_stations/transmittingFrequencies.h"
+#include "tudat/astro/observation_models/linkTypeDefs.h"
 #include "tudat/astro/observation_models/observableTypes.h"
+#include "tudat/astro/observation_models/observationAncillarySettings.h"
 #include "tudat/basics/utilities.h"
 #include "tudat/io/readOdfFile.h"
 #include "tudat/math/interpolators/lookupScheme.h"
-#include "tudat/math/quadrature/trapezoidQuadrature.h"
 #include "tudat/simulation/environment_setup/body.h"
 #include "tudat/simulation/environment_setup/defaultGroundStationSettings.h"
 #include "tudat/simulation/estimation_setup/observationSimulationSettings.h"
@@ -363,20 +364,18 @@ public:
     {
         std::vector< std::string > groundStations;
 
-        for( auto observableIt = processedDataBlocks_.begin( ); observableIt != processedDataBlocks_.end( ); ++observableIt )
+        for( auto const& [ observableType, linkDataBlocks ] : processedDataBlocks_ )
         {
-            for( auto linkEndIt = observableIt->second.begin( ); linkEndIt != observableIt->second.end( ); ++linkEndIt )
+            for( auto const& [ linkEnd, singleLinkDataBlock ] : linkDataBlocks )
             {
-                observation_models::LinkEnds linkEnd = linkEndIt->first;
-
-                for( auto linkEndTypeIt = linkEnd.begin( ); linkEndTypeIt != linkEnd.end( ); ++linkEndTypeIt )
+                for( auto const& [ linkEndType, linkEndId ] : linkEnd )
                 {
                     // Check if linkEndId is a ground station
-                    if( linkEndTypeIt->second.stationName_ != "" && linkEndTypeIt->second.bodyName_ != spacecraftName_ )
+                    if( linkEndId.stationName_ != "" && linkEndId.bodyName_ != spacecraftName_ )
                     {
-                        if( !std::count( groundStations.begin( ), groundStations.end( ), linkEndTypeIt->second.stationName_ ) )
+                        if( !std::count( groundStations.begin( ), groundStations.end( ), linkEndId.stationName_ ) )
                         {
-                            groundStations.push_back( linkEndTypeIt->second.stationName_ );
+                            groundStations.push_back( linkEndId.stationName_ );
                         }
                     }
                 }
@@ -391,9 +390,9 @@ public:
     {
         std::vector< observation_models::ObservableType > observableTypes;
 
-        for( auto observableIt = processedDataBlocks_.begin( ); observableIt != processedDataBlocks_.end( ); ++observableIt )
+        for( auto const& [ observableType, linkDataBlocks ] : processedDataBlocks_ )
         {
-            observableTypes.push_back( observableIt->first );
+            observableTypes.push_back( observableType );
         }
 
         return observableTypes;
@@ -407,19 +406,17 @@ public:
         double endTimeTdbSinceJ2000 = TUDAT_NAN;
 
         // Loop over data
-        for( auto observableIt = processedDataBlocks_.begin( ); observableIt != processedDataBlocks_.end( ); ++observableIt )
+        for( auto const& [ observableType, linkDataBlocks ] : processedDataBlocks_ )
         {
-            for( auto linkEndIt = observableIt->second.begin( ); linkEndIt != observableIt->second.end( ); ++linkEndIt )
+            for( auto const& [ linkEnd, singleLinkDataBlock ] : linkDataBlocks )
             {
-                std::shared_ptr< ProcessedOdfFileSingleLinkData< TimeType > > processedSingleLinkData = linkEndIt->second;
-
                 // Extract the start and end times
-                std::vector< TimeType > timeVectorTimeType = processedSingleLinkData->processedObservationTimes_;
+                std::vector< TimeType > timeVectorTimeType = singleLinkDataBlock->processedObservationTimes_;
 
                 std::vector< double > timeVector;
-                for( unsigned int k = 0; k < timeVectorTimeType.size( ); k++ )
+                for( auto const& timeTimeType : timeVectorTimeType )
                 {
-                    timeVector.push_back( double( timeVectorTimeType[ k ] ) );
+                    timeVector.push_back( double( timeTimeType ) );
                 }
 
                 if( timeVector.front( ) < startTimeTdbSinceJ2000 || std::isnan( startTimeTdbSinceJ2000 ) )
@@ -477,20 +474,19 @@ public:
                   std::map< observation_models::LinkEnds, std::shared_ptr< ProcessedOdfFileSingleLinkData< TimeType > > > >
                 reprocessedDataBlocks;
 
-        for( auto observationIterator : processedDataBlocks_ )
+        for( auto const& [ observableType, linkDataBlocks ] : processedDataBlocks_ )
         {
-            for( auto linkEndIterator : observationIterator.second )
+            for( auto const& [ linkEnd, singleLinkDataBlock ] : linkDataBlocks )
             {
-                LinkEnds oldLinkEnds = linkEndIterator.first;
-                LinkEnds newLinkEnds = oldLinkEnds;
-                for( auto idIterator : oldLinkEnds )
+                LinkEnds newLinkEnds = linkEnd;
+                for( auto const& [ linkEndType, linkEndId ] : linkEnd )
                 {
-                    if( idIterator.second.bodyName_ == spacecraft )
+                    if( linkEndId.bodyName_ == spacecraft )
                     {
-                        newLinkEnds[ idIterator.first ] = LinkEndId( spacecraft, antennaName );
+                        newLinkEnds[ linkEndType ] = LinkEndId( spacecraft, antennaName );
                     }
                 }
-                reprocessedDataBlocks[ observationIterator.first ][ newLinkEnds ] = linkEndIterator.second;
+                reprocessedDataBlocks[ observableType ][ newLinkEnds ] = singleLinkDataBlock;
             }
         }
         processedDataBlocks_ = reprocessedDataBlocks;
@@ -502,8 +498,7 @@ public:
     {
         // Create lookup scheme to find closest time interval
         std::vector< double > timeIntervalStarts = utilities::createVectorFromMapKeys( timeIntervals );
-        std::shared_ptr< interpolators::LookUpScheme< double > > lookUpScheme_ =
-                std::make_shared< interpolators::HuntingAlgorithmLookupScheme< double > >( timeIntervalStarts );
+        auto lookUpScheme_ = std::make_shared< interpolators::HuntingAlgorithmLookupScheme< double > >( timeIntervalStarts );
 
         // Define new data blocks
         std::map< observation_models::ObservableType,
@@ -511,16 +506,13 @@ public:
                 reprocessedDataBlocks;
 
         // Iterate over all observable types
-        for( auto observationIterator : processedDataBlocks_ )
+        for( auto const& [ observableType, linkDataBlocks ] : processedDataBlocks_ )
         {
             // Iterate over all link ends
-            for( auto linkEndIterator : observationIterator.second )
+            for( auto const& [ linkEnd, singleLinkDataBlock ] : linkDataBlocks )
             {
-                // Get current data block
-                std::shared_ptr< ProcessedOdfFileSingleLinkData< TimeType > > currentDataBlock = linkEndIterator.second;
-
                 // Get start and end times of current block
-                std::pair< double, double > timeBounds = currentDataBlock->getTimeBounds( );
+                std::pair< double, double > timeBounds = singleLinkDataBlock->getTimeBounds( );
 
                 // Get start and end time of nearest interval
                 double timeIntervalStart = TUDAT_NAN;
@@ -538,16 +530,15 @@ public:
                 // Copy entire block
                 if( timeIntervalStart < timeBounds.first && timeIntervalEnd > timeBounds.second )
                 {
-                    LinkEnds oldLinkEnds = linkEndIterator.first;
-                    LinkEnds newLinkEnds = oldLinkEnds;
-                    for( auto idIterator : oldLinkEnds )
+                    LinkEnds newLinkEnds = linkEnd;
+                    for( auto const& [ linkEndType, linkEndId ] : linkEnd )
                     {
-                        if( idIterator.second.bodyName_ == spacecraft )
+                        if( linkEndId.bodyName_ == spacecraft )
                         {
-                            newLinkEnds[ idIterator.first ] = LinkEndId( spacecraft, antennaName );
+                            newLinkEnds[ linkEndType ] = LinkEndId( spacecraft, antennaName );
                         }
                     }
-                    reprocessedDataBlocks[ observationIterator.first ][ newLinkEnds ] = linkEndIterator.second;
+                    reprocessedDataBlocks[ observableType ][ newLinkEnds ] = singleLinkDataBlock;
                 }
                 else if( timeIntervalEnd > timeBounds.second )
                 {
@@ -568,16 +559,16 @@ private:
     {
         unsigned int spacecraftId = rawOdfDataVector.front( )->spacecraftId_;
 
-        for( unsigned int i = 0; i < rawOdfDataVector.size( ); ++i )
+        for( auto const& rawOdfData : rawOdfDataVector )
         {
             // Check if spacecraft ID is valid
-            if( rawOdfDataVector.at( i )->spacecraftId_ != spacecraftId )
+            if( rawOdfData->spacecraftId_ != spacecraftId )
             {
                 throw std::runtime_error(
                         "Error when creating processed ODF object from raw data: multiple "
                         "spacecraft IDs"
                         "found (" +
-                        std::to_string( spacecraftId ) + " and " + std::to_string( rawOdfDataVector.at( i )->spacecraftId_ ) + ")." );
+                        std::to_string( spacecraftId ) + " and " + std::to_string( rawOdfData->spacecraftId_ ) + ")." );
             }
         }
 
@@ -603,7 +594,7 @@ private:
 
         if( requiresTransmittingStation( currentObservableType ) )
         {
-            transmittingStation = linkEnds.at( transmitter ).stationName_;
+            transmittingStation = linkEnds.at( observation_models::LinkEndType::transmitter ).stationName_;
 
             // Check if transmitting station is in ramp tables
             if( rampInterpolators_.count( transmittingStation ) == 0 )
@@ -636,7 +627,7 @@ private:
         }
         if( requiresFirstReceivingStation( currentObservableType ) )
         {
-            receivingStation = linkEnds.at( receiver ).stationName_;
+            receivingStation = linkEnds.at( observation_models::LinkEndType::receiver ).stationName_;
 
             // Check if receiving station is in ramp tables
             if( rampInterpolators_.count( receivingStation ) == 0 )
@@ -732,19 +723,20 @@ private:
                 {
                     switch( currentObservableType )
                     {
-                        case observation_models::dsn_n_way_averaged_doppler: {
+                        case observation_models::ObservableType::dsn_n_way_averaged_doppler: {
                             processedDataBlocks_[ currentObservableType ][ linkEnds ] =
-                                    std::make_shared< ProcessedOdfFileDopplerData< TimeType > >( currentObservableType,
-                                                                                                 linkEnds.at( receiver ).stationName_,
-                                                                                                 linkEnds.at( transmitter ).stationName_ );
+                                    std::make_shared< ProcessedOdfFileDopplerData< TimeType > >(
+                                            currentObservableType,
+                                            linkEnds.at( observation_models::LinkEndType::receiver ).stationName_,
+                                            linkEnds.at( observation_models::LinkEndType::transmitter ).stationName_ );
                             break;
                         }
-                        case observation_models::dsn_n_way_range: {
+                        case observation_models::ObservableType::dsn_n_way_range: {
                             processedDataBlocks_[ currentObservableType ][ linkEnds ] =
                                     std::make_shared< ProcessedOdfFileSequentialRangeData< TimeType > >(
                                             currentObservableType,
-                                            linkEnds.at( receiver ).stationName_,
-                                            linkEnds.at( transmitter ).stationName_ );
+                                            linkEnds.at( observation_models::LinkEndType::receiver ).stationName_,
+                                            linkEnds.at( observation_models::LinkEndType::transmitter ).stationName_ );
                             break;
                         }
                         default: {
@@ -849,17 +841,15 @@ private:
     {
         std::map< std::string, std::vector< double > > rampRatesPerStation, startFrequenciesPerStation;
 
-        for( unsigned int i = 0; i < rawOdfDataVector.size( ); ++i )
+        for( auto const& rawOdfData : rawOdfDataVector )
         {
             std::map< int, std::vector< std::shared_ptr< input_output::OdfRampBlock > > > rampBlocksPerStation =
-                    rawOdfDataVector.at( i )->getRampBlocks( );
-            for( auto it = rampBlocksPerStation.begin( ); it != rampBlocksPerStation.end( ); it++ )
+                    rawOdfData->getRampBlocks( );
+            for( auto const& [ stationId, rampBlocks ] : rampBlocksPerStation )
             {
-                std::string stationName = getStationNameFromStationId( 0, it->first );
+                std::string stationName = getStationNameFromStationId( 0, stationId );
 
-                std::vector< std::shared_ptr< input_output::OdfRampBlock > > rampBlocks = it->second;
-
-                for( unsigned int j = 0; j < it->second.size( ); j++ )
+                for( unsigned int j = 0; j < rampBlocks.size( ); j++ )
                 {
                     // Check if zero time ramp
                     if( rampBlocks.at( j )->getRampStartTime( ) == rampBlocks.at( j )->getRampEndTime( ) )
@@ -909,14 +899,12 @@ private:
     void updateProcessedObservationTimes( )
     {
         // Loop over saved data and convert time to TDB wrt J2000
-        for( auto observableTypeIterator = processedDataBlocks_.begin( ); observableTypeIterator != processedDataBlocks_.end( );
-             ++observableTypeIterator )
+        for( auto const& [ observableType, linkDataBlocks ] : processedDataBlocks_ )
         {
-            for( auto linkEndsIterator = observableTypeIterator->second.begin( ); linkEndsIterator != observableTypeIterator->second.end( );
-                 ++linkEndsIterator )
+            for( auto const& [ linkEnd, singleLinkDataBlock ] : linkDataBlocks )
             {
-                linkEndsIterator->second->processedObservationTimes_ = computeObservationTimesTdbFromJ2000(
-                        linkEndsIterator->second->receivingStation_, linkEndsIterator->second->unprocessedObservationTimes_ );
+                singleLinkDataBlock->processedObservationTimes_ = computeObservationTimesTdbFromJ2000(
+                        singleLinkDataBlock->receivingStation_, singleLinkDataBlock->unprocessedObservationTimes_ );
             }
         }
     }
@@ -1128,28 +1116,25 @@ observation_models::ObservationAncillarySimulationSettings createOdfAncillarySet
         getFrequencyBandForOdfId( odfDataContents->downlinkBandIds_.at( dataIndex ) )
     };
 
-    ancillarySettings.setAncillaryDoubleVectorData( observation_models::frequency_bands,
+    ancillarySettings.setAncillaryDoubleVectorData( observation_models::ObservationAncillarySimulationVariable::frequency_bands,
                                                     convertFrequencyBandsToDoubleVector( frequencyBands ) );
 
     ancillarySettings.setAncillaryDoubleData(
-            observation_models::reception_reference_frequency_band,
+            observation_models::ObservationAncillarySimulationVariable::reception_reference_frequency_band,
             convertFrequencyBandToDouble( getFrequencyBandForOdfId( odfDataContents->referenceBandIds_.at( dataIndex ) ) ) );
 
-    if( std::dynamic_pointer_cast< ProcessedOdfFileDopplerData< TimeType > >( odfDataContents ) != nullptr )
+    if( auto dopplerDataBlock = std::dynamic_pointer_cast< ProcessedOdfFileDopplerData< TimeType > >( odfDataContents ) )
     {
-        std::shared_ptr< ProcessedOdfFileDopplerData< TimeType > > dopplerDataBlock =
-                std::dynamic_pointer_cast< ProcessedOdfFileDopplerData< TimeType > >( odfDataContents );
-
-        ancillarySettings.setAncillaryDoubleData( observation_models::doppler_integration_time,
+        ancillarySettings.setAncillaryDoubleData( observation_models::ObservationAncillarySimulationVariable::doppler_integration_time,
                                                   dopplerDataBlock->countInterval_.at( dataIndex ) );
 
-        ancillarySettings.setAncillaryDoubleData( observation_models::doppler_reference_frequency,
+        ancillarySettings.setAncillaryDoubleData( observation_models::ObservationAncillarySimulationVariable::doppler_reference_frequency,
                                                   dopplerDataBlock->referenceFrequencies_.at( dataIndex ) );
 
-        if( currentObservableType == observation_models::dsn_n_way_averaged_doppler )
+        if( currentObservableType == observation_models::ObservableType::dsn_n_way_averaged_doppler )
         {
             ancillarySettings.setAncillaryDoubleVectorData(
-                    observation_models::link_ends_delays,
+                    observation_models::ObservationAncillarySimulationVariable::link_ends_delays,
                     std::vector< double >{ dopplerDataBlock->transmitterUplinkDelays_.at( dataIndex ),
                                            0.0,
                                            dopplerDataBlock->receiverDownlinkDelays_.at( dataIndex ) } );
@@ -1157,21 +1142,20 @@ observation_models::ObservationAncillarySimulationSettings createOdfAncillarySet
         else
         {
             ancillarySettings.setAncillaryDoubleVectorData(
-                    observation_models::link_ends_delays,
+                    observation_models::ObservationAncillarySimulationVariable::link_ends_delays,
                     std::vector< double >{ dopplerDataBlock->transmitterUplinkDelays_.at( dataIndex ),
                                            dopplerDataBlock->receiverDownlinkDelays_.at( dataIndex ) } );
         }
     }
-    else if( std::dynamic_pointer_cast< ProcessedOdfFileSequentialRangeData< TimeType > >( odfDataContents ) != nullptr )
+    else if( auto sequentialRangeDataBlock =
+                     std::dynamic_pointer_cast< ProcessedOdfFileSequentialRangeData< TimeType > >( odfDataContents ) )
     {
-        std::shared_ptr< ProcessedOdfFileSequentialRangeData< TimeType > > sequentialRangeDataBlock =
-                std::dynamic_pointer_cast< ProcessedOdfFileSequentialRangeData< TimeType > >( odfDataContents );
-
-        ancillarySettings.setAncillaryDoubleData( observation_models::sequential_range_lowest_ranging_component,
-                                                  sequentialRangeDataBlock->lowestRangingComponent_.at( dataIndex ) );
+        ancillarySettings.setAncillaryDoubleData(
+                observation_models::ObservationAncillarySimulationVariable::sequential_range_lowest_ranging_component,
+                sequentialRangeDataBlock->lowestRangingComponent_.at( dataIndex ) );
 
         ancillarySettings.setAncillaryDoubleVectorData(
-                observation_models::link_ends_delays,
+                observation_models::ObservationAncillarySimulationVariable::link_ends_delays,
                 std::vector< double >{ sequentialRangeDataBlock->transmitterUplinkDelay_.at( dataIndex ),
                                        0.0,
                                        sequentialRangeDataBlock->receiverDownlinkDelays_.at( dataIndex ) } );
@@ -1267,25 +1251,16 @@ std::shared_ptr< observation_models::ObservationCollection< ObservationScalarTyp
                         std::vector< std::shared_ptr< observation_models::SingleObservationSet< ObservationScalarType, TimeType > > > > >
             sortedObservationSets;
 
-    for( auto observableTypeIterator = processedOdfFileContents->getProcessedDataBlocks( ).begin( );
-         observableTypeIterator != processedOdfFileContents->getProcessedDataBlocks( ).end( );
-         ++observableTypeIterator )
+    for( auto const& [ currentObservableType, linkDataBlocks ] : processedOdfFileContents->getProcessedDataBlocks( ) )
     {
-        observation_models::ObservableType currentObservableType = observableTypeIterator->first;
-
         // Check if an observation set should be created for the current observable type
         if( std::count( observableTypesToProcess.begin( ), observableTypesToProcess.end( ), currentObservableType ) == 0 )
         {
             continue;
         }
 
-        for( auto linkEndsIterator = observableTypeIterator->second.begin( ); linkEndsIterator != observableTypeIterator->second.end( );
-             ++linkEndsIterator )
+        for( auto const& [ currentLinkEnds, currentOdfSingleLinkData ] : linkDataBlocks )
         {
-            observation_models::LinkEnds currentLinkEnds = linkEndsIterator->first;
-
-            std::shared_ptr< ProcessedOdfFileSingleLinkData< TimeType > > currentOdfSingleLinkData = linkEndsIterator->second;
-
             // Get vectors of times, observations, and ancillary settings for the current observable
             // type and link ends
             std::vector< std::vector< TimeType > > observationTimes;
@@ -1313,14 +1288,19 @@ std::shared_ptr< observation_models::ObservationCollection< ObservationScalarTyp
 
                     for( unsigned int j = 0; j < observationTimes.at( i ).size( ); ++j )
                     {
-                        if( ( ( !std::isnan( static_cast< double >( startAndEndTimesToProcess.first ) ) &&
-                                observationTimes.at( i ).at( j ) >= startAndEndTimesToProcess.first ) ||
-                              std::isnan( static_cast< double >( startAndEndTimesToProcess.first ) ) ) &&
-                            ( ( !std::isnan( static_cast< double >( startAndEndTimesToProcess.second ) ) &&
-                                observationTimes.at( i ).at( j ) <= startAndEndTimesToProcess.second ) ||
-                              std::isnan( static_cast< double >( startAndEndTimesToProcess.second ) ) ) )
+                        TimeType observationTime = observationTimes.at( i ).at( j );
+
+                        bool observationTimeAfterIntervalStart =
+                                ( !std::isnan( static_cast< double >( startAndEndTimesToProcess.first ) ) &&
+                                  observationTime >= startAndEndTimesToProcess.first ) ||
+                                std::isnan( static_cast< double >( startAndEndTimesToProcess.first ) );
+                        bool observationTimeBeforeIntervalEnd =
+                                ( ( !std::isnan( static_cast< double >( startAndEndTimesToProcess.second ) ) &&
+                                    observationTime <= startAndEndTimesToProcess.second ) ||
+                                  std::isnan( static_cast< double >( startAndEndTimesToProcess.second ) ) );
+                        if( observationTimeAfterIntervalStart && observationTimeBeforeIntervalEnd )
                         {
-                            singleTruncatedObservationTimes.push_back( observationTimes.at( i ).at( j ) );
+                            singleTruncatedObservationTimes.push_back( observationTime );
                             singleTruncatedObservables.push_back( observables.at( i ).at( j ) );
                         }
                     }
@@ -1360,7 +1340,8 @@ std::shared_ptr< observation_models::SingleObservationSet< ObservationScalarType
     ObservationScalarType floatingCompressionRatio =
             mathematical_constants::getFloatingInteger< ObservationScalarType >( compressionRatio );
 
-    double currentCompressionTime = originalDopplerData->getAncillarySettings( )->getAncillaryDoubleData( doppler_integration_time );
+    double currentCompressionTime = originalDopplerData->getAncillarySettings( )->getAncillaryDoubleData(
+            observation_models::ObservationAncillarySimulationVariable::doppler_integration_time );
 
     std::vector< Eigen::Matrix< ObservationScalarType, Eigen::Dynamic, 1 > > originalObservations =
             originalDopplerData->getObservationsReference( );
@@ -1368,10 +1349,13 @@ std::shared_ptr< observation_models::SingleObservationSet< ObservationScalarType
 
     earth_orientation::TerrestrialTimeScaleConverter timeScaleConverter = earth_orientation::TerrestrialTimeScaleConverter( );
     Eigen::Vector3d stationPosition = simulation_setup::getCombinedApproximateGroundStationPositions( ).at(
-            originalDopplerData->getLinkEnds( ).at( receiver ).stationName_ );
+            originalDopplerData->getLinkEnds( ).at( observation_models::LinkEndType::receiver ).stationName_ );
 
-    std::vector< TimeType > originalObservationTimesUtc = timeScaleConverter.getCurrentTimesFromSinglePosition< TimeType >(
-            basic_astrodynamics::tdb_scale, basic_astrodynamics::utc_scale, originalObservationTimesTdb, stationPosition );
+    std::vector< TimeType > originalObservationTimesUtc =
+            timeScaleConverter.getCurrentTimesFromSinglePosition< TimeType >( basic_astrodynamics::TimeScales::tdb_scale,
+                                                                              basic_astrodynamics::TimeScales::utc_scale,
+                                                                              originalObservationTimesTdb,
+                                                                              stationPosition );
 
     std::vector< Eigen::Matrix< ObservationScalarType, Eigen::Dynamic, 1 > > compressedObservations;
     std::vector< TimeType > compressedObservationTimesUtc;
@@ -1409,7 +1393,7 @@ std::shared_ptr< observation_models::SingleObservationSet< ObservationScalarType
         }
     }
 
-    std::string stationName = originalDopplerData->getLinkEnds( ).at( receiver ).stationName_;
+    std::string stationName = originalDopplerData->getLinkEnds( ).at( observation_models::LinkEndType::receiver ).stationName_;
     if( simulation_setup::getCombinedApproximateGroundStationPositions( ).count( stationName ) == 0 )
     {
         throw std::runtime_error(
@@ -1423,14 +1407,19 @@ std::shared_ptr< observation_models::SingleObservationSet< ObservationScalarType
     {
         compressedEarthFixedPositions.push_back( stationPosition );
     }
-    std::vector< TimeType > compressedObservationTimesTdb = timeScaleConverter.getCurrentTimes< TimeType >(
-            basic_astrodynamics::utc_scale, basic_astrodynamics::tdb_scale, compressedObservationTimesUtc, compressedEarthFixedPositions );
+    std::vector< TimeType > compressedObservationTimesTdb =
+            timeScaleConverter.getCurrentTimes< TimeType >( basic_astrodynamics::TimeScales::utc_scale,
+                                                            basic_astrodynamics::TimeScales::tdb_scale,
+                                                            compressedObservationTimesUtc,
+                                                            compressedEarthFixedPositions );
 
     std::shared_ptr< ObservationAncillarySimulationSettings > ancillarySimulationSettings =
             std::make_shared< ObservationAncillarySimulationSettings >( *( originalDopplerData->getAncillarySettings( ) ) );
-    double originalIntegrationTime = ancillarySimulationSettings->getAncillaryDoubleData( doppler_integration_time );
-    ancillarySimulationSettings->setAncillaryDoubleData( doppler_integration_time,
-                                                         originalIntegrationTime * static_cast< double >( floatingCompressionRatio ) );
+    double originalIntegrationTime = ancillarySimulationSettings->getAncillaryDoubleData(
+            observation_models::ObservationAncillarySimulationVariable::doppler_integration_time );
+    ancillarySimulationSettings->setAncillaryDoubleData(
+            observation_models::ObservationAncillarySimulationVariable::doppler_integration_time,
+            originalIntegrationTime * static_cast< double >( floatingCompressionRatio ) );
     return std::make_shared< SingleObservationSet< ObservationScalarType, TimeType > >(
             originalDopplerData->getObservableType( ),
             originalDopplerData->getLinkEnds( ),
@@ -1453,18 +1442,19 @@ std::shared_ptr< observation_models::ObservationCollection< ObservationScalarTyp
     std::shared_ptr< observation_models::ObservationCollection< ObservationScalarType, TimeType > > compressedData =
             splitObservationSets( originalDopplerData,
                                   observationSetSplitter( time_interval_splitter, maxArcGap, minNumberObservations ),
-                                  observationParser( dsn_n_way_averaged_doppler ) );
+                                  observationParser( observation_models::ObservableType::dsn_n_way_averaged_doppler ) );
 
     std::map< LinkEnds, std::vector< std::shared_ptr< observation_models::SingleObservationSet< ObservationScalarType, TimeType > > > >
-            uncompressedObservationSets = compressedData->getObservationsSets( ).at( dsn_n_way_averaged_doppler );
+            uncompressedObservationSets =
+                    compressedData->getObservationsSets( ).at( observation_models::ObservableType::dsn_n_way_averaged_doppler );
 
     std::map< LinkEnds, std::vector< unsigned int > > indicesSetsToRemove;
-    for( auto it : uncompressedObservationSets )
+    for( auto const& [ linkEnds, observationSets ] : uncompressedObservationSets )
     {
-        for( unsigned int index = 0; index < it.second.size( ); index++ )
+        for( unsigned int index = 0; index < observationSets.size( ); index++ )
         {
             std::shared_ptr< observation_models::SingleObservationSet< ObservationScalarType, TimeType > > compressedDataSet =
-                    compressDopplerData< ObservationScalarType, TimeType >( it.second.at( index ), compressionRatio );
+                    compressDopplerData< ObservationScalarType, TimeType >( observationSets.at( index ), compressionRatio );
 
             if( compressedDataSet->getObservationTimes( ).size( ) )
             {
@@ -1472,13 +1462,14 @@ std::shared_ptr< observation_models::ObservationCollection< ObservationScalarTyp
             }
             else
             {
-                indicesSetsToRemove[ it.first ].push_back( index );
+                indicesSetsToRemove[ linkEnds ].push_back( index );
             }
         }
     }
 
     // Remove empty compressed sets if any
-    compressedData->removeSingleObservationSets( { { dsn_n_way_averaged_doppler, indicesSetsToRemove } } );
+    compressedData->removeSingleObservationSets(
+            { { observation_models::ObservableType::dsn_n_way_averaged_doppler, indicesSetsToRemove } } );
 
     return compressedData;
 }
@@ -1523,15 +1514,13 @@ template< typename TimeType = Time >
 inline void setTransmittingFrequenciesInGroundStations( std::shared_ptr< ProcessedOdfFileContents< TimeType > > processedOdfFileContents,
                                                         std::shared_ptr< simulation_setup::Body > bodyWithGroundStations )
 {
-    for( auto it = processedOdfFileContents->getRampInterpolators( ).begin( );
-         it != processedOdfFileContents->getRampInterpolators( ).end( );
-         it++ )
+    for( auto const& [ stationName, transmittingFrequencyCalculator ] : processedOdfFileContents->getRampInterpolators( ) )
     {
-        if( bodyWithGroundStations->getGroundStationMap( ).count( it->first ) == 0 )
+        if( bodyWithGroundStations->getGroundStationMap( ).count( stationName ) == 0 )
         {
-            throw std::runtime_error( "Error when setting frequencies for station " + it->first + ", station not found." );
+            throw std::runtime_error( "Error when setting frequencies for station " + stationName + ", station not found." );
         }
-        bodyWithGroundStations->getGroundStation( it->first )->setTransmittingFrequencyCalculator( it->second );
+        bodyWithGroundStations->getGroundStation( stationName )->setTransmittingFrequencyCalculator( transmittingFrequencyCalculator );
     }
 }
 

--- a/include/tudat/simulation/estimation_setup/processOdfFile.h
+++ b/include/tudat/simulation/estimation_setup/processOdfFile.h
@@ -1253,7 +1253,7 @@ std::shared_ptr< observation_models::ObservationCollection< ObservationScalarTyp
         std::shared_ptr< ProcessedOdfFileContents< TimeType > > processedOdfFileContents,
         std::vector< observation_models::ObservableType > observableTypesToProcess = std::vector< observation_models::ObservableType >( ),
         std::pair< TimeType, TimeType > startAndEndTimesToProcess = std::make_pair< TimeType, TimeType >( TUDAT_NAN, TUDAT_NAN ),
-        const bool allowDuplicateObservationsWithinSingleObservationSet = true)
+        const bool allowDuplicateObservationsWithinSingleObservationSet = true )
 {
     // Set observables to process
     if( observableTypesToProcess.empty( ) )
@@ -1341,12 +1341,10 @@ std::shared_ptr< observation_models::ObservationCollection< ObservationScalarTyp
                                 observation_models::receiver,
                                 std::vector< Eigen::VectorXd >( ),
                                 nullptr,
-                                std::make_shared< observation_models::ObservationAncillarySimulationSettings >(
-                                        ancillarySettings.at( i ) ),
-                                std::vector<Eigen::Matrix<double, Eigen::Dynamic, 1>>(),                // weights
-                                std::vector<Eigen::Matrix<ObservationScalarType, Eigen::Dynamic, 1>>(), // residuals
-                                !allowDuplicateObservationsWithinSingleObservationSet) );
-
+                                std::make_shared< observation_models::ObservationAncillarySimulationSettings >( ancillarySettings.at( i ) ),
+                                std::vector< Eigen::Matrix< double, Eigen::Dynamic, 1 > >( ),                 // weights
+                                std::vector< Eigen::Matrix< ObservationScalarType, Eigen::Dynamic, 1 > >( ),  // residuals
+                                !allowDuplicateObservationsWithinSingleObservationSet ) );
             }
         }
     }
@@ -1572,7 +1570,7 @@ createOdfObservedObservationCollectionFromFile( simulation_setup::SystemOfBodies
                                                 const bool verboseOutput = true,
                                                 const std::map< std::string, Eigen::Vector3d >& earthFixedGroundStationPositions =
                                                         simulation_setup::getApproximateDsnGroundStationPositions( ),
-                                                const bool allowDuplicateObservationsWithinSingleObservationSet = true)
+                                                const bool allowDuplicateObservationsWithinSingleObservationSet = true )
 {
     std::vector< std::shared_ptr< input_output::OdfRawFileContents > > rawOdfDataVector;
     for( std::string odfFileName : odfFileNames )
@@ -1587,9 +1585,10 @@ createOdfObservedObservationCollectionFromFile( simulation_setup::SystemOfBodies
 
     // Create observed observation collection
     return observation_models::createOdfObservedObservationCollection< ObservationScalarType, TimeType >(
-        processedOdfFileContents, std::vector< observation_models::ObservableType >(),
-        std::make_pair< TimeType, TimeType >( TUDAT_NAN, TUDAT_NAN ),
-        allowDuplicateObservationsWithinSingleObservationSet);
+            processedOdfFileContents,
+            std::vector< observation_models::ObservableType >( ),
+            std::make_pair< TimeType, TimeType >( TUDAT_NAN, TUDAT_NAN ),
+            allowDuplicateObservationsWithinSingleObservationSet );
 }
 
 }  // namespace observation_models

--- a/src/tudat/io/readOdfFile.cpp
+++ b/src/tudat/io/readOdfFile.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "tudat/io/readOdfFile.h"
+#include "tudat/io/readBinaryFile.h"
 
 namespace tudat
 {

--- a/src/tudat/simulation/estimation_setup/processOdfFile.cpp
+++ b/src/tudat/simulation/estimation_setup/processOdfFile.cpp
@@ -10,8 +10,6 @@
 
 #include "tudat/simulation/estimation_setup/processOdfFile.h"
 
-#include <algorithm>
-
 namespace tio = tudat::input_output;
 
 namespace tudat

--- a/src/tudatpy/data/processTrk234/processor.py
+++ b/src/tudatpy/data/processTrk234/processor.py
@@ -64,7 +64,7 @@ class Trk234Processor:
         self.spacecraft_name = spacecraft_name
 
         # Initialize observables converters.
-        self.converters = {}
+        self.converters : dict[str, cnv.Converter] = {}
         if "doppler" in requested_types:
             self.converters["doppler"] = cnv.DerivedDopplerConverter()
         if "range" in requested_types:

--- a/src/tudatpy/dynamics/environment_setup/atmosphere/expose_atmosphere.cpp
+++ b/src/tudatpy/dynamics/environment_setup/atmosphere/expose_atmosphere.cpp
@@ -83,7 +83,7 @@ The values in this class may be recomputed every time step to reflect changing a
 
                          Currently, the ideal gas law is used to compute the speed of sound and the specific heat ratio is assumed to be constant and equal to 1.4.
 
-                         :param solar_activity_data: Solar activity data for a range of epochs as produced by tudatpy.io.read_solar_activity_data.
+                         :param solar_activity_data: Solar activity data for a range of epochs as produced by tudatpy.data.read_solar_activity_data.
                          )doc" )
             .def( py::init< const std::map< double, std::shared_ptr< tio::solar_activity::SolarActivityData > >,
                             const bool,

--- a/src/tudatpy/estimation/observations_setup/observations_wrapper/expose_observations_wrapper_io.cpp
+++ b/src/tudatpy/estimation/observations_setup/observations_wrapper/expose_observations_wrapper_io.cpp
@@ -84,7 +84,7 @@ void expose_observations_wrapper_io_bindings( py::module &m )
 
         Returns
         -------
-        list[tudatpy.io.odf.OdfDataType]
+        list[tudatpy.data.OdfDataType]
             List of ignored ODF observable type IDs.
         )doc" )
             .def_property_readonly( "ignored_ground_stations",
@@ -102,7 +102,7 @@ void expose_observations_wrapper_io_bindings( py::module &m )
 
         Returns
         -------
-        list[tudatpy.io.OdfRawFileContents]
+        list[tudatpy.data.OdfRawFileContents]
             List of raw ODF data objects.
         )doc" )
             .def( "define_antenna_id",
@@ -431,7 +431,7 @@ void expose_observations_wrapper_io_bindings( py::module &m )
 
         Parameters
         ----------
-        raw_tracking_txtfile_contents : tudatpy.io.TrackingTxtFileContents
+        raw_tracking_txtfile_contents : tudatpy.data.TrackingTxtFileContents
             The raw tracking file contents.
         spacecraft_name : str
             Name of the spacecraft.


### PR DESCRIPTION
This PR:

- applies the clang-format to a bunch of unformatted files
- adds the required header includes to the binary file reader to make it self-contained
- improves readability of the ODF processing by using structured bindings in for-loops and using the enum members explicitly through the enum parent instead of the global namespace
- remove deprecated `tudatpy.io` links in docs