### PR TITLE
Update GH action versions to latest release to avoid deprecation notice

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -80,11 +80,11 @@ jobs:
             compilers: {c: gcc, cxx: g++}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup conda environment
       # This step creates an empty conda environment with the name 'tudat' and activates it. Use latest conda version.
-      uses: conda-incubator/setup-miniconda@v3
+      uses: conda-incubator/setup-miniconda@v4
       with:
            activate-environment: tudat
            auto-activate: false

--- a/.github/workflows/bump_dev_version_nightly.yml
+++ b/.github/workflows/bump_dev_version_nightly.yml
@@ -33,7 +33,7 @@ jobs:
         outputs:
           should_run: ${{ steps.should_bump_version.outputs.should_run }}
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@v6
             with:
               ref: develop  # Check the latest commits on the develop branch of tudatpy repository
           - name: print latest_commit
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: develop
 
@@ -88,7 +88,7 @@ jobs:
     name: bump version and create tag in tudatpy-feedstock
     steps:
         - name: checkout tudatpy-feedstock
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
           with:
             repository: tudat-team/tudatpy-feedstock
             token: ${{ secrets.BUMP_VERSION_NIGHTLY }}


### PR DESCRIPTION
Node 20 will be deprecated in June, see https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
This PR updates all GH actions to the latest major versions, which fixes the deprecations warnings.