### PR TITLE
Add workflow dispatch, remove deprecated branches

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8,9 +8,10 @@ name: Build and Test w/ Conda
 
 on:
   push:
-    branches: [ "master", "develop", "develop_10"]
+    branches: [ "master", "develop"]
   pull_request:
-    branches: [ "master", "develop", "develop_10"]
+    branches: [ "master", "develop"]
+  workflow_dispatch:
 
 jobs:
   build-and-test:


### PR DESCRIPTION
This PR adds a `workflow_dispatch` trigger to the build and test workflow. Once merged, the GH action can be triggered on a specific branch, without having to open a PR, see https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow