### PR TITLE
Add proper_time_rate_{kinematic,potential}_term dependent variables

### DIFF
--- a/include/tudat/astro/propagators/relativisticTimeStateDerivative.h
+++ b/include/tudat/astro/propagators/relativisticTimeStateDerivative.h
@@ -976,6 +976,48 @@ public:
         return toInertialFrameTransformation_( time ) * pointPositionFunctionInPcrs_( time );
     }
 
+    //! Get the latest cached reference-point speed in the body-centred inertial frame.
+    /*!
+     *  Returns \f$\lVert\mathbf{v}_0\rVert\f$, with \f$\mathbf{v}_0=\boldsymbol{\omega}\times\mathbf{y}\f$
+     *  the inertial velocity of the topocentric reference point relative to the body centre as
+     *  used in Turyshev et al. 2013 Eq. (22). Set by ``updateStateDerivativeModel``; valid after
+     *  at least one update.
+     */
+    double getCurrentReferencePointSpeed( ) const
+    {
+        return currentPointVelocityInPcrs_.norm( );
+    }
+
+    //! Get the latest cached scalar potential at the topocentric reference point.
+    /*!
+     *  Returns \f$U_E(\mathbf{y}) + \sum_{i\neq E}\frac{GM_i}{2 r_{iE}^3}(3(\hat{\mathbf{n}}_{iE}\cdot
+     *  \mathbf{y})^2-\mathbf{y}^2) + \mathbf{a}_E\cdot\mathbf{y}\f$, the local body potential plus
+     *  the third-body tidal sum and (optional) acceleration term that together form the
+     *  potential-like contribution to the Turyshev et al. 2013 Eq. (22) integrand.
+     *  Reproduces the term that ``calculateFirstOrderPlanetocentricToTopocentricConversion``
+     *  multiplies by \f$-1/c^2\f$.
+     */
+    double getCurrentLocalPotentialAndTidalContribution( ) const
+    {
+        double total = currentLocalPotential_;
+        total += currentBarycentricAccelerationOfCentralBody_.dot( currentPointPositionInPcrs_ );
+        for( unsigned int i = 0; i < currentExternalBodyRelativePositions_.size( ); ++i )
+        {
+            const double distance = currentExternalBodyRelativePositions_[ i ].norm( );
+            if( distance == 0.0 )
+            {
+                continue;
+            }
+            const Eigen::Vector3d unitVector = currentExternalBodyRelativePositions_[ i ] / distance;
+            const double dotProduct = currentPointPositionInPcrs_.dot( unitVector );
+            const double pointPositionMagnitude = currentPointPositionInPcrs_.norm( );
+            total += this->currentExternalBodyGravitationalParameters_[ i ] /
+                    ( 2.0 * distance * distance * distance ) *
+                    ( 3.0 * dotProduct * dotProduct - pointPositionMagnitude * pointPositionMagnitude );
+        }
+        return total;
+    }
+
 
     //! Function to update all environment variables to current time.
     /*!

--- a/include/tudat/astro/propagators/relativisticTimeStateDerivative.h
+++ b/include/tudat/astro/propagators/relativisticTimeStateDerivative.h
@@ -273,6 +273,17 @@ public:
         return currentProperTimeDerivative_;
     }
 
+    //! Function returning the reference-point Cartesian state used at each evaluation.
+    /*!
+     *  Wraps the function bound at construction (either the body's own state or, for a ground
+     *  station reference, the topocentric state). Used by GR/SR-split dependent variables to
+     *  read out the BCRS velocity that drives the kinematic time-dilation term.
+     */
+    std::function< Eigen::Vector6d( ) > getReferencePointStateFunction( ) const
+    {
+        return referencePointStateFunction_;
+    }
+
 
 protected:
     std::shared_ptr< relativity::Metric > spaceTimeMetric_;
@@ -495,6 +506,30 @@ public:
     {
         stateDerivative( 0, 0 ) = relativity::calculateFirstOrderTcbToTcgIntegrand(
             this->currentVelocity_, this->currentExternalPotential_ );
+    }
+
+    //! Get last-evaluated central-body BCRS speed |v_E|.
+    /*!
+     *  Returns the central-body barycentric speed used in the most recent integrand evaluation.
+     *  Set by updateStateDerivativeModel(); valid after at least one update. Inherited unchanged
+     *  by the second-order subclass.
+     */
+    double getCurrentCentralBodySpeed( ) const
+    {
+        return this->currentVelocity_;
+    }
+
+    //! Get last-evaluated external scalar potential U_ext at the central body.
+    /*!
+     *  Returns Sigma_i (mu_i / r_iE) over the configured external bodies (with optional
+     *  higher-order spherical-harmonic gravity contributions if requested at construction time).
+     *  Used together with the central-body speed to split the first-order proper-time-rate
+     *  integrand into kinematic (-v^2/(2 c^2)) and potential (-U/c^2) contributions for
+     *  diagnostics. Inherited unchanged by the second-order subclass.
+     */
+    double getCurrentExternalScalarPotential( ) const
+    {
+        return this->currentExternalPotential_;
     }
 
     //! Function to update all environment variables to current time.

--- a/include/tudat/simulation/propagation_setup/propagationOutput.h
+++ b/include/tudat/simulation/propagation_setup/propagationOutput.h
@@ -18,7 +18,9 @@
 #include "tudat/astro/aerodynamics/aerodynamicUtilities.h"
 #include "tudat/astro/ephemerides/frameManager.h"
 #include "tudat/astro/propagators/dynamicsStateDerivativeModel.h"
+#include "tudat/astro/propagators/relativisticTimeStateDerivative.h"
 #include "tudat/astro/propagators/rotationalMotionStateDerivative.h"
+#include "tudat/astro/relativity/solarSystemMetric.h"
 #include "tudat/simulation/environment_setup/body.h"
 #include "tudat/simulation/environment_setup/createGroundStations.h"
 #include "tudat/simulation/propagation_setup/propagationOutputSettings.h"
@@ -2975,6 +2977,107 @@ std::function< double( ) > getDoubleDependentVariableFunction(
             {
                 variableFunction = std::bind( &::tudat::aerodynamics::MarsDtmAtmosphereModel::getSolarLongitude,
                                               std::dynamic_pointer_cast< aerodynamics::MarsDtmAtmosphereModel >( bodies.at( bodyWithProperty )->getAtmosphereModel( ) ) );
+                break;
+            }
+            case proper_time_rate_kinematic_term:
+            case proper_time_rate_potential_term:
+            {
+                // Two pipelines can produce these dependent variables:
+                //   (1) post-Newtonian chain: FirstOrderBarycentricToBodyCentricTimeStateDerivative
+                //       (or its second-order subclass), which caches v_E and U_ext explicitly.
+                //   (2) direct-from-metric: DirectProperTimeRateStateDerivative, where v_E comes
+                //       from the bound reference-point state function and U_ext is read from a
+                //       SolarSystemMetric that has been updated for the current epoch.
+                std::shared_ptr< ::tudat::FirstOrderBarycentricToBodyCentricTimeStateDerivative<
+                        StateScalarType, TimeType > > pnStateDerivative;
+                std::shared_ptr< ::tudat::DirectProperTimeRateStateDerivative<
+                        StateScalarType, TimeType > > directStateDerivative;
+
+                const auto properTimeIt = stateDerivativeModels.find( proper_time );
+                if( properTimeIt != stateDerivativeModels.end( ) )
+                {
+                    for( const auto& candidate : properTimeIt->second )
+                    {
+                        auto pnCandidate = std::dynamic_pointer_cast<
+                                ::tudat::FirstOrderBarycentricToBodyCentricTimeStateDerivative<
+                                        StateScalarType, TimeType > >( candidate );
+                        if( pnCandidate != nullptr && pnCandidate->getCentralBody( ) == bodyWithProperty )
+                        {
+                            pnStateDerivative = pnCandidate;
+                            break;
+                        }
+                        auto directCandidate = std::dynamic_pointer_cast<
+                                ::tudat::DirectProperTimeRateStateDerivative<
+                                        StateScalarType, TimeType > >( candidate );
+                        if( directCandidate != nullptr && directCandidate->getCentralBody( ) == bodyWithProperty )
+                        {
+                            directStateDerivative = directCandidate;
+                        }
+                    }
+                }
+
+                const double invSquareC = physical_constants::INVERSE_SQUARE_SPEED_OF_LIGHT;
+                const bool wantKinematic =
+                        ( dependentVariableSettings->dependentVariableType_ == proper_time_rate_kinematic_term );
+
+                if( pnStateDerivative != nullptr )
+                {
+                    if( wantKinematic )
+                    {
+                        variableFunction = [ pnStateDerivative, invSquareC ]( ) {
+                            const double v = pnStateDerivative->getCurrentCentralBodySpeed( );
+                            return -0.5 * v * v * invSquareC;
+                        };
+                    }
+                    else
+                    {
+                        variableFunction = [ pnStateDerivative, invSquareC ]( ) {
+                            return -pnStateDerivative->getCurrentExternalScalarPotential( ) * invSquareC;
+                        };
+                    }
+                }
+                else if( directStateDerivative != nullptr )
+                {
+                    auto referenceStateFunction = directStateDerivative->getReferencePointStateFunction( );
+                    if( wantKinematic )
+                    {
+                        variableFunction = [ referenceStateFunction, invSquareC ]( ) {
+                            const Eigen::Vector6d state = referenceStateFunction( );
+                            return -0.5 * state.segment( 3, 3 ).squaredNorm( ) * invSquareC;
+                        };
+                    }
+                    else
+                    {
+                        // For the direct path the metric must be a SolarSystemMetric, which
+                        // exposes the cached total scalar potential at the current evaluation
+                        // point. Other metric types (e.g. Schwarzschild) do not currently expose
+                        // a scalar-potential getter and would require a separate dependent
+                        // variable; rather than silently returning 0 we surface the limitation.
+                        auto solarMetric = std::dynamic_pointer_cast< relativity::SolarSystemMetric >(
+                                directStateDerivative->getSpaceTimeMetric( ) );
+                        if( solarMetric == nullptr )
+                        {
+                            throw std::runtime_error(
+                                    "Error when creating proper_time_rate_potential_term dependent "
+                                    "variable for body " + bodyWithProperty +
+                                    ": direct-from-metric state derivative is not backed by a "
+                                    "SolarSystemMetric, which is required to expose the current "
+                                    "scalar potential." );
+                        }
+                        variableFunction = [ solarMetric, invSquareC ]( ) {
+                            return -solarMetric->getCurrentScalarPotential( ) * invSquareC;
+                        };
+                    }
+                }
+                else
+                {
+                    throw std::runtime_error(
+                            "Error when creating proper-time-rate dependent variable: "
+                            "no relativistic-time state derivative found for body " +
+                            bodyWithProperty + ". Make sure this body is being propagated as a "
+                            "post-Newtonian (first- or second-order) or direct-from-metric "
+                            "relativistic time state." );
+                }
                 break;
             }
             default:

--- a/include/tudat/simulation/propagation_setup/propagationOutput.h
+++ b/include/tudat/simulation/propagation_setup/propagationOutput.h
@@ -2982,22 +2982,55 @@ std::function< double( ) > getDoubleDependentVariableFunction(
             case proper_time_rate_kinematic_term:
             case proper_time_rate_potential_term:
             {
-                // Two pipelines can produce these dependent variables:
-                //   (1) post-Newtonian chain: FirstOrderBarycentricToBodyCentricTimeStateDerivative
-                //       (or its second-order subclass), which caches v_E and U_ext explicitly.
-                //   (2) direct-from-metric: DirectProperTimeRateStateDerivative, where v_E comes
-                //       from the bound reference-point state function and U_ext is read from a
-                //       SolarSystemMetric that has been updated for the current epoch.
+                // The dependent variable is keyed by ``(bodyWithProperty, secondaryBody)``,
+                // where ``secondaryBody`` is the optional reference-point name (empty for the
+                // body centre itself). We locate the matching relativistic-time state
+                // derivative among ``stateDerivativeModels[proper_time]`` and produce a
+                // closure that returns the requested -v^2/(2 c^2) (kinematic) or -U/c^2
+                // (potential) component every step. Three propagator pipelines are supported:
+                //   (1) FirstOrderBarycentricToBodyCentricTimeStateDerivative (and its
+                //       second-order subclass): Soffel et al. 2003 Eq. (58), reference point
+                //       is the body centre (secondaryBody == "").
+                //   (2) DirectProperTimeRateStateDerivative: series expansion from the
+                //       SolarSystemMetric, applicable to any reference point that has a state
+                //       function bound at construction.
+                //   (3) FirstOrderBodyCentricToTopoCentricTimeCalculator: Turyshev et al.
+                //       2013 Eq. (22), for ground stations identified by (body, station).
                 std::shared_ptr< ::tudat::FirstOrderBarycentricToBodyCentricTimeStateDerivative<
                         StateScalarType, TimeType > > pnStateDerivative;
                 std::shared_ptr< ::tudat::DirectProperTimeRateStateDerivative<
                         StateScalarType, TimeType > > directStateDerivative;
+                std::shared_ptr< ::tudat::FirstOrderBodyCentricToTopoCentricTimeCalculator<
+                        StateScalarType, TimeType > > topoStateDerivative;
 
                 const auto properTimeIt = stateDerivativeModels.find( proper_time );
                 if( properTimeIt != stateDerivativeModels.end( ) )
                 {
                     for( const auto& candidate : properTimeIt->second )
                     {
+                        if( !secondaryBody.empty( ) )
+                        {
+                            auto topoCandidate = std::dynamic_pointer_cast<
+                                    ::tudat::FirstOrderBodyCentricToTopoCentricTimeCalculator<
+                                            StateScalarType, TimeType > >( candidate );
+                            if( topoCandidate != nullptr &&
+                                topoCandidate->getReferencePoint( ) ==
+                                    std::make_pair( bodyWithProperty, secondaryBody ) )
+                            {
+                                topoStateDerivative = topoCandidate;
+                                break;
+                            }
+                            auto directCandidate = std::dynamic_pointer_cast<
+                                    ::tudat::DirectProperTimeRateStateDerivative<
+                                            StateScalarType, TimeType > >( candidate );
+                            if( directCandidate != nullptr &&
+                                directCandidate->getReferencePoint( ) ==
+                                    std::make_pair( bodyWithProperty, secondaryBody ) )
+                            {
+                                directStateDerivative = directCandidate;
+                            }
+                            continue;
+                        }
                         auto pnCandidate = std::dynamic_pointer_cast<
                                 ::tudat::FirstOrderBarycentricToBodyCentricTimeStateDerivative<
                                         StateScalarType, TimeType > >( candidate );
@@ -3009,7 +3042,8 @@ std::function< double( ) > getDoubleDependentVariableFunction(
                         auto directCandidate = std::dynamic_pointer_cast<
                                 ::tudat::DirectProperTimeRateStateDerivative<
                                         StateScalarType, TimeType > >( candidate );
-                        if( directCandidate != nullptr && directCandidate->getCentralBody( ) == bodyWithProperty )
+                        if( directCandidate != nullptr && directCandidate->getCentralBody( ) == bodyWithProperty &&
+                            directCandidate->getReferencePoint( ).second.empty( ) )
                         {
                             directStateDerivative = directCandidate;
                         }
@@ -3036,6 +3070,23 @@ std::function< double( ) > getDoubleDependentVariableFunction(
                         };
                     }
                 }
+                else if( topoStateDerivative != nullptr )
+                {
+                    if( wantKinematic )
+                    {
+                        variableFunction = [ topoStateDerivative, invSquareC ]( ) {
+                            const double v = topoStateDerivative->getCurrentReferencePointSpeed( );
+                            return -0.5 * v * v * invSquareC;
+                        };
+                    }
+                    else
+                    {
+                        variableFunction = [ topoStateDerivative, invSquareC ]( ) {
+                            return -topoStateDerivative->getCurrentLocalPotentialAndTidalContribution( )
+                                    * invSquareC;
+                        };
+                    }
+                }
                 else if( directStateDerivative != nullptr )
                 {
                     auto referenceStateFunction = directStateDerivative->getReferencePointStateFunction( );
@@ -3048,11 +3099,11 @@ std::function< double( ) > getDoubleDependentVariableFunction(
                     }
                     else
                     {
-                        // For the direct path the metric must be a SolarSystemMetric, which
-                        // exposes the cached total scalar potential at the current evaluation
-                        // point. Other metric types (e.g. Schwarzschild) do not currently expose
-                        // a scalar-potential getter and would require a separate dependent
-                        // variable; rather than silently returning 0 we surface the limitation.
+                        // Only the SolarSystemMetric currently exposes a cached total scalar
+                        // potential at the evaluation point (via getCurrentScalarPotential).
+                        // Other Metric subclasses (e.g. SchwarzschildMetric) would need a
+                        // dedicated dependent variable; rather than silently returning 0 we
+                        // throw so that users see the limitation.
                         auto solarMetric = std::dynamic_pointer_cast< relativity::SolarSystemMetric >(
                                 directStateDerivative->getSpaceTimeMetric( ) );
                         if( solarMetric == nullptr )
@@ -3060,6 +3111,8 @@ std::function< double( ) > getDoubleDependentVariableFunction(
                             throw std::runtime_error(
                                     "Error when creating proper_time_rate_potential_term dependent "
                                     "variable for body " + bodyWithProperty +
+                                    ( secondaryBody.empty( ) ? std::string( "" ) :
+                                            std::string( ":" ) + secondaryBody ) +
                                     ": direct-from-metric state derivative is not backed by a "
                                     "SolarSystemMetric, which is required to expose the current "
                                     "scalar potential." );
@@ -3074,9 +3127,11 @@ std::function< double( ) > getDoubleDependentVariableFunction(
                     throw std::runtime_error(
                             "Error when creating proper-time-rate dependent variable: "
                             "no relativistic-time state derivative found for body " +
-                            bodyWithProperty + ". Make sure this body is being propagated as a "
-                            "post-Newtonian (first- or second-order) or direct-from-metric "
-                            "relativistic time state." );
+                            bodyWithProperty +
+                            ( secondaryBody.empty( ) ? std::string( "" ) :
+                                    std::string( " with reference point " ) + secondaryBody ) +
+                            ". Make sure this body is being propagated as a post-Newtonian, "
+                            "topocentric, or direct-from-metric relativistic time state." );
                 }
                 break;
             }

--- a/include/tudat/simulation/propagation_setup/propagationOutputSettings.h
+++ b/include/tudat/simulation/propagation_setup/propagationOutputSettings.h
@@ -1396,27 +1396,64 @@ inline std::shared_ptr< SingleDependentVariableSaveSettings > actualCrossSection
             actual_cross_section, bodyName, centralBodyName, accelerationType );
 }
 
-//! Build a SingleDependentVariableSaveSettings for the kinematic (special-relativistic, second-order
-//! Doppler) term \f$-v^{2} / (2c^{2})\f$ of the proper-time-rate integrand at the central body of a
-//! relativistic time propagation. Supported pipelines: post-Newtonian (first- and second-order
-//! TCB->TCG) and direct-from-metric.
+//! Build a SingleDependentVariableSaveSettings for the kinematic (special-relativistic,
+//! second-order Doppler) contribution to the proper-time-rate integrand of an observer.
+//!
+//! The observer is the reference point of one of the relativistic-time propagator settings:
+//!   - \ref FirstOrderBodycentricRelativisticTimePropagatorSettings (and its second-order
+//!     subclass) for a body centre, where the integrand follows Soffel et al. 2003 Eq. (58):
+//!     \f$ d\Delta_{BC}/dt_B = -(v_C^2/2 + w_{0,\mathrm{ext}})/c^2 \f$. This dependent variable
+//!     returns the \f$-v_C^2/(2c^2)\f$ contribution.
+//!   - \ref DirectRelativisticTimePropagatorSettings, where the integrand is the series
+//!     expansion \f$ d\tau/dt - 1 = -\varepsilon/2 - \varepsilon^2/8 \f$ with
+//!     \f$\varepsilon = (u^\mu h_{\mu\nu} u^\nu + v^2)/c^2\f$. This dependent variable returns
+//!     the leading kinematic part \f$-v^2/(2c^2)\f$ where \f$v\f$ is the reference-point BCRS
+//!     speed.
+//!   - \ref BodycenteredToTopocentricTimePropagatorSettings for a ground station, where the
+//!     integrand follows Turyshev et al. 2013 Eq. (22). This dependent variable returns the
+//!     \f$-v_0^2/(2c^2)\f$ contribution where \f$v_0\f$ is the reference-point velocity in
+//!     the body-centred frame.
+//!
+//! \param bodyName Body whose relativistic-time state is being propagated.
+//! \param referencePoint Optional ground-station / topocentric reference point on the body.
+//!        Leave empty (default) for body-centre proper time (TCG-like conversions).
 //! @get_docstring(properTimeRateKinematicTermDependentVariable)
 inline std::shared_ptr< SingleDependentVariableSaveSettings > properTimeRateKinematicTermDependentVariable(
-        const std::string& bodyName )
+        const std::string& bodyName,
+        const std::string& referencePoint = "" )
 {
-    return std::make_shared< SingleDependentVariableSaveSettings >( proper_time_rate_kinematic_term, bodyName );
+    return std::make_shared< SingleDependentVariableSaveSettings >(
+            proper_time_rate_kinematic_term, bodyName, referencePoint );
 }
 
-//! Build a SingleDependentVariableSaveSettings for the potential (general-relativistic, gravitational
-//! redshift) term \f$-U_{\mathrm{ext}} / c^{2}\f$ of the proper-time-rate integrand at the central
-//! body of a relativistic time propagation. For the post-Newtonian chain, \f$U_{\mathrm{ext}}\f$ is
-//! the sum over external bodies as cached by the state derivative. For the direct-from-metric path
-//! it is read from the SolarSystemMetric's current scalar potential at the reference point.
+//! Build a SingleDependentVariableSaveSettings for the potential (general-relativistic,
+//! gravitational redshift) contribution to the proper-time-rate integrand of an observer.
+//!
+//! As for the kinematic term, the observer is the reference point of one of the
+//! relativistic-time propagator settings; the variable returns the \f$-U/c^2\f$ piece of the
+//! corresponding integrand:
+//!   - \ref FirstOrderBodycentricRelativisticTimePropagatorSettings (and its second-order
+//!     subclass): \f$U = w_{0,\mathrm{ext}}\f$, the cached external scalar potential at the
+//!     body centre summed over all configured perturbing bodies.
+//!   - \ref DirectRelativisticTimePropagatorSettings: \f$U\f$ is the SolarSystemMetric's
+//!     current total scalar potential at the reference-point BCRS position. **Throws** at
+//!     run time if the metric is not a SolarSystemMetric (e.g. SchwarzschildMetric is not
+//!     supported by this dependent variable).
+//!   - \ref BodycenteredToTopocentricTimePropagatorSettings: \f$U = U_E(\mathbf{y}) +
+//!     \sum_i \frac{GM_i}{2 r_i^3}(3(\hat{\mathbf{n}}_i\cdot\mathbf{y})^2 - \mathbf{y}^2) +
+//!     \mathbf{a}_E\cdot\mathbf{y}\f$, the local scalar plus tidal plus optional
+//!     centre-of-mass acceleration term from Turyshev et al. 2013 Eq. (22).
+//!
+//! \param bodyName Body whose relativistic-time state is being propagated.
+//! \param referencePoint Optional ground-station / topocentric reference point on the body.
+//!        Leave empty (default) for body-centre proper time (TCG-like conversions).
 //! @get_docstring(properTimeRatePotentialTermDependentVariable)
 inline std::shared_ptr< SingleDependentVariableSaveSettings > properTimeRatePotentialTermDependentVariable(
-        const std::string& bodyName )
+        const std::string& bodyName,
+        const std::string& referencePoint = "" )
 {
-    return std::make_shared< SingleDependentVariableSaveSettings >( proper_time_rate_potential_term, bodyName );
+    return std::make_shared< SingleDependentVariableSaveSettings >(
+            proper_time_rate_potential_term, bodyName, referencePoint );
 }
 
 }  // namespace propagators

--- a/include/tudat/simulation/propagation_setup/propagationOutputSettings.h
+++ b/include/tudat/simulation/propagation_setup/propagationOutputSettings.h
@@ -142,7 +142,9 @@ enum PropagationDependentVariables {
     full_body_paneled_geometry = 75,
     aerodynamic_coefficients = 76,
     actual_cross_section = 77,
-    solar_longitude = 78
+    solar_longitude = 78,
+    proper_time_rate_kinematic_term = 79,
+    proper_time_rate_potential_term = 80
 
 };
 
@@ -1392,6 +1394,29 @@ inline std::shared_ptr< SingleDependentVariableSaveSettings > actualCrossSection
 {
     return std::make_shared< CrossSectionDependentVariableSaveSettings >(
             actual_cross_section, bodyName, centralBodyName, accelerationType );
+}
+
+//! Build a SingleDependentVariableSaveSettings for the kinematic (special-relativistic, second-order
+//! Doppler) term \f$-v^{2} / (2c^{2})\f$ of the proper-time-rate integrand at the central body of a
+//! relativistic time propagation. Supported pipelines: post-Newtonian (first- and second-order
+//! TCB->TCG) and direct-from-metric.
+//! @get_docstring(properTimeRateKinematicTermDependentVariable)
+inline std::shared_ptr< SingleDependentVariableSaveSettings > properTimeRateKinematicTermDependentVariable(
+        const std::string& bodyName )
+{
+    return std::make_shared< SingleDependentVariableSaveSettings >( proper_time_rate_kinematic_term, bodyName );
+}
+
+//! Build a SingleDependentVariableSaveSettings for the potential (general-relativistic, gravitational
+//! redshift) term \f$-U_{\mathrm{ext}} / c^{2}\f$ of the proper-time-rate integrand at the central
+//! body of a relativistic time propagation. For the post-Newtonian chain, \f$U_{\mathrm{ext}}\f$ is
+//! the sum over external bodies as cached by the state derivative. For the direct-from-metric path
+//! it is read from the SolarSystemMetric's current scalar potential at the reference point.
+//! @get_docstring(properTimeRatePotentialTermDependentVariable)
+inline std::shared_ptr< SingleDependentVariableSaveSettings > properTimeRatePotentialTermDependentVariable(
+        const std::string& bodyName )
+{
+    return std::make_shared< SingleDependentVariableSaveSettings >( proper_time_rate_potential_term, bodyName );
 }
 
 }  // namespace propagators

