### PR TITLE
Fix/clang compiler warnings

### DIFF
--- a/cmake/tudat/compiler.cmake
+++ b/cmake/tudat/compiler.cmake
@@ -160,6 +160,7 @@
      set(CMAKE_C_FLAGS_MINSIZEREL "-DNDEBUG")
      set(CMAKE_C_FLAGS_RELEASE "-DNDEBUG")
      set(CMAKE_C_FLAGS_RELWITHDEBINFO "-g")
+     set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
      if (APPLE)
          # standard apple clang compiler flags

--- a/cmake/tudat/compiler.cmake
+++ b/cmake/tudat/compiler.cmake
@@ -160,7 +160,9 @@
      set(CMAKE_C_FLAGS_MINSIZEREL "-DNDEBUG")
      set(CMAKE_C_FLAGS_RELEASE "-DNDEBUG")
      set(CMAKE_C_FLAGS_RELWITHDEBINFO "-g")
-     set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+     if (NOT DEFINED CMAKE_EXPORT_COMPILE_COMMANDS)
+         set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+     endif ()
 
      if (APPLE)
          # standard apple clang compiler flags

--- a/include/tudat/astro/orbit_determination/acceleration_partials/ringAccelerationPartial.h
+++ b/include/tudat/astro/orbit_determination/acceleration_partials/ringAccelerationPartial.h
@@ -200,14 +200,6 @@ private:
      */
     Eigen::Vector3d bodyFixedPosition_;
 
-    //! Current spherical coordinate of body undergoing acceleration
-    /*!
-     *  Current spherical coordinate of body undergoing acceleration, in reference frame fixed to body exerting acceleration.
-     *  Order of components is radial distance (from center of body), latitude, longitude. Note that the the second entry
-     *  differs from the direct output of the cartesian -> spherical coordinates, which produces a colatitude.
-     */
-    Eigen::Vector3d bodyFixedSphericalPosition_;
-
     //! The current partial of the acceleration wrt the position of the body undergoing the acceleration.
     /*!
      *  The current partial of the acceleration wrt the position of the body undergoing the acceleration.

--- a/include/tudat/astro/orbit_determination/acceleration_partials/rtgAccelerationPartial.h
+++ b/include/tudat/astro/orbit_determination/acceleration_partials/rtgAccelerationPartial.h
@@ -25,22 +25,6 @@ namespace tudat
 namespace acceleration_partials
 {
 
-//! Function determine the numerical partial derivative of the true anomaly wrt the elements of the Cartesian state
-/*!
- *  unction determine the numerical partial derivative of the true anomaly wrt the elements of the Cartesian state,
- *  from the Cartesian state as input.
- *  A first-order central difference with a user-defined Cartesian state perturbation vector is used.
- *  \param cartesianElements Nominal Cartesian elements at which the partials are to be computed
- *  \param gravitationalParameter Gravitational parameter of central body around which Keplerian orbit is given
- *  \param cartesianStateElementPerturbations Numerical perturbations of Cartesian state that are to be used
- *  \return Partial of Cartesian state wrt true anomaly of orbit.
- */
-/*
-Eigen::Matrix< double, 1, 6 > calculateNumericalPartialOfTrueAnomalyWrtState( const Eigen::Vector6d& cartesianElements,
-                                                                              const double gravitationalParameter,
-                                                                              const Eigen::Vector6d& cartesianStateElementPerturbations );
-*/
-
 class RTGAccelerationPartial : public AccelerationPartial
 {
 public:
@@ -184,9 +168,6 @@ public:
 private:
     //! Acceleration w.r.t. which partials are to be computed.
     std::shared_ptr< system_models::RTGAccelerationModel > rtgAcceleration_;
-
-    //! Perturbations to use on Cartesian state elements when computing partial of true anomaly w.r.t. state.
-    Eigen::Matrix< double, 1, 6 > cartesianStateElementPerturbations;
 };
 
 }  // namespace acceleration_partials

--- a/include/tudat/astro/system_models/rtgAccelerationModel.h
+++ b/include/tudat/astro/system_models/rtgAccelerationModel.h
@@ -79,7 +79,8 @@ public:
             currentTimeDelta_ = currentTime - referenceEpoch_;
             currentDecayTerm_ = std::exp(-decayScaleFactor_ * currentTimeDelta_);
             currentBodyFixedForceVector_ = bodyFixedForceVectorAtReferenceEpoch_ * currentDecayTerm_;
-            currentAcceleration_ = rotationToIntegrationFrame_ * currentBodyFixedForceVector_ / bodyMassFunction_();
+            currentAccelerationInBodyFixedFrame_ = currentBodyFixedForceVector_ / bodyMassFunction_();
+            currentAcceleration_ = rotationToIntegrationFrame_ * currentAccelerationInBodyFixedFrame_;
         }
     }
 

--- a/include/tudat/math/basic/leastSquaresEstimation.h
+++ b/include/tudat/math/basic/leastSquaresEstimation.h
@@ -34,7 +34,14 @@ namespace linear_algebra
  */
 double getConditionNumberOfDesignMatrix( const Eigen::MatrixXd designMatrix );
 
-template <int Options>
+//! Function to get condition number of matrix from SVD decomposition
+/*!
+ *  Function to get condition number of matrix from SVD decomposition
+ * \param singularValueDecomposition SVD decomposition of matrix
+ * \tparam Options Options for the underlying Eigen JacobiSVD decomposition
+ * \return Condition number of matrix
+ */
+template< int Options >
 double getConditionNumberOfDecomposedMatrix( const Eigen::JacobiSVD< Eigen::MatrixXd, Options >& singularValueDecomposition )
 {
     Eigen::VectorXd singularValues = singularValueDecomposition.singularValues( );

--- a/include/tudat/math/basic/leastSquaresEstimation.h
+++ b/include/tudat/math/basic/leastSquaresEstimation.h
@@ -34,13 +34,12 @@ namespace linear_algebra
  */
 double getConditionNumberOfDesignMatrix( const Eigen::MatrixXd designMatrix );
 
-//! Function to get condition number of matrix from SVD decomposition
-/*!
- *  Function to get condition number of matrix from SVD decomposition
- * \param singularValueDecomposition SVD decomposition of matrix
- * \return Condition number of matrix
- */
-double getConditionNumberOfDecomposedMatrix( const Eigen::JacobiSVD< Eigen::MatrixXd >& singularValueDecomposition );
+template <int Options>
+double getConditionNumberOfDecomposedMatrix( const Eigen::JacobiSVD< Eigen::MatrixXd, Options >& singularValueDecomposition )
+{
+    Eigen::VectorXd singularValues = singularValueDecomposition.singularValues( );
+    return singularValues( 0 ) / singularValues( singularValues.rows( ) - 1 );
+}
 
 //! Solve system of equations with SVD decomposition, checking condition number in the process
 /*!

--- a/src/tudat/astro/system_models/selfShadowing.cpp
+++ b/src/tudat/astro/system_models/selfShadowing.cpp
@@ -674,7 +674,7 @@ void SelfShadowing::updateIlluminatedPanelFractions( const Eigen::Vector3d& inco
             }
             int i = numberOfThreads - 1;
             std::vector< int > indexes( toBePixelated.begin( ) + i * chunk, toBePixelated.end( ) );
-            threads.emplace_back( [ &, i, indexes ]( ) {
+            threads.emplace_back( [ &, indexes ]( ) {
                 results[ numberOfThreads - 1 ] =
                         computeFractionWithPixelation( sigmaMatrix, allPanels_, maximumNumberOfPixels_, projections, indexes );
             } );

--- a/src/tudat/math/basic/leastSquaresEstimation.cpp
+++ b/src/tudat/math/basic/leastSquaresEstimation.cpp
@@ -26,14 +26,7 @@ namespace linear_algebra
 //! Function to get condition number of matrix (using SVD decomposition)
 double getConditionNumberOfDesignMatrix( const Eigen::MatrixXd designMatrix )
 {
-    return getConditionNumberOfDecomposedMatrix( ( designMatrix.jacobiSvd( Eigen::ComputeThinU | Eigen::ComputeFullV ) ) );
-}
-
-//! Function to get condition number of matrix from SVD decomposition
-double getConditionNumberOfDecomposedMatrix( const Eigen::JacobiSVD< Eigen::MatrixXd >& singularValueDecomposition )
-{
-    Eigen::VectorXd singularValues = singularValueDecomposition.singularValues( );
-    return singularValues( 0 ) / singularValues( singularValues.rows( ) - 1 );
+    return getConditionNumberOfDecomposedMatrix( ( designMatrix.jacobiSvd<Eigen::ComputeThinU | Eigen::ComputeFullV>( ) ) );
 }
 
 //! Solve system of equations with SVD decomposition, checking condition number in the process
@@ -41,7 +34,7 @@ Eigen::VectorXd solveSystemOfEquationsWithSvd( const Eigen::MatrixXd matrixToInv
                                                const Eigen::VectorXd rightHandSideVector,
                                                const double limitConditionNumberForWarning )
 {
-    Eigen::JacobiSVD< Eigen::MatrixXd > svdDecomposition = matrixToInvert.jacobiSvd( Eigen::ComputeThinU | Eigen::ComputeThinV );
+    Eigen::JacobiSVD< Eigen::MatrixXd, Eigen::ComputeThinU | Eigen::ComputeThinV > svdDecomposition = matrixToInvert.jacobiSvd<Eigen::ComputeThinU | Eigen::ComputeThinV>( );
     if( limitConditionNumberForWarning == limitConditionNumberForWarning )
     {
         double conditionNumber = getConditionNumberOfDecomposedMatrix( svdDecomposition );

--- a/src/tudat/simulation/estimation_setup/createCartesianStatePartials.cpp
+++ b/src/tudat/simulation/estimation_setup/createCartesianStatePartials.cpp
@@ -221,8 +221,8 @@ std::map< observation_models::LinkEndType, std::shared_ptr< CartesianStatePartia
                             }
                             if( currentBody->getGroundStationMap( ).count( linkEndIterator->second.stationName_ ) == 0 )
                             {
-                                std::runtime_error( "Warning, ground station " + linkEndIterator->second.stationName_ +
-                                                    "not found when making ground station position position partial" );
+                                throw std::runtime_error( "Warning, ground station " + linkEndIterator->second.stationName_ +
+                                                          "not found when making ground station position position partial" );
                             }
 
                             // Create partial object.

--- a/tests/test_tudat/src/astro/system_models/unitTestRTGAcceleration.cpp
+++ b/tests/test_tudat/src/astro/system_models/unitTestRTGAcceleration.cpp
@@ -215,7 +215,6 @@ BOOST_AUTO_TEST_CASE( testRTGAcceleration )
     rtgAccelerationModel->updateMembers( newTestTime );
 
     rotationMatrixFromFunction = timeDependentRotationFunction( newTestTime );
-    std::exp( -decayScaleFactor * ( newTestTime - referenceEpoch ) );
     expectedAcceleration = rtgForceVector * std::exp( -decayScaleFactor * ( newTestTime - referenceEpoch ) );
     expectedAcceleration = rotationMatrixFromFunction * expectedAcceleration / initialVehicleMass;
 

--- a/tests/test_tudat/src/io/unitTestIfmsFileReader.cpp
+++ b/tests/test_tudat/src/io/unitTestIfmsFileReader.cpp
@@ -26,6 +26,7 @@
 #include "tudat/io/readTrackingTxtFile.h"
 #include "tudat/simulation/estimation_setup/processTrackingTxtFile.h"
 #include "tudat/astro/observation_models/linkTypeDefs.h"
+#include "tudat/astro/observation_models/observableTypes.h"
 
 // Some simplifications for shorter lines
 using namespace tudat::input_output;
@@ -97,10 +98,10 @@ BOOST_AUTO_TEST_CASE( testIfmsFileReader )
             }
         }
 
-        setTrackingDataInformationInBodies( processedIfmsFiles, bodies, { dsn_n_way_averaged_doppler } );
+        setTrackingDataInformationInBodies( processedIfmsFiles, bodies,  ObservableType::dsn_n_way_averaged_doppler  );
 
         auto observationCollection = observation_models::createTrackingTxtFilesObservationCollection< double, Time >(
-                processedIfmsFiles, { dsn_n_way_averaged_doppler } );
+                processedIfmsFiles, { ObservableType::dsn_n_way_averaged_doppler } );
 
         std::vector< Time > observationTimes = observationCollection->getConcatenatedTimeVector( );
         Eigen::VectorXd observationValues = observationCollection->getObservationVector( );

--- a/tests/test_tudat/src/math/integrators/unitTestIntegratorOrders.cpp
+++ b/tests/test_tudat/src/math/integrators/unitTestIntegratorOrders.cpp
@@ -254,7 +254,7 @@ BOOST_AUTO_TEST_CASE( testFixedMultiStageNumericalIntegratorOrder )
             {
                 BOOST_CHECK( meanOrder > expectedHigherOrders.at( j ) - 0.5 );
                 BOOST_CHECK( meanOrder < expectedHigherOrders.at( j ) + 1.0 );
-                BOOST_CHECK( standardDeviationOrder < ( j == 6 ) ? 1.0 : 0.4 );
+                BOOST_CHECK( standardDeviationOrder < ( ( j == 6 ) ? 1.0 : 0.4 ) );
             }
         }
     }


### PR DESCRIPTION
- fix apple clang compiler warnings
- export compile commands for clang builds. this is useful for static analysis, e.g. as provided by clangd