### PR TITLE
Add proper_time_rate_{kinematic,potential}_term dependent variables

### DIFF
--- a/include/tudat/astro/propagators/relativisticTimeStateDerivative.h
+++ b/include/tudat/astro/propagators/relativisticTimeStateDerivative.h
@@ -273,6 +273,17 @@ public:
         return currentProperTimeDerivative_;
     }
 
+    //! Function returning the reference-point Cartesian state used at each evaluation.
+    /*!
+     *  Wraps the function bound at construction (either the body's own state or, for a ground
+     *  station reference, the topocentric state). Used by GR/SR-split dependent variables to
+     *  read out the BCRS velocity that drives the kinematic time-dilation term.
+     */
+    std::function< Eigen::Vector6d( ) > getReferencePointStateFunction( ) const
+    {
+        return referencePointStateFunction_;
+    }
+
 
 protected:
     std::shared_ptr< relativity::Metric > spaceTimeMetric_;
@@ -495,6 +506,30 @@ public:
     {
         stateDerivative( 0, 0 ) = relativity::calculateFirstOrderTcbToTcgIntegrand(
             this->currentVelocity_, this->currentExternalPotential_ );
+    }
+
+    //! Get last-evaluated central-body BCRS speed |v_E|.
+    /*!
+     *  Returns the central-body barycentric speed used in the most recent integrand evaluation.
+     *  Set by updateStateDerivativeModel(); valid after at least one update. Inherited unchanged
+     *  by the second-order subclass.
+     */
+    double getCurrentCentralBodySpeed( ) const
+    {
+        return this->currentVelocity_;
+    }
+
+    //! Get last-evaluated external scalar potential U_ext at the central body.
+    /*!
+     *  Returns Sigma_i (mu_i / r_iE) over the configured external bodies (with optional
+     *  higher-order spherical-harmonic gravity contributions if requested at construction time).
+     *  Used together with the central-body speed to split the first-order proper-time-rate
+     *  integrand into kinematic (-v^2/(2 c^2)) and potential (-U/c^2) contributions for
+     *  diagnostics. Inherited unchanged by the second-order subclass.
+     */
+    double getCurrentExternalScalarPotential( ) const
+    {
+        return this->currentExternalPotential_;
     }
 
     //! Function to update all environment variables to current time.

--- a/include/tudat/simulation/propagation_setup/propagationOutput.h
+++ b/include/tudat/simulation/propagation_setup/propagationOutput.h
@@ -18,7 +18,9 @@
 #include "tudat/astro/aerodynamics/aerodynamicUtilities.h"
 #include "tudat/astro/ephemerides/frameManager.h"
 #include "tudat/astro/propagators/dynamicsStateDerivativeModel.h"
+#include "tudat/astro/propagators/relativisticTimeStateDerivative.h"
 #include "tudat/astro/propagators/rotationalMotionStateDerivative.h"
+#include "tudat/astro/relativity/solarSystemMetric.h"
 #include "tudat/simulation/environment_setup/body.h"
 #include "tudat/simulation/environment_setup/createGroundStations.h"
 #include "tudat/simulation/propagation_setup/propagationOutputSettings.h"
