### PR TITLE
Fix JacobiSVD usage and coma_model stub packaging

### DIFF
--- a/src/tudat/math/basic/leastSquaresEstimation.cpp
+++ b/src/tudat/math/basic/leastSquaresEstimation.cpp
@@ -26,7 +26,7 @@ namespace linear_algebra
 //! Function to get condition number of matrix (using SVD decomposition)
 double getConditionNumberOfDesignMatrix( const Eigen::MatrixXd designMatrix )
 {
-    return getConditionNumberOfDecomposedMatrix( ( designMatrix.jacobiSvd<Eigen::ComputeThinU | Eigen::ComputeFullV>( ) ) );
+    return getConditionNumberOfDecomposedMatrix( ( designMatrix.jacobiSvd( Eigen::ComputeThinU | Eigen::ComputeFullV ) ) );
 }
 
 //! Solve system of equations with SVD decomposition, checking condition number in the process
@@ -34,7 +34,7 @@ Eigen::VectorXd solveSystemOfEquationsWithSvd( const Eigen::MatrixXd matrixToInv
                                                const Eigen::VectorXd rightHandSideVector,
                                                const double limitConditionNumberForWarning )
 {
-    Eigen::JacobiSVD< Eigen::MatrixXd, Eigen::ComputeThinU | Eigen::ComputeThinV > svdDecomposition = matrixToInvert.jacobiSvd<Eigen::ComputeThinU | Eigen::ComputeThinV>( );
+    Eigen::JacobiSVD< Eigen::MatrixXd > svdDecomposition = matrixToInvert.jacobiSvd( Eigen::ComputeThinU | Eigen::ComputeThinV );
     if( limitConditionNumberForWarning == limitConditionNumberForWarning )
     {
         double conditionNumber = getConditionNumberOfDecomposedMatrix( svdDecomposition );

--- a/src/tudatpy/data/coma_model/__init__.py
+++ b/src/tudatpy/data/coma_model/__init__.py
@@ -1,0 +1,1 @@
+from tudatpy.kernel.data.coma_model import *


### PR DESCRIPTION
Updates JacobiSVD calls to pass computation options as runtime arguments for Eigen compatibility.

  Also adds the missing `tudatpy.data.coma_model` package wrapper so stub generation creates the expected `coma_model` directory.