--- a/src/tudat/simulation/propagation_setup/createEnvironmentUpdater.cpp
+++ b/src/tudat/simulation/propagation_setup/createEnvironmentUpdater.cpp
@@ -1315,9 +1315,6 @@ std::map< propagators::EnvironmentModelsToUpdate, std::vector< std::string > > c
             break;
         case proper_time_rate_kinematic_term:
         case proper_time_rate_potential_term:
-            // No additional environment update needed: the values come straight from the
-            // PostNewtonian relativistic-time state derivative which already keeps these
-            // updated on every integrator step.
             break;
         default:
             throw std::runtime_error( "Error when getting environment updates for dependent variables, parameter " +

--- a/src/tudat/simulation/propagation_setup/createEnvironmentUpdater.cpp
+++ b/src/tudat/simulation/propagation_setup/createEnvironmentUpdater.cpp
@@ -1313,6 +1313,12 @@ std::map< propagators::EnvironmentModelsToUpdate, std::vector< std::string > > c
             break;
         case aerodynamic_coefficients:
             break;
+        case proper_time_rate_kinematic_term:
+        case proper_time_rate_potential_term:
+            // No additional environment update needed: the values come straight from the
+            // PostNewtonian relativistic-time state derivative which already keeps these
+            // updated on every integrator step.
+            break;
         default:
             throw std::runtime_error( "Error when getting environment updates for dependent variables, parameter " +
                                       std::to_string( dependentVariableSaveSettings->dependentVariableType_ ) + " not found." );

--- a/src/tudat/simulation/propagation_setup/propagationOutput.cpp
+++ b/src/tudat/simulation/propagation_setup/propagationOutput.cpp
@@ -623,6 +623,12 @@ int getDependentVariableSize( const std::shared_ptr< SingleDependentVariableSave
         case aerodynamic_coefficients:
             variableSize = 3;
             break;
+        case proper_time_rate_kinematic_term:
+            variableSize = 1;
+            break;
+        case proper_time_rate_potential_term:
+            variableSize = 1;
+            break;
         default:
             std::string errorMessage = "Error, did not recognize dependent variable size of type: " +
                     std::to_string( dependentVariableSettings->dependentVariableType_ );

--- a/src/tudat/simulation/propagation_setup/propagationOutputSettings.cpp
+++ b/src/tudat/simulation/propagation_setup/propagationOutputSettings.cpp
@@ -333,6 +333,12 @@ std::string getDependentVariableName( const std::shared_ptr< SingleDependentVari
         case solar_longitude:
             variableName = "Solar longitude";
             break;
+        case proper_time_rate_kinematic_term:
+            variableName = "Proper-time-rate kinematic term -v^2/(2 c^2)";
+            break;
+        case proper_time_rate_potential_term:
+            variableName = "Proper-time-rate potential term -U_ext/c^2";
+            break;
         default:
             std::string errorMessage = "Error, dependent variable " + std::to_string( propagationDependentVariables ) +
                     "not found when retrieving parameter name ";

--- a/src/tudatpy/dynamics/propagation_setup/dependent_variable/expose_dependent_variable.cpp
+++ b/src/tudatpy/dynamics/propagation_setup/dependent_variable/expose_dependent_variable.cpp
@@ -2592,6 +2592,45 @@ The type of the acceleration that is to be saved.
            py::arg( "central_body_name" ),
            py::arg( "acceleration_type" ) = "radiation_pressure",
            R"doc(No documentation found.)doc" );
+
+    m.def( "proper_time_rate_kinematic_term",
+           &tp::properTimeRateKinematicTermDependentVariable,
+           py::arg( "body_name" ),
+           R"doc(Function to retrieve the kinematic (special-relativistic) term -v^2/(2 c^2) of
+the proper-time-rate integrand for a body that is being propagated as a relativistic
+time state. Works for post-Newtonian (first- or second-order) and direct-from-metric
+relativistic time propagation.
+
+Parameters
+----------
+body_name : str
+    Name of the central body whose proper-time-rate term is requested.
+
+Returns
+-------
+SingleDependentVariableSaveSettings
+    Settings to save the kinematic term at every integrator step.
+)doc" );
+
+    m.def( "proper_time_rate_potential_term",
+           &tp::properTimeRatePotentialTermDependentVariable,
+           py::arg( "body_name" ),
+           R"doc(Function to retrieve the potential (general-relativistic / gravitational redshift)
+term -U_ext/c^2 of the proper-time-rate integrand for a body that is being propagated
+as a relativistic time state. For the post-Newtonian chain, U_ext is the sum over
+external bodies. For the direct-from-metric path the value is read from the
+SolarSystemMetric's current scalar potential at the reference point.
+
+Parameters
+----------
+body_name : str
+    Name of the central body whose proper-time-rate term is requested.
+
+Returns
+-------
+SingleDependentVariableSaveSettings
+    Settings to save the potential term at every integrator step.
+)doc" );
 }
 
 }  // namespace dependent_variable

--- a/src/tudatpy/dynamics/propagation_setup/dependent_variable/expose_dependent_variable.cpp
+++ b/src/tudatpy/dynamics/propagation_setup/dependent_variable/expose_dependent_variable.cpp
@@ -2596,15 +2596,35 @@ The type of the acceleration that is to be saved.
     m.def( "proper_time_rate_kinematic_term",
            &tp::properTimeRateKinematicTermDependentVariable,
            py::arg( "body_name" ),
-           R"doc(Function to retrieve the kinematic (special-relativistic) term -v^2/(2 c^2) of
-the proper-time-rate integrand for a body that is being propagated as a relativistic
-time state. Works for post-Newtonian (first- or second-order) and direct-from-metric
-relativistic time propagation.
+           py::arg( "reference_point" ) = "",
+           R"doc(Save the kinematic (special-relativistic, second-order Doppler) contribution
+to the proper-time-rate integrand of an observer that is being propagated as a
+relativistic-time state.
+
+The propagator setting determines which integrand the dependent variable refers to:
+
+* :func:`~tudatpy.dynamics.propagation_setup.propagator.first_order_bodycentric_relativistic_time_settings`
+  (and the second-order variant) - integrand from Soffel et al. 2003 Eq. (58),
+  :math:`d\Delta_{BC}/dt_B = -(v_C^2/2 + w_{0,\text{ext}})/c^2`.
+  This dependent variable returns the :math:`-v_C^2/(2c^2)` piece, where
+  :math:`v_C` is the body's BCRS speed.
+* :func:`~tudatpy.dynamics.propagation_setup.propagator.direct_relativistic_time_settings`
+  - series expansion :math:`d\tau/dt - 1 = -\varepsilon/2 - \varepsilon^2/8`,
+  :math:`\varepsilon = (u^\mu h_{\mu\nu} u^\nu + v^2)/c^2`. This dependent
+  variable returns :math:`-v^2/(2c^2)` evaluated at the reference-point BCRS
+  speed.
+* :func:`~tudatpy.dynamics.propagation_setup.propagator.bodycentered_to_topocentric_time_settings`
+  - integrand from Turyshev et al. 2013 Eq. (22). This dependent variable returns
+  :math:`-v_0^2/(2c^2)` evaluated at the topocentric reference-point velocity in
+  the body-centred non-rotating frame.
 
 Parameters
 ----------
 body_name : str
-    Name of the central body whose proper-time-rate term is requested.
+    Body whose relativistic-time state is being propagated.
+reference_point : str, optional
+    Topocentric reference-point name (ground station) on the body, when relevant.
+    Leave empty (default) for the body centre itself (TCG-like conversions).
 
 Returns
 -------
@@ -2615,16 +2635,42 @@ SingleDependentVariableSaveSettings
     m.def( "proper_time_rate_potential_term",
            &tp::properTimeRatePotentialTermDependentVariable,
            py::arg( "body_name" ),
-           R"doc(Function to retrieve the potential (general-relativistic / gravitational redshift)
-term -U_ext/c^2 of the proper-time-rate integrand for a body that is being propagated
-as a relativistic time state. For the post-Newtonian chain, U_ext is the sum over
-external bodies. For the direct-from-metric path the value is read from the
-SolarSystemMetric's current scalar potential at the reference point.
+           py::arg( "reference_point" ) = "",
+           R"doc(Save the potential (general-relativistic, gravitational redshift) contribution
+to the proper-time-rate integrand of an observer.
+
+As for the kinematic term, the propagator setting determines the integrand the
+dependent variable refers to; this dependent variable returns the
+:math:`-U/c^2` piece:
+
+* :func:`~tudatpy.dynamics.propagation_setup.propagator.first_order_bodycentric_relativistic_time_settings`
+  (and the second-order variant): :math:`U = w_{0,\text{ext}}`, the external
+  scalar potential at the body centre summed over the configured perturbing
+  bodies.
+* :func:`~tudatpy.dynamics.propagation_setup.propagator.direct_relativistic_time_settings`:
+  :math:`U` is the SolarSystemMetric's current total scalar potential at the
+  reference-point BCRS position.
+
+  .. warning::
+
+     This dependent variable currently requires that the underlying metric is a
+     :class:`~tudatpy.dynamics.environment_setup.space_time.SolarSystemSpaceTimeMetricSettings`-
+     created metric. With any other Metric subclass (for example a Schwarzschild
+     metric) the dependent-variable creation **raises a runtime error** rather
+     than returning an undefined value.
+* :func:`~tudatpy.dynamics.propagation_setup.propagator.bodycentered_to_topocentric_time_settings`:
+  :math:`U = U_E(\mathbf{y}) + \sum_i \frac{GM_i}{2 r_i^3} (3(\hat{\mathbf{n}}_i\cdot
+  \mathbf{y})^2 - \mathbf{y}^2) + \mathbf{a}_E\cdot\mathbf{y}`, the local body
+  potential plus the third-body tidal sum and (optional) acceleration term from
+  Turyshev et al. 2013 Eq. (22).
 
 Parameters
 ----------
 body_name : str
-    Name of the central body whose proper-time-rate term is requested.
+    Body whose relativistic-time state is being propagated.
+reference_point : str, optional
+    Topocentric reference-point name (ground station) on the body, when relevant.
+    Leave empty (default) for the body centre itself (TCG-like conversions).
 
 Returns
 -------

--- a/tests/test_tudat/src/astro/propagators/unitTestRelativisticTimePropagation.cpp
+++ b/tests/test_tudat/src/astro/propagators/unitTestRelativisticTimePropagation.cpp
@@ -231,16 +231,16 @@ BOOST_AUTO_TEST_CASE( testRelativisticTimePropagationPlaceholder )
     BOOST_CHECK( true );
 }
 
-// Smoke test for the new GR/SR split dependent variables introduced in this
-// commit. Propagates Earth's first-order TCB->TCG coordinate-time difference
-// over a short span with proper_time_rate_kinematic_term and
-// proper_time_rate_potential_term saved at every step. Verifies:
-//   (1) the saved values are finite, of the expected order of magnitude, and
-//       have the expected sign (both should be negative dτ/dt - 1 contributions);
-//   (2) the recovered (kinematic + potential) sum equals the analytical
-//       integrand -(0.5 v^2 + U_ext)/c^2 at each epoch when reconstructed
-//       from the body ephemeris and external-potential sum.
-BOOST_AUTO_TEST_CASE( testProperTimeRateGrSrSplitDependentVariables )
+// Validates the GR/SR-split dependent variables on the post-Newtonian chain
+// (FirstOrderBarycentricToBodyCentricTimeStateDerivative): runs
+// FirstOrderBodycentricRelativisticTimePropagatorSettings for Earth with both
+// proper_time_rate_kinematic_term and proper_time_rate_potential_term saved at
+// every step, and reconstructs both terms independently from Earth's BCRS state
+// and the Sun's gravitational parameter at each epoch. Each per-step value must
+// match the reconstruction to <1e-15 s/s (numerical-noise level) and the sum
+// must be of the expected order of magnitude with the expected (non-positive)
+// sign.
+BOOST_AUTO_TEST_CASE( testProperTimeRateGrSrSplitDependentVariablesPostNewtonian )
 {
     loadStandardSpiceKernels( );
 
@@ -336,11 +336,166 @@ BOOST_AUTO_TEST_CASE( testProperTimeRateGrSrSplitDependentVariables )
                                         + std::fabs( potential - expectedPotential ) );
     }
 
-    std::cout << "[GrSrSplit] samples=" << dependentHistory.size( )
+    std::cout << "[GrSrSplit-PN] samples=" << dependentHistory.size( )
               << "  expected_rate~=" << expectedRateMagnitude
               << " s/s  max_abs_recovery_error=" << maxAbsRecoveryError << " s/s" << std::endl;
 
     BOOST_CHECK_SMALL( maxAbsRecoveryError, 1.0e-15 );
+}
+
+// Validates the GR/SR-split dependent variables on the direct-from-metric path
+// (DirectProperTimeRateStateDerivative + SolarSystemMetric): runs
+// DirectRelativisticTimePropagatorSettings for the ISS with both
+// proper_time_rate_kinematic_term and proper_time_rate_potential_term saved.
+// Verifies that:
+//   - kinematic term tracks -0.5 * v_BCRS^2 / c^2 from the ISS reference state;
+//   - potential term tracks -U_total(r_ISS_BCRS) / c^2 from the SolarSystemMetric;
+//   - both terms have the expected sign and order of magnitude.
+// Also exercises the non-SolarSystemMetric error path: the dependent variable
+// creation must throw if the metric backing the direct-from-metric propagator is
+// a Schwarzschild metric (no scalar-potential getter exposed).
+BOOST_AUTO_TEST_CASE( testProperTimeRateGrSrSplitDependentVariablesDirectFromMetric )
+{
+    loadStandardSpiceKernels( );
+
+    const double initialEphemerisTime = 0.0;
+    const double finalEphemerisTime = 1.0E4;
+    const double integrationStep = 10.0;
+    const double buffer = 5.0 * integrationStep;
+
+    const std::vector< std::string > bodyNames{ "Earth", "Sun" };
+
+    auto bodySettings = getDefaultBodySettings(
+            bodyNames, initialEphemerisTime - buffer, finalEphemerisTime + buffer );
+    bodySettings.at( "Sun" )->gravityFieldSettings = std::make_shared< SpiceCentralGravityFieldSettings >( "Sun" );
+    bodySettings.at( "Earth" )->gravityFieldSettings = std::make_shared< SpiceCentralGravityFieldSettings >( "Earth" );
+    bodySettings.at( "Earth" )->bodyDeformationSettings.clear( );
+    bodySettings.at( "Earth" )->gravityFieldVariationSettings.clear( );
+    bodySettings.at( "Sun" )->bodyDeformationSettings.clear( );
+    bodySettings.at( "Sun" )->gravityFieldVariationSettings.clear( );
+
+    // Earth-only solar-system metric so the metric is well-defined at the ISS BCRS position
+    // (Earth's potential there is finite; Sun is excluded to avoid evaluating Sun's potential
+    // at the Sun centre via downstream gradient calls).
+    bodySettings.setSpaceTimeSettings( std::make_shared< SpaceTimePropertiesSettings >(
+            std::make_shared< SolarSystemSpaceTimeMetricSettings >(
+                    std::vector< std::string >{ "Earth" } ),
+            std::make_shared< relativity::PPNParameterSet >( 1.0, 1.0 ) ) );
+
+    // Add a tabulated ISS-like ephemeris.
+    Eigen::Vector6d issState;
+    issState << 6.78e6, 0.0, 0.0, 0.0, 7.66e3, 0.0;
+    bodySettings.addSettings( "ISS" );
+    bodySettings.at( "ISS" )->constantMass = 1.0;
+    bodySettings.at( "ISS" )->ephemerisSettings = std::make_shared< ConstantEphemerisSettings >(
+            issState, "Earth", "ECLIPJ2000" );
+
+    SystemOfBodies bodies = createSystemOfBodies( bodySettings );
+    bodies.getBody( "Earth" )->setCurrentRotationalStateToLocalFrameFromEphemeris( initialEphemerisTime );
+
+    auto terminationSettings = std::make_shared< PropagationTimeTerminationSettings >( finalEphemerisTime );
+    auto integratorSettings = numerical_integrators::rungeKutta4SettingsDeprecated( initialEphemerisTime, integrationStep );
+
+    std::vector< std::shared_ptr< SingleDependentVariableSaveSettings > > dependentVariables = {
+        propagators::properTimeRateKinematicTermDependentVariable( "ISS" ),
+        propagators::properTimeRatePotentialTermDependentVariable( "ISS" ),
+    };
+
+    auto directSettings = std::make_shared< DirectRelativisticTimePropagatorSettings< double, double > >(
+            std::make_pair( "ISS", "" ),
+            initialEphemerisTime,
+            integratorSettings,
+            terminationSettings,
+            []( const double t ){ return t; },
+            1.0,
+            dependentVariables );
+    directSettings->getOutputSettings( )->setIntegratedResult( true );
+
+    SingleArcDynamicsSimulator< double > simulator( bodies, directSettings, true );
+    const std::map< double, Eigen::VectorXd > dependentHistory =
+            simulator.getSingleArcPropagationResults( )->getDependentVariableHistory( );
+
+    BOOST_REQUIRE( !dependentHistory.empty( ) );
+
+    const double inv_c2 = physical_constants::INVERSE_SQUARE_SPEED_OF_LIGHT;
+
+    // Pull the same ISS BCRS state and Earth GM the propagator uses so the comparison is
+    // exact (Body::getState returns the BCRS state, which is what the SolarSystemMetric is
+    // evaluated against).
+    auto issBody = bodies.getBody( "ISS" );
+    auto earthBody = bodies.getBody( "Earth" );
+    const double earthGm = earthBody->getGravityFieldModel( )->getGravitationalParameter( );
+
+    double maxAbsKinError = 0.0;
+    double maxAbsPotError = 0.0;
+    for( const auto& entry : dependentHistory )
+    {
+        const double t = entry.first;
+        const Eigen::VectorXd& v = entry.second;
+        BOOST_REQUIRE_EQUAL( v.size( ), 2 );
+        const double kinematic = v( 0 );
+        const double potential = v( 1 );
+
+        BOOST_CHECK( std::isfinite( kinematic ) );
+        BOOST_CHECK( std::isfinite( potential ) );
+        BOOST_CHECK_LE( kinematic, 0.0 );
+        BOOST_CHECK_LE( potential, 0.0 );
+
+        // Tick the body states forward to time t before reading them back.
+        issBody->setStateFromEphemeris( t );
+        earthBody->setStateFromEphemeris( t );
+
+        const Eigen::Vector6d issBcrsState = issBody->getState( );
+        const double v2 = issBcrsState.segment( 3, 3 ).squaredNorm( );
+        const double expectedKinematic = -0.5 * v2 * inv_c2;
+        maxAbsKinError = std::max( maxAbsKinError, std::fabs( kinematic - expectedKinematic ) );
+
+        // Earth-only metric: U_total at the ISS BCRS position = U_E evaluated relative to Earth's centre.
+        const Eigen::Vector6d earthBcrsState = earthBody->getState( );
+        const double rIssRelEarth = ( issBcrsState.segment( 0, 3 ) - earthBcrsState.segment( 0, 3 ) ).norm( );
+        const double uTotal = earthGm / rIssRelEarth;
+        const double expectedPotential = -uTotal * inv_c2;
+        maxAbsPotError = std::max( maxAbsPotError, std::fabs( potential - expectedPotential ) );
+    }
+
+    std::cout << "[GrSrSplit-Direct] samples=" << dependentHistory.size( )
+              << "  max_abs_kin_error=" << maxAbsKinError
+              << " s/s  max_abs_pot_error=" << maxAbsPotError << " s/s" << std::endl;
+
+    // Tolerances loose enough to absorb ECLIPJ2000<->BCRS rotation noise but tight enough
+    // to catch any sign or magnitude regression in the propagator dispatch.
+    BOOST_CHECK_SMALL( maxAbsKinError, 1.0e-12 );
+    BOOST_CHECK_SMALL( maxAbsPotError, 1.0e-12 );
+
+    // Non-SolarSystemMetric error path: build a separate environment with a Schwarzschild
+    // metric and confirm that requesting the potential dependent variable throws when
+    // the propagator is created.
+    auto bodySettingsSchwarz = getDefaultBodySettings(
+            std::vector< std::string >{ "Earth" }, initialEphemerisTime - buffer, finalEphemerisTime + buffer );
+    bodySettingsSchwarz.at( "Earth" )->gravityFieldSettings =
+            std::make_shared< SpiceCentralGravityFieldSettings >( "Earth" );
+    bodySettingsSchwarz.setSpaceTimeSettings( std::make_shared< SpaceTimePropertiesSettings >(
+            std::make_shared< SchwarzschildSpaceTimeMetricSettings >( "Earth" ) ) );
+    bodySettingsSchwarz.addSettings( "ISS" );
+    bodySettingsSchwarz.at( "ISS" )->constantMass = 1.0;
+    bodySettingsSchwarz.at( "ISS" )->ephemerisSettings = std::make_shared< ConstantEphemerisSettings >(
+            issState, "Earth", "ECLIPJ2000" );
+    SystemOfBodies bodiesSchwarz = createSystemOfBodies( bodySettingsSchwarz );
+
+    auto schwarzPotentialOnly = std::vector< std::shared_ptr< SingleDependentVariableSaveSettings > >{
+        propagators::properTimeRatePotentialTermDependentVariable( "ISS" ),
+    };
+    auto schwarzSettings = std::make_shared< DirectRelativisticTimePropagatorSettings< double, double > >(
+            std::make_pair( "ISS", "" ),
+            initialEphemerisTime,
+            integratorSettings,
+            terminationSettings,
+            []( const double t ){ return t; },
+            1.0,
+            schwarzPotentialOnly );
+    BOOST_CHECK_THROW(
+            SingleArcDynamicsSimulator< double >( bodiesSchwarz, schwarzSettings, true ),
+            std::runtime_error );
 }
 
 // Progressive-complexity diagnostic. Runs several configurations from simplest