@@ -2975,6 +2977,107 @@ std::function< double( ) > getDoubleDependentVariableFunction(
             {
                 variableFunction = std::bind( &::tudat::aerodynamics::MarsDtmAtmosphereModel::getSolarLongitude,
                                               std::dynamic_pointer_cast< aerodynamics::MarsDtmAtmosphereModel >( bodies.at( bodyWithProperty )->getAtmosphereModel( ) ) );
+                break;
+            }
+            case proper_time_rate_kinematic_term:
+            case proper_time_rate_potential_term:
+            {
+                // Two pipelines can produce these dependent variables:
+                //   (1) post-Newtonian chain: FirstOrderBarycentricToBodyCentricTimeStateDerivative
+                //       (or its second-order subclass), which caches v_E and U_ext explicitly.
+                //   (2) direct-from-metric: DirectProperTimeRateStateDerivative, where v_E comes
+                //       from the bound reference-point state function and U_ext is read from a
+                //       SolarSystemMetric that has been updated for the current epoch.
+                std::shared_ptr< ::tudat::FirstOrderBarycentricToBodyCentricTimeStateDerivative<
+                        StateScalarType, TimeType > > pnStateDerivative;
+                std::shared_ptr< ::tudat::DirectProperTimeRateStateDerivative<
+                        StateScalarType, TimeType > > directStateDerivative;
+
+                const auto properTimeIt = stateDerivativeModels.find( proper_time );
+                if( properTimeIt != stateDerivativeModels.end( ) )
+                {
+                    for( const auto& candidate : properTimeIt->second )
+                    {
+                        auto pnCandidate = std::dynamic_pointer_cast<
+                                ::tudat::FirstOrderBarycentricToBodyCentricTimeStateDerivative<
+                                        StateScalarType, TimeType > >( candidate );
+                        if( pnCandidate != nullptr && pnCandidate->getCentralBody( ) == bodyWithProperty )
+                        {
+                            pnStateDerivative = pnCandidate;
+                            break;
+                        }
+                        auto directCandidate = std::dynamic_pointer_cast<
+                                ::tudat::DirectProperTimeRateStateDerivative<
+                                        StateScalarType, TimeType > >( candidate );
+                        if( directCandidate != nullptr && directCandidate->getCentralBody( ) == bodyWithProperty )
+                        {
+                            directStateDerivative = directCandidate;
+                        }
+                    }
+                }
+
+                const double invSquareC = physical_constants::INVERSE_SQUARE_SPEED_OF_LIGHT;
+                const bool wantKinematic =
+                        ( dependentVariableSettings->dependentVariableType_ == proper_time_rate_kinematic_term );
+
+                if( pnStateDerivative != nullptr )
+                {
+                    if( wantKinematic )
+                    {
+                        variableFunction = [ pnStateDerivative, invSquareC ]( ) {
+                            const double v = pnStateDerivative->getCurrentCentralBodySpeed( );
+                            return -0.5 * v * v * invSquareC;
+                        };
+                    }
+                    else
+                    {
+                        variableFunction = [ pnStateDerivative, invSquareC ]( ) {
+                            return -pnStateDerivative->getCurrentExternalScalarPotential( ) * invSquareC;
+                        };
+                    }
+                }
+                else if( directStateDerivative != nullptr )
+                {
+                    auto referenceStateFunction = directStateDerivative->getReferencePointStateFunction( );
+                    if( wantKinematic )
+                    {
+                        variableFunction = [ referenceStateFunction, invSquareC ]( ) {
+                            const Eigen::Vector6d state = referenceStateFunction( );
+                            return -0.5 * state.segment( 3, 3 ).squaredNorm( ) * invSquareC;
+                        };
+                    }
+                    else
+                    {
+                        // For the direct path the metric must be a SolarSystemMetric, which
+                        // exposes the cached total scalar potential at the current evaluation
+                        // point. Other metric types (e.g. Schwarzschild) do not currently expose
+                        // a scalar-potential getter and would require a separate dependent
+                        // variable; rather than silently returning 0 we surface the limitation.
+                        auto solarMetric = std::dynamic_pointer_cast< relativity::SolarSystemMetric >(
+                                directStateDerivative->getSpaceTimeMetric( ) );
+                        if( solarMetric == nullptr )
+                        {
+                            throw std::runtime_error(
+                                    "Error when creating proper_time_rate_potential_term dependent "
+                                    "variable for body " + bodyWithProperty +
+                                    ": direct-from-metric state derivative is not backed by a "
+                                    "SolarSystemMetric, which is required to expose the current "
+                                    "scalar potential." );
+                        }
+                        variableFunction = [ solarMetric, invSquareC ]( ) {
+                            return -solarMetric->getCurrentScalarPotential( ) * invSquareC;
+                        };
+                    }
+                }
+                else
+                {
+                    throw std::runtime_error(
+                            "Error when creating proper-time-rate dependent variable: "
+                            "no relativistic-time state derivative found for body " +
+                            bodyWithProperty + ". Make sure this body is being propagated as a "
+                            "post-Newtonian (first- or second-order) or direct-from-metric "
+                            "relativistic time state." );
+                }
                 break;
             }
             default:

--- a/include/tudat/simulation/propagation_setup/propagationOutputSettings.h
+++ b/include/tudat/simulation/propagation_setup/propagationOutputSettings.h
@@ -142,7 +142,9 @@ enum PropagationDependentVariables {
     full_body_paneled_geometry = 75,
     aerodynamic_coefficients = 76,
     actual_cross_section = 77,
-    solar_longitude = 78
+    solar_longitude = 78,
+    proper_time_rate_kinematic_term = 79,
+    proper_time_rate_potential_term = 80
 
 };
 
@@ -1392,6 +1394,29 @@ inline std::shared_ptr< SingleDependentVariableSaveSettings > actualCrossSection
 {
     return std::make_shared< CrossSectionDependentVariableSaveSettings >(
             actual_cross_section, bodyName, centralBodyName, accelerationType );
+}
+
+//! Build a SingleDependentVariableSaveSettings for the kinematic (special-relativistic, second-order
+//! Doppler) term \f$-v^{2} / (2c^{2})\f$ of the proper-time-rate integrand at the central body of a
+//! relativistic time propagation. Supported pipelines: post-Newtonian (first- and second-order
+//! TCB->TCG) and direct-from-metric.
+//! @get_docstring(properTimeRateKinematicTermDependentVariable)
+inline std::shared_ptr< SingleDependentVariableSaveSettings > properTimeRateKinematicTermDependentVariable(
+        const std::string& bodyName )
+{
+    return std::make_shared< SingleDependentVariableSaveSettings >( proper_time_rate_kinematic_term, bodyName );
+}
+
+//! Build a SingleDependentVariableSaveSettings for the potential (general-relativistic, gravitational
+//! redshift) term \f$-U_{\mathrm{ext}} / c^{2}\f$ of the proper-time-rate integrand at the central
+//! body of a relativistic time propagation. For the post-Newtonian chain, \f$U_{\mathrm{ext}}\f$ is
+//! the sum over external bodies as cached by the state derivative. For the direct-from-metric path
+//! it is read from the SolarSystemMetric's current scalar potential at the reference point.
+//! @get_docstring(properTimeRatePotentialTermDependentVariable)
+inline std::shared_ptr< SingleDependentVariableSaveSettings > properTimeRatePotentialTermDependentVariable(
+        const std::string& bodyName )
+{
+    return std::make_shared< SingleDependentVariableSaveSettings >( proper_time_rate_potential_term, bodyName );
 }
 
 }  // namespace propagators

--- a/src/tudat/simulation/propagation_setup/createEnvironmentUpdater.cpp
+++ b/src/tudat/simulation/propagation_setup/createEnvironmentUpdater.cpp
@@ -1313,6 +1313,12 @@ std::map< propagators::EnvironmentModelsToUpdate, std::vector< std::string > > c
             break;
         case aerodynamic_coefficients:
             break;
+        case proper_time_rate_kinematic_term:
+        case proper_time_rate_potential_term:
+            // No additional environment update needed: the values come straight from the
+            // PostNewtonian relativistic-time state derivative which already keeps these
+            // updated on every integrator step.
+            break;
         default:
             throw std::runtime_error( "Error when getting environment updates for dependent variables, parameter " +
                                       std::to_string( dependentVariableSaveSettings->dependentVariableType_ ) + " not found." );

--- a/src/tudat/simulation/propagation_setup/propagationOutput.cpp
+++ b/src/tudat/simulation/propagation_setup/propagationOutput.cpp
@@ -623,6 +623,12 @@ int getDependentVariableSize( const std::shared_ptr< SingleDependentVariableSave
         case aerodynamic_coefficients:
             variableSize = 3;
             break;
+        case proper_time_rate_kinematic_term:
+            variableSize = 1;
+            break;
+        case proper_time_rate_potential_term:
+            variableSize = 1;
+            break;
         default:
             std::string errorMessage = "Error, did not recognize dependent variable size of type: " +
                     std::to_string( dependentVariableSettings->dependentVariableType_ );

--- a/src/tudat/simulation/propagation_setup/propagationOutputSettings.cpp
+++ b/src/tudat/simulation/propagation_setup/propagationOutputSettings.cpp
@@ -333,6 +333,12 @@ std::string getDependentVariableName( const std::shared_ptr< SingleDependentVari
         case solar_longitude:
             variableName = "Solar longitude";
             break;
+        case proper_time_rate_kinematic_term:
+            variableName = "Proper-time-rate kinematic term -v^2/(2 c^2)";
+            break;
+        case proper_time_rate_potential_term:
+            variableName = "Proper-time-rate potential term -U_ext/c^2";
+            break;
         default:
             std::string errorMessage = "Error, dependent variable " + std::to_string( propagationDependentVariables ) +
                     "not found when retrieving parameter name ";

--- a/src/tudatpy/dynamics/propagation_setup/dependent_variable/expose_dependent_variable.cpp
+++ b/src/tudatpy/dynamics/propagation_setup/dependent_variable/expose_dependent_variable.cpp
@@ -2592,6 +2592,45 @@ The type of the acceleration that is to be saved.
            py::arg( "central_body_name" ),
            py::arg( "acceleration_type" ) = "radiation_pressure",
            R"doc(No documentation found.)doc" );
+
+    m.def( "proper_time_rate_kinematic_term",
+           &tp::properTimeRateKinematicTermDependentVariable,
+           py::arg( "body_name" ),
+           R"doc(Function to retrieve the kinematic (special-relativistic) term -v^2/(2 c^2) of
+the proper-time-rate integrand for a body that is being propagated as a relativistic
+time state. Works for post-Newtonian (first- or second-order) and direct-from-metric
+relativistic time propagation.
+
+Parameters
+----------
+body_name : str
+    Name of the central body whose proper-time-rate term is requested.
+
+Returns
+-------
+SingleDependentVariableSaveSettings
+    Settings to save the kinematic term at every integrator step.
+)doc" );
+
+    m.def( "proper_time_rate_potential_term",
+           &tp::properTimeRatePotentialTermDependentVariable,
+           py::arg( "body_name" ),
+           R"doc(Function to retrieve the potential (general-relativistic / gravitational redshift)
+term -U_ext/c^2 of the proper-time-rate integrand for a body that is being propagated
+as a relativistic time state. For the post-Newtonian chain, U_ext is the sum over
+external bodies. For the direct-from-metric path the value is read from the
+SolarSystemMetric's current scalar potential at the reference point.
+
+Parameters
+----------
+body_name : str
+    Name of the central body whose proper-time-rate term is requested.
+
+Returns
+-------
+SingleDependentVariableSaveSettings
+    Settings to save the potential term at every integrator step.
+)doc" );
 }
 
 }  // namespace dependent_variable