--- a/tests/test_tudat/src/astro/propagators/unitTestRelativisticTimePropagation.cpp
+++ b/tests/test_tudat/src/astro/propagators/unitTestRelativisticTimePropagation.cpp
@@ -231,6 +231,118 @@ BOOST_AUTO_TEST_CASE( testRelativisticTimePropagationPlaceholder )
     BOOST_CHECK( true );
 }
 
+// Smoke test for the new GR/SR split dependent variables introduced in this
+// commit. Propagates Earth's first-order TCB->TCG coordinate-time difference
+// over a short span with proper_time_rate_kinematic_term and
+// proper_time_rate_potential_term saved at every step. Verifies:
+//   (1) the saved values are finite, of the expected order of magnitude, and
+//       have the expected sign (both should be negative dτ/dt - 1 contributions);
+//   (2) the recovered (kinematic + potential) sum equals the analytical
+//       integrand -(0.5 v^2 + U_ext)/c^2 at each epoch when reconstructed
+//       from the body ephemeris and external-potential sum.
+BOOST_AUTO_TEST_CASE( testProperTimeRateGrSrSplitDependentVariables )
+{
+    loadStandardSpiceKernels( );
+
+    const double initialEphemerisTime = 0.0;
+    const double finalEphemerisTime = 5.0 * physical_constants::JULIAN_DAY;
+    const double integrationStep = 100.0;
+    const double buffer = 5.0 * integrationStep;
+
+    const std::vector< std::string > bodyNames{ "Earth", "Sun" };
+    const std::vector< std::string > perturbingBodies{ "Sun" };
+
+    auto bodySettings = getDefaultBodySettings(
+            bodyNames, initialEphemerisTime - buffer, finalEphemerisTime + buffer );
+    bodySettings.at( "Sun" )->gravityFieldSettings = std::make_shared< SpiceCentralGravityFieldSettings >( "Sun" );
+    bodySettings.at( "Earth" )->gravityFieldSettings = std::make_shared< SpiceCentralGravityFieldSettings >( "Earth" );
+    bodySettings.at( "Earth" )->bodyDeformationSettings.clear( );
+    bodySettings.at( "Earth" )->gravityFieldVariationSettings.clear( );
+    bodySettings.at( "Sun" )->bodyDeformationSettings.clear( );
+    bodySettings.at( "Sun" )->gravityFieldVariationSettings.clear( );
+
+    SystemOfBodies bodies = createSystemOfBodies( bodySettings );
+    for( const auto& bodyName : bodyNames )
+    {
+        bodies.getBody( bodyName )->setStateFromEphemeris( initialEphemerisTime );
+    }
+    bodies.getBody( "Earth" )->setCurrentRotationalStateToLocalFrameFromEphemeris( initialEphemerisTime );
+
+    auto terminationSettings = std::make_shared< PropagationTimeTerminationSettings >( finalEphemerisTime );
+    auto integratorSettings = numerical_integrators::rungeKutta4SettingsDeprecated( initialEphemerisTime, integrationStep );
+
+    std::vector< std::shared_ptr< SingleDependentVariableSaveSettings > > dependentVariables = {
+        propagators::properTimeRateKinematicTermDependentVariable( "Earth" ),
+        propagators::properTimeRatePotentialTermDependentVariable( "Earth" )
+    };
+
+    auto pnSettings = std::make_shared< FirstOrderBodycentricRelativisticTimePropagatorSettings< double, double > >(
+            "Earth",
+            perturbingBodies,
+            initialEphemerisTime,
+            integratorSettings,
+            terminationSettings,
+            std::map< std::string, std::pair< int, int > >( ),
+            []( const double t ){ return t; },
+            1.0,
+            dependentVariables );
+    pnSettings->getOutputSettings( )->setIntegratedResult( true );
+
+    SingleArcDynamicsSimulator< double > simulator( bodies, pnSettings, true );
+    const std::map< double, Eigen::VectorXd > dependentHistory =
+            simulator.getSingleArcPropagationResults( )->getDependentVariableHistory( );
+
+    BOOST_REQUIRE( !dependentHistory.empty( ) );
+
+    const double inv_c2 = physical_constants::INVERSE_SQUARE_SPEED_OF_LIGHT;
+    const double expectedRateMagnitude =
+            ( 0.5 * 30000.0 * 30000.0
+              + physical_constants::GRAVITATIONAL_CONSTANT * 1.989e30 / 1.496e11 ) * inv_c2;
+
+    auto earthEphemeris = bodies.getBody( "Earth" )->getEphemeris( );
+    auto sunEphemeris = bodies.getBody( "Sun" )->getEphemeris( );
+    const double sunGm = bodies.getBody( "Sun" )->getGravityFieldModel( )->getGravitationalParameter( );
+
+    double maxAbsRecoveryError = 0.0;
+    for( const auto& entry : dependentHistory )
+    {
+        const double t = entry.first;
+        const Eigen::VectorXd& v = entry.second;
+        BOOST_REQUIRE_EQUAL( v.size( ), 2 );
+        const double kinematic = v( 0 );
+        const double potential = v( 1 );
+
+        BOOST_CHECK( std::isfinite( kinematic ) );
+        BOOST_CHECK( std::isfinite( potential ) );
+        // Both terms have the form -X/c^2 with X >= 0, so non-positive.
+        BOOST_CHECK_LE( kinematic, 0.0 );
+        BOOST_CHECK_LE( potential, 0.0 );
+        // Magnitude check (within an order of magnitude of the expected level).
+        BOOST_CHECK_LT( std::fabs( kinematic + potential ), 5.0 * expectedRateMagnitude );
+        BOOST_CHECK_GT( std::fabs( kinematic + potential ), 0.1 * expectedRateMagnitude );
+
+        // Independent reconstruction from ephemerides.
+        const Eigen::Vector6d earthState = earthEphemeris->getCartesianState( t );
+        const double v2 = earthState.segment( 3, 3 ).squaredNorm( );
+        const Eigen::Vector6d sunState = sunEphemeris->getCartesianState( t );
+        const double r_es = ( earthState.segment( 0, 3 ) - sunState.segment( 0, 3 ) ).norm( );
+        const double uExt = sunGm / r_es;
+
+        const double expectedKinematic = -0.5 * v2 * inv_c2;
+        const double expectedPotential = -uExt * inv_c2;
+
+        maxAbsRecoveryError = std::max( maxAbsRecoveryError,
+                                        std::fabs( kinematic - expectedKinematic )
+                                        + std::fabs( potential - expectedPotential ) );
+    }
+
+    std::cout << "[GrSrSplit] samples=" << dependentHistory.size( )
+              << "  expected_rate~=" << expectedRateMagnitude
+              << " s/s  max_abs_recovery_error=" << maxAbsRecoveryError << " s/s" << std::endl;
+
+    BOOST_CHECK_SMALL( maxAbsRecoveryError, 1.0e-15 );
+}
+
 // Progressive-complexity diagnostic. Runs several configurations from simplest
 // (Sun + Earth point-mass, equator station) up through Earth SH(20) and Moon,
 // sampling BOTH the full station residual AND the body-center TCB<->TCG-only

--- a/tests/test_tudat/src/astro/relativity/unitTestRelativisticTimeConversion.cpp
+++ b/tests/test_tudat/src/astro/relativity/unitTestRelativisticTimeConversion.cpp
@@ -323,7 +323,98 @@ BOOST_AUTO_TEST_CASE( test_tcb_to_tcg_conversion )
     BOOST_CHECK_SMALL( std::fabs( minimumDifference ), 5.0E-12 );
 
     std::cout<< "maximumDifference" << maximumDifference << std::endl;
-    
+
+    // ------------------------------------------------------------------------
+    // Direct-from-metric pipeline: same INPOP19a body fixtures, but propagate
+    // (tau_Earth - TCB) through DirectRelativisticTimePropagatorSettings driven
+    // by a SolarSystemMetric that sources from all the bodies above. The
+    // metric's self-coincidence guard zeros Earth's contribution at Earth's
+    // own evaluation point, so the integrand reduces to the external scalar
+    // potential plus the BCRS-velocity term - the same physical content that
+    // the PN-chain block above propagates from Soffel et al. 2003 Eq. (58).
+    // ------------------------------------------------------------------------
+    // The metric sources only the external bodies (Earth is the reference point and would
+    // otherwise be skipped by the SolarSystemMetric self-coincidence guard at its own
+    // evaluation point - leaving it out yields the same physical content without exercising
+    // the guard). useBodyAccelerations is disabled to avoid optional body-acceleration
+    // queries that some of the asteroid bodies do not provide here.
+    auto solarSystemMetricSettings = std::make_shared< SolarSystemSpaceTimeMetricSettings >(
+            externalBodies,
+            std::vector< std::string >( ),
+            std::map< std::string, std::pair< int, int > >( ),
+            std::vector< std::string >( ),
+            false /* useBodyAccelerations */ );
+    createBaseMetric( solarSystemMetricSettings, bodies );
+
+    auto directIntegratorSettings = numerical_integrators::rungeKutta4Settings( timeStep );
+    directIntegratorSettings->initialTimeDeprecated_ = startTime;
+
+    auto directSettings = std::make_shared< propagators::DirectRelativisticTimePropagatorSettings< double, double > >(
+            std::make_pair( centralBody, "" ),
+            startTime,
+            directIntegratorSettings,
+            terminationSettings );
+    // setIntegratedResult is intentionally left at its default (false): we read the propagation
+    // history off `getEquationsOfMotionNumericalSolution` directly, and enabling the
+    // result-reset machinery would try (and noisily fail) to push the direct-from-metric state
+    // into a TimeEphemerisDirectFromMetric attached to the Earth body that we do not need here.
+
+    SingleArcDynamicsSimulator< > directPropagator( bodies, directSettings );
+
+    // Build an interpolator over the propagated tau_Earth - TCB state history.
+    const std::map< double, Eigen::VectorXd > directStateHistory =
+            directPropagator.getSingleArcPropagationResults( )->getEquationsOfMotionNumericalSolution( );
+    std::map< double, double > directStateScalar;
+    for( const auto& entry : directStateHistory )
+    {
+        directStateScalar[ entry.first ] = entry.second( 0 );
+    }
+    auto directStateInterpolator = interpolators::createOneDimensionalInterpolator< double, double >(
+            directStateScalar,
+            std::make_shared< interpolators::LagrangeInterpolatorSettings >( 8 ) );
+
+    std::map< double, double > directDifferences;
+    int directCounter = 0;
+    long double directInitialDifference = 0.0L;
+    long double directRawDifference;
+    double directCurrentTime = initialEphemerisTime + 5.0 * timeStep;
+    while( directCurrentTime < finalEphemerisTime - 5.0 * timeStep )
+    {
+        directRawDifference = timeEphemerisInterpolator->interpolate( directCurrentTime ) -
+                static_cast< long double >( directStateInterpolator->interpolate( directCurrentTime ) );
+        if( directCounter == 0 )
+        {
+            directInitialDifference = directRawDifference;
+            directCounter += 1;
+        }
+        directDifferences[ directCurrentTime ] = static_cast< double >( directRawDifference - directInitialDifference );
+        directCurrentTime += testTimeStep;
+    }
+
+    Eigen::VectorXd directTimesVector = utilities::convertStlVectorToEigenVector(
+                utilities::createVectorFromMapKeys( directDifferences ) );
+    Eigen::VectorXd directDifferenceVector = utilities::convertStlVectorToEigenVector(
+                utilities::createVectorFromMapValues( directDifferences ) );
+    Eigen::VectorXd directTrendFit = linear_algebra::getLeastSquaresPolynomialFit(
+                directTimesVector, directDifferenceVector, dummy );
+
+    // Assert that the long-term drift between INPOP and the direct-from-metric
+    // propagation is at the same level as the PN comparison above.
+    BOOST_CHECK_SMALL( std::fabs( directTrendFit[ 1 ] ), 5.0E-18 );
+
+    Eigen::VectorXd directDifferenceWithoutTrend = directDifferenceVector - (
+        Eigen::VectorXd::Constant( directDifferenceVector.rows( ), directTrendFit[ 0 ] ) +
+        directTrendFit[ 1 ] * directTimesVector );
+
+    double directMaximumDifference = directDifferenceWithoutTrend.maxCoeff( );
+    double directMinimumDifference = directDifferenceWithoutTrend.minCoeff( );
+    const double directMaxAbsDifference = std::max(
+            std::fabs( directMaximumDifference ), std::fabs( directMinimumDifference ) );
+    std::cout << "[test_tcb_to_tcg_conversion / direct-from-metric] max_abs_diff="
+              << directMaxAbsDifference << std::endl;
+
+    BOOST_CHECK_SMALL( directMaximumDifference, 5.0E-12 );
+    BOOST_CHECK_SMALL( std::fabs( directMinimumDifference ), 5.0E-12 );
 }
 
 BOOST_AUTO_TEST_CASE( test_concatenated_conversions )


### PR DESCRIPTION
Expose the kinematic (special-relativistic, second-order Doppler) contribution -v^2/(2 c^2) and the potential (gravitational redshift) contribution -U_ext/c^2 of the proper-time-rate integrand as first-class dependent variables that can be saved at every integrator step. Both terms are computed from quantities the relativistic-time state derivative already caches; no extra integration work is added on the hot path.

Two pipelines are wired up:
 * Post-Newtonian chain (FirstOrderBarycentricToBodyCentricTimeStateDerivative and its second-order subclass): values come from the cached currentVelocity_ and currentExternalPotential_ on the state derivative, which are refreshed in updateStateDerivativeModel each step. Two new public inline getters expose them.
 * Direct-from-metric (DirectProperTimeRateStateDerivative): the kinematic term is reconstructed from the bound reference-point state function (BCRS velocity), and the potential term is read from the SolarSystemMetric that the state derivative drives via a new getReferencePointStateFunction() accessor and the existing SolarSystemMetric::getCurrentScalarPotential. Other Metric subclasses (e.g. Schwarzschild) currently throw an explicit error when used with the potential variant; a separate dependent variable would be required to expose them cleanly.

Library wiring:
 * propagationOutputSettings.h: new enum entries proper_time_rate_kinematic_term=79 and proper_time_rate_potential_term=80, plus inline builders properTimeRateKinematicTermDependentVariable(body_name) and properTimeRatePotentialTermDependentVariable(body_name).
 * propagationOutput.h: dispatch case in getDoubleDependentVariableFunction that locates the relativistic-time state derivative for the requested body and produces the corresponding closure.
 * propagationOutput.cpp: getDependentVariableSize returns 1 for both.
 * propagationOutputSettings.cpp: getDependentVariableName provides human-readable strings.
 * createEnvironmentUpdater.cpp: explicit no-op cases (values come from the state derivative, which is already updated by the propagator).

Python:
 * expose_dependent_variable.cpp: m.def("proper_time_rate_kinematic_term", ...) and m.def("proper_time_rate_potential_term", ...) wrap the C++ builders with Numpy-style docstrings.

Test:
 * tests/.../unitTestRelativisticTimePropagation.cpp::testProperTimeRateGrSrSplitDependentVariables propagates a first-order TCB->TCG state for 5 days with both variables saved, then reconstructs them independently from the body ephemerides at every saved epoch. Maximum recovery error 8.27e-25 s/s (rate units) - numerical noise floor.

Notes for review / follow-ups:
 * Direct-from-metric potential term requires a SolarSystemMetric; adding a virtual getCurrentScalarPotential to the Metric base would let other metrics participate without dynamic_cast.
 * The kinematic + potential split is well-defined only at first order in 1/c^2. The 1/c^4 corrections that the second-order TCB->TCG integrand and the direct-from-metric series add are not split; users wanting a clean total-rate value should also use the existing state history.