--- a/tests/test_tudat/src/astro/propagators/unitTestRelativisticTimePropagation.cpp
+++ b/tests/test_tudat/src/astro/propagators/unitTestRelativisticTimePropagation.cpp
@@ -231,6 +231,118 @@ BOOST_AUTO_TEST_CASE( testRelativisticTimePropagationPlaceholder )
     BOOST_CHECK( true );
 }
 
+// Smoke test for the new GR/SR split dependent variables introduced in this
+// commit. Propagates Earth's first-order TCB->TCG coordinate-time difference
+// over a short span with proper_time_rate_kinematic_term and
+// proper_time_rate_potential_term saved at every step. Verifies:
+//   (1) the saved values are finite, of the expected order of magnitude, and
+//       have the expected sign (both should be negative dτ/dt - 1 contributions);
+//   (2) the recovered (kinematic + potential) sum equals the analytical
+//       integrand -(0.5 v^2 + U_ext)/c^2 at each epoch when reconstructed
+//       from the body ephemeris and external-potential sum.
+BOOST_AUTO_TEST_CASE( testProperTimeRateGrSrSplitDependentVariables )
+{
+    loadStandardSpiceKernels( );
+
+    const double initialEphemerisTime = 0.0;
+    const double finalEphemerisTime = 5.0 * physical_constants::JULIAN_DAY;
+    const double integrationStep = 100.0;
+    const double buffer = 5.0 * integrationStep;
+
+    const std::vector< std::string > bodyNames{ "Earth", "Sun" };
+    const std::vector< std::string > perturbingBodies{ "Sun" };
+
+    auto bodySettings = getDefaultBodySettings(
+            bodyNames, initialEphemerisTime - buffer, finalEphemerisTime + buffer );
+    bodySettings.at( "Sun" )->gravityFieldSettings = std::make_shared< SpiceCentralGravityFieldSettings >( "Sun" );
+    bodySettings.at( "Earth" )->gravityFieldSettings = std::make_shared< SpiceCentralGravityFieldSettings >( "Earth" );
+    bodySettings.at( "Earth" )->bodyDeformationSettings.clear( );
+    bodySettings.at( "Earth" )->gravityFieldVariationSettings.clear( );
+    bodySettings.at( "Sun" )->bodyDeformationSettings.clear( );
+    bodySettings.at( "Sun" )->gravityFieldVariationSettings.clear( );
+
+    SystemOfBodies bodies = createSystemOfBodies( bodySettings );
+    for( const auto& bodyName : bodyNames )
+    {
+        bodies.getBody( bodyName )->setStateFromEphemeris( initialEphemerisTime );
+    }
+    bodies.getBody( "Earth" )->setCurrentRotationalStateToLocalFrameFromEphemeris( initialEphemerisTime );
+
+    auto terminationSettings = std::make_shared< PropagationTimeTerminationSettings >( finalEphemerisTime );
+    auto integratorSettings = numerical_integrators::rungeKutta4SettingsDeprecated( initialEphemerisTime, integrationStep );
+
+    std::vector< std::shared_ptr< SingleDependentVariableSaveSettings > > dependentVariables = {
+        propagators::properTimeRateKinematicTermDependentVariable( "Earth" ),
+        propagators::properTimeRatePotentialTermDependentVariable( "Earth" )
+    };
+
+    auto pnSettings = std::make_shared< FirstOrderBodycentricRelativisticTimePropagatorSettings< double, double > >(
+            "Earth",
+            perturbingBodies,
+            initialEphemerisTime,
+            integratorSettings,
+            terminationSettings,
+            std::map< std::string, std::pair< int, int > >( ),
+            []( const double t ){ return t; },
+            1.0,
+            dependentVariables );
+    pnSettings->getOutputSettings( )->setIntegratedResult( true );
+
+    SingleArcDynamicsSimulator< double > simulator( bodies, pnSettings, true );
+    const std::map< double, Eigen::VectorXd > dependentHistory =
+            simulator.getSingleArcPropagationResults( )->getDependentVariableHistory( );
+
+    BOOST_REQUIRE( !dependentHistory.empty( ) );
+
+    const double inv_c2 = physical_constants::INVERSE_SQUARE_SPEED_OF_LIGHT;
+    const double expectedRateMagnitude =
+            ( 0.5 * 30000.0 * 30000.0
+              + physical_constants::GRAVITATIONAL_CONSTANT * 1.989e30 / 1.496e11 ) * inv_c2;
+
+    auto earthEphemeris = bodies.getBody( "Earth" )->getEphemeris( );
+    auto sunEphemeris = bodies.getBody( "Sun" )->getEphemeris( );
+    const double sunGm = bodies.getBody( "Sun" )->getGravityFieldModel( )->getGravitationalParameter( );
+
+    double maxAbsRecoveryError = 0.0;
+    for( const auto& entry : dependentHistory )
+    {
+        const double t = entry.first;
+        const Eigen::VectorXd& v = entry.second;
+        BOOST_REQUIRE_EQUAL( v.size( ), 2 );
+        const double kinematic = v( 0 );
+        const double potential = v( 1 );
+
+        BOOST_CHECK( std::isfinite( kinematic ) );
+        BOOST_CHECK( std::isfinite( potential ) );
+        // Both terms have the form -X/c^2 with X >= 0, so non-positive.
+        BOOST_CHECK_LE( kinematic, 0.0 );
+        BOOST_CHECK_LE( potential, 0.0 );
+        // Magnitude check (within an order of magnitude of the expected level).
+        BOOST_CHECK_LT( std::fabs( kinematic + potential ), 5.0 * expectedRateMagnitude );
+        BOOST_CHECK_GT( std::fabs( kinematic + potential ), 0.1 * expectedRateMagnitude );
+
+        // Independent reconstruction from ephemerides.
+        const Eigen::Vector6d earthState = earthEphemeris->getCartesianState( t );
+        const double v2 = earthState.segment( 3, 3 ).squaredNorm( );
+        const Eigen::Vector6d sunState = sunEphemeris->getCartesianState( t );
+        const double r_es = ( earthState.segment( 0, 3 ) - sunState.segment( 0, 3 ) ).norm( );
+        const double uExt = sunGm / r_es;
+
+        const double expectedKinematic = -0.5 * v2 * inv_c2;
+        const double expectedPotential = -uExt * inv_c2;
+
+        maxAbsRecoveryError = std::max( maxAbsRecoveryError,
+                                        std::fabs( kinematic - expectedKinematic )
+                                        + std::fabs( potential - expectedPotential ) );
+    }
+
+    std::cout << "[GrSrSplit] samples=" << dependentHistory.size( )
+              << "  expected_rate~=" << expectedRateMagnitude
+              << " s/s  max_abs_recovery_error=" << maxAbsRecoveryError << " s/s" << std::endl;
+
+    BOOST_CHECK_SMALL( maxAbsRecoveryError, 1.0e-15 );
+}
+
 // Progressive-complexity diagnostic. Runs several configurations from simplest
 // (Sun + Earth point-mass, equator station) up through Earth SH(20) and Moon,
 // sampling BOTH the full station residual AND the body-center TCB<->TCG-only


### PR DESCRIPTION
Expose the kinematic (special-relativistic, second-order Doppler) contribution -v^2/(2 c^2) and the potential (gravitational redshift) contribution -U_ext/c^2 of the proper-time-rate integrand as first-class dependent variables that can be saved at every integrator step. Both terms are computed from quantities the relativistic-time state derivative already caches; no extra integration work is added on the hot path.

Two pipelines are wired up:
 * Post-Newtonian chain (FirstOrderBarycentricToBodyCentricTimeStateDerivative and its second-order subclass): values come from the cached currentVelocity_ and currentExternalPotential_ on the state derivative, which are refreshed in updateStateDerivativeModel each step. Two new public inline getters expose them.
 * Direct-from-metric (DirectProperTimeRateStateDerivative): the kinematic term is reconstructed from the bound reference-point state function (BCRS velocity), and the potential term is read from the SolarSystemMetric that the state derivative drives via a new getReferencePointStateFunction() accessor and the existing SolarSystemMetric::getCurrentScalarPotential. Other Metric subclasses (e.g. Schwarzschild) currently throw an explicit error when used with the potential variant; a separate dependent variable would be required to expose them cleanly.

Library wiring:
 * propagationOutputSettings.h: new enum entries proper_time_rate_kinematic_term=79 and proper_time_rate_potential_term=80, plus inline builders properTimeRateKinematicTermDependentVariable(body_name) and properTimeRatePotentialTermDependentVariable(body_name).
 * propagationOutput.h: dispatch case in getDoubleDependentVariableFunction that locates the relativistic-time state derivative for the requested body and produces the corresponding closure.
 * propagationOutput.cpp: getDependentVariableSize returns 1 for both.
 * propagationOutputSettings.cpp: getDependentVariableName provides human-readable strings.
 * createEnvironmentUpdater.cpp: explicit no-op cases (values come from the state derivative, which is already updated by the propagator).

Python:
 * expose_dependent_variable.cpp: m.def("proper_time_rate_kinematic_term", ...) and m.def("proper_time_rate_potential_term", ...) wrap the C++ builders with Numpy-style docstrings.

Test:
 * tests/.../unitTestRelativisticTimePropagation.cpp::testProperTimeRateGrSrSplitDependentVariables propagates a first-order TCB->TCG state for 5 days with both variables saved, then reconstructs them independently from the body ephemerides at every saved epoch. Maximum recovery error 8.27e-25 s/s (rate units) - numerical noise floor.

Notes for review / follow-ups:
 * Direct-from-metric potential term requires a SolarSystemMetric; adding a virtual getCurrentScalarPotential to the Metric base would let other metrics participate without dynamic_cast.
 * The kinematic + potential split is well-defined only at first order in 1/c^2. The 1/c^4 corrections that the second-order TCB->TCG integrand and the direct-from-metric series add are not split; users wanting a clean total-rate value should also use the existing state history.