### PR TITLE
Fix frozen station rotation in direct-from-metric proper-time propaga…

### DIFF
--- a/src/tudat/simulation/propagation_setup/createEnvironmentUpdater.cpp
+++ b/src/tudat/simulation/propagation_setup/createEnvironmentUpdater.cpp
@@ -450,6 +450,20 @@ std::map< propagators::EnvironmentModelsToUpdate, std::vector< std::string > > c
                 environmentModelsToUpdate[ spherical_harmonic_gravity_field_update ].push_back( shList.at( i ) );
             }
 
+            // When the reference point is a ground station, the direct-from-metric path evaluates the
+            // metric at the station's inertial BCRS state, which is built from the central body's
+            // *stored* rotation (Body::getCurrentRotationToGlobalFrame, see
+            // createReferencePointStateFunctionDuringPropagation). That stored rotation is only
+            // refreshed by a body_rotational_state_update; without it the station's body-fixed->inertial
+            // rotation is frozen at the initial epoch and the integrated proper time picks up a ~us
+            // diurnal error. (A spherical-harmonic central body masks this because the SH-field update
+            // already pulls in the rotation; a point-mass central body does not.)
+            if( stateDerivativeModel->getReferencePointId( ).second != "" )
+            {
+                environmentModelsToUpdate[ body_rotational_state_update ].push_back(
+                        stateDerivativeModel->getReferencePointId( ).first );
+            }
+
             break;
         }
         default:

--- a/tests/test_tudat/src/astro/propagators/unitTestRelativisticTimePropagation.cpp
+++ b/tests/test_tudat/src/astro/propagators/unitTestRelativisticTimePropagation.cpp
@@ -652,10 +652,12 @@ BOOST_AUTO_TEST_CASE( testProgressiveComplexityDiagnostic )
     }
 }
 
-// Original strict one-year test: Earth equator station, 100 s step,
-// detrended residual amplitude < 6 ns (matches Dominic's baseline after
-// the body-fixed vs inertial station-position fix at
-// setNumericallyIntegratedStates.h:1259).
+// Strict one-year test: Earth equator station, 100 s step. Detrended residual amplitude
+// observed at ~0.1 ns after the direct-from-metric station-rotation fix
+// (createEnvironmentUpdater.cpp, direct_from_metric case, now requesting
+// body_rotational_state_update for the reference body); tolerance 1 ns gives ~10x headroom.
+// (Was ~3.9 ns before that fix, with the body-fixed vs inertial station-position fix at
+// setNumericallyIntegratedStates.h:1259 already in place.)
 BOOST_AUTO_TEST_CASE( testDirectFromMetricVsChainedPnEquatorOneYearEarthMoonSun )
 {
     loadStandardSpiceKernels( );
@@ -771,7 +773,7 @@ BOOST_AUTO_TEST_CASE( testDirectFromMetricVsChainedPnEquatorOneYearEarthMoonSun 
     residuals.reserve( sampleTimes.capacity( ) );
 
     double sumTime = 0.0, sumResidual = 0.0, sumTimeSquared = 0.0, sumTimeResidual = 0.0;
-    const double residualAmplitudeTolerance = 6.0e-9;
+    const double residualAmplitudeTolerance = 1.0e-9;
 
     for( double currentTime = initialEphemerisTime + integrationStep; currentTime <= finalEphemerisTime - integrationStep;
          currentTime += integrationStep )
@@ -808,6 +810,369 @@ BOOST_AUTO_TEST_CASE( testDirectFromMetricVsChainedPnEquatorOneYearEarthMoonSun 
 
     BOOST_CHECK( std::isfinite( amp ) );
     BOOST_CHECK_SMALL( amp, residualAmplitudeTolerance );
+}
+
+// Data-driven growing-complexity ladder comparing the direct-from-metric proper
+// time against the concatenated post-Newtonian chain (TCB->TCG first order +
+// body->topocentric). Each rung shares one configuration struct; the chain's
+// per-leg spherical-harmonic settings and the topocentric central-body SH degree
+// are derived from the single metric SH map so the two formulations stay
+// consistent by construction.
+//
+// The ladder climbs from an Earth point-mass case up to the lunar target:
+// Moon as central body (TCL at the lunar centre), Earth+Sun as perturbers, and a
+// lunar-surface station (the proper time underlying TL). The detrended residual
+// amplitude (direct - chain), with the irrelevant constant rate offset removed,
+// is the discrepancy of interest; the per-scenario note below records the
+// post-fix agreement (~10 ps on every rung) and the root cause / fix.
+BOOST_AUTO_TEST_CASE( testDirectVsChainComplexityLadder )
+{
+    loadStandardSpiceKernels( );
+
+    struct LadderScenario
+    {
+        std::string name;
+        std::string centralBody;
+        std::vector< std::string > perturbingBodies;               // external bodies for the chain (also metric bodies)
+        std::map< std::string, std::pair< int, int > > metricShOrders;  // SH degree/order per body in the metric
+        double centralBodyRadius;                                  // for the equatorial surface station
+        double durationDays;
+        double integrationStep;
+        double detrendedTolerance;                                 // <= 0 => report only (no hard assert)
+    };
+
+    const double earthRadius = 6378137.0;
+    const double moonRadius  = 1737400.0;
+
+    // Each rung is also compared against an independent analytic first-order truth rate
+    //   dtau/dt - 1 = -( 1/2 |v_st|^2 + sum_i GM_i/|r_st - r_i| ) / c^2
+    // integrated on the same grid (see "vs analytic 1st-order truth" below). Both the direct
+    // metric and the post-Newtonian chain now track that truth, and each other, to ~10 ps on
+    // every rung (Earth and Moon, point-mass and SH), including the lunar TCL/TL target (M2).
+    //
+    // This followed a fix to the direct-from-metric environment updater: for a ground-station
+    // reference point it now requests body_rotational_state_update for the central body
+    // (createEnvironmentUpdater.cpp, direct_from_metric case). Previously the station's
+    // body-fixed->inertial rotation was frozen at the initial epoch during integration, giving a
+    // ~us diurnal error on point-mass central bodies (E1 ~9.7us, M1 ~0.6us); a spherical-harmonic
+    // central body masked it because the SH-field update already pulled in the rotation. The
+    // chain was always immune (its topocentric calculator reads the rotational ephemeris directly
+    // each step). The metric VALUE itself was correct throughout (see
+    // testPointMassVsShMetricAtRotatingStation in unitTestSolarSystemMetric.cpp).
+    //
+    // Tolerances (1 ns) are hard regression guards on every rung, with ~25x headroom over the
+    // observed ~10-40 ps; the chain-vs-truth bound below is enforced identically.
+    const std::vector< LadderScenario > scenarios = {
+        { "E1_Earth_Sun_PointMass",
+          "Earth", { "Sun" }, {},
+          earthRadius, 30.0, 120.0, 1.0e-9 },
+        { "E2_Earth_Sun_EarthSH20",
+          "Earth", { "Sun" }, { { "Earth", { 20, 20 } } },
+          earthRadius, 30.0, 120.0, 1.0e-9 },
+        { "E3_Earth_SunMoon_EarthSH20_MoonSH2",
+          "Earth", { "Sun", "Moon" }, { { "Earth", { 20, 20 } }, { "Moon", { 2, 2 } } },
+          earthRadius, 30.0, 120.0, 1.0e-9 },
+        { "M1_Moon_EarthSun_PointMass",
+          "Moon", { "Earth", "Sun" }, {},
+          moonRadius, 30.0, 120.0, 1.0e-9 },
+        { "M2_Moon_EarthSun_MoonSH2",   // <- lunar target: TCL centre + TL surface, Moon SH(2,2)
+          "Moon", { "Earth", "Sun" }, { { "Moon", { 2, 2 } } },
+          moonRadius, 30.0, 120.0, 1.0e-9 }
+    };
+
+    // Configure a body's gravity field from the scenario SH map (FromFile SH when
+    // requested, point-mass otherwise) and strip time-variable gravity so the two
+    // environments are static and identical.
+    auto configureGravity = [ ]( BodyListSettings& bodySettings,
+                                 const std::string& body,
+                                 const std::map< std::string, std::pair< int, int > >& shOrders ) {
+        if( shOrders.count( body ) )
+        {
+            const int degree = shOrders.at( body ).first;
+            if( body == "Earth" )
+            {
+                bodySettings.at( body )->gravityFieldSettings =
+                        std::make_shared< FromFileSphericalHarmonicsGravityFieldSettings >( ggm02c, degree );
+            }
+            else if( body == "Moon" )
+            {
+                bodySettings.at( body )->gravityFieldSettings =
+                        std::make_shared< FromFileSphericalHarmonicsGravityFieldSettings >( lpe200, degree );
+            }
+            else
+            {
+                bodySettings.at( body )->gravityFieldSettings =
+                        std::make_shared< SpiceCentralGravityFieldSettings >( body );
+            }
+        }
+        else
+        {
+            bodySettings.at( body )->gravityFieldSettings =
+                    std::make_shared< SpiceCentralGravityFieldSettings >( body );
+        }
+        bodySettings.at( body )->bodyDeformationSettings.clear( );
+        bodySettings.at( body )->gravityFieldVariationSettings.clear( );
+    };
+
+    for( const LadderScenario& scenario : scenarios )
+    {
+        std::cout << "\n=== " << scenario.name << " ===" << std::endl;
+
+        const double duration = scenario.durationDays * physical_constants::JULIAN_DAY;
+        const double initialEphemerisTime = -0.5 * duration;
+        const double finalEphemerisTime = 0.5 * duration;
+        const double integrationStep = scenario.integrationStep;
+        const double buffer = 5.0 * integrationStep;
+        const std::string stationName = "LadderStation";
+
+        // Body list: central body + perturbers (unique), metric evaluates over all of them.
+        std::vector< std::string > bodyNames{ scenario.centralBody };
+        for( const std::string& body : scenario.perturbingBodies )
+        {
+            if( std::find( bodyNames.begin( ), bodyNames.end( ), body ) == bodyNames.end( ) )
+            {
+                bodyNames.push_back( body );
+            }
+        }
+
+        // Derive the chain's per-leg SH config from the single metric SH map:
+        //  - TCB->TCG perturber SH: any perturber that carries SH in the metric;
+        //  - topocentric central-body SH degree: the central body's metric SH degree.
+        std::map< std::string, std::pair< int, int > > chainPerturberShOrders;
+        for( const std::string& body : scenario.perturbingBodies )
+        {
+            if( scenario.metricShOrders.count( body ) )
+            {
+                chainPerturberShOrders[ body ] = scenario.metricShOrders.at( body );
+            }
+        }
+        const int topoCentralShDegree =
+                scenario.metricShOrders.count( scenario.centralBody ) ?
+                scenario.metricShOrders.at( scenario.centralBody ).first : 0;
+
+        auto bodySettings = getDefaultBodySettings(
+                bodyNames, initialEphemerisTime - buffer, finalEphemerisTime + buffer );
+        // Sun always a point mass; other bodies per the SH map.
+        bodySettings.at( "Sun" )->gravityFieldSettings = std::make_shared< SpiceCentralGravityFieldSettings >( "Sun" );
+        bodySettings.at( "Sun" )->bodyDeformationSettings.clear( );
+        bodySettings.at( "Sun" )->gravityFieldVariationSettings.clear( );
+        for( const std::string& body : bodyNames )
+        {
+            if( body != "Sun" )
+            {
+                configureGravity( bodySettings, body, scenario.metricShOrders );
+            }
+        }
+
+        const Eigen::Vector3d equatorStationPosition =
+                ( Eigen::Vector3d( ) <<
+                  scenario.centralBodyRadius / std::sqrt( 2.0 ),
+                  scenario.centralBodyRadius / std::sqrt( 2.0 ),
+                  0.0 ).finished( );
+        std::map< std::pair< std::string, std::string >, Eigen::Vector3d > groundStations;
+        groundStations[ std::make_pair( scenario.centralBody, stationName ) ] = equatorStationPosition;
+
+        SystemOfBodies bodiesDirect = createSystemOfBodies( bodySettings );
+        SystemOfBodies bodiesPn = createSystemOfBodies( bodySettings );
+        createGroundStations( bodiesDirect, groundStations );
+        createGroundStations( bodiesPn, groundStations );
+
+        for( const std::string& body : bodyNames )
+        {
+            if( bodiesDirect.doesBodyExist( body ) )
+            {
+                bodiesDirect.getBody( body )->setStateFromEphemeris( initialEphemerisTime );
+            }
+            if( bodiesPn.doesBodyExist( body ) )
+            {
+                bodiesPn.getBody( body )->setStateFromEphemeris( initialEphemerisTime );
+            }
+        }
+        bodiesDirect.getBody( scenario.centralBody )->setCurrentRotationalStateToLocalFrameFromEphemeris( initialEphemerisTime );
+        bodiesPn.getBody( scenario.centralBody )->setCurrentRotationalStateToLocalFrameFromEphemeris( initialEphemerisTime );
+
+        auto terminationSettings = std::make_shared< PropagationTimeTerminationSettings >( finalEphemerisTime );
+        auto intSetDirect = numerical_integrators::rungeKutta4SettingsDeprecated( initialEphemerisTime, integrationStep );
+        auto intSetTcb = numerical_integrators::rungeKutta4SettingsDeprecated( initialEphemerisTime, integrationStep );
+        auto intSetTopo = numerical_integrators::rungeKutta4SettingsDeprecated( initialEphemerisTime, integrationStep );
+
+        // --- Direct-from-metric: SolarSystemMetric over all bodies, evaluated at the station. ---
+        auto metricSettings = std::make_shared< SolarSystemSpaceTimeMetricSettings >(
+                bodyNames,
+                std::vector< std::string >( ),
+                scenario.metricShOrders,
+                std::vector< std::string >( ),
+                false );
+        auto baseMetric = createSpaceTimeMetric( metricSettings, bodiesDirect );
+        evaluatedMetricObjects.clear( );
+        evaluatedMetricObjects[ std::make_pair( scenario.centralBody, stationName ) ] = baseMetric->Clone( );
+
+        auto directFromMetricSettings = std::make_shared< DirectRelativisticTimePropagatorSettings< double, double > >(
+                std::make_pair( scenario.centralBody, stationName ),
+                initialEphemerisTime, intSetDirect, terminationSettings );
+        directFromMetricSettings->getOutputSettings( )->setIntegratedResult( true );
+        SingleArcDynamicsSimulator< double > directDynamicsSimulator( bodiesDirect, directFromMetricSettings, true );
+
+        // --- PN chain: TCB->TCG (first order) then body->topocentric. ---
+        auto firstOrderPnSettings =
+                std::make_shared< FirstOrderBodycentricRelativisticTimePropagatorSettings< double, double > >(
+                        scenario.centralBody, scenario.perturbingBodies,
+                        initialEphemerisTime, intSetTcb, terminationSettings, chainPerturberShOrders );
+        firstOrderPnSettings->getOutputSettings( )->setIntegratedResult( true );
+
+        Eigen::Matrix< double, Eigen::Dynamic, 1 > initialRelativisticState =
+                Eigen::Matrix< double, Eigen::Dynamic, 1 >::Zero( 1 );
+        auto bodyToTopoSettings =
+                std::make_shared< BodycenteredToTopocentricTimePropagatorSettings< double, double > >(
+                        std::make_pair( scenario.centralBody, stationName ),
+                        false,  // acceleration term off (IBP-paired with the -v_E.r/c^2 direct correction)
+                        topoCentralShDegree,
+                        false,
+                        scenario.perturbingBodies,
+                        initialRelativisticState,
+                        initialEphemerisTime, intSetTopo, terminationSettings );
+        bodyToTopoSettings->getOutputSettings( )->setIntegratedResult( true );
+
+        SingleArcDynamicsSimulator< double > barycentricPnDynamicsSimulator( bodiesPn, firstOrderPnSettings, true );
+        SingleArcDynamicsSimulator< double > topocentricPnDynamicsSimulator( bodiesPn, bodyToTopoSettings, true );
+
+        auto timeEphemerisDirect = bodiesDirect.getBody( scenario.centralBody )->getTimeScaleConverter( );
+        auto timeEphemerisPn = bodiesPn.getBody( scenario.centralBody )->getTimeScaleConverter( );
+        BOOST_REQUIRE_NE( timeEphemerisDirect, nullptr );
+        BOOST_REQUIRE_NE( timeEphemerisPn, nullptr );
+
+        const auto directFunction = timeEphemerisDirect->getTimeDifferenceFunction(
+                barycentric_coordinate_time_scale, local_proper_time_scale, stationName );
+        const auto pnFunction = timeEphemerisPn->getTimeDifferenceFunction(
+                barycentric_coordinate_time_scale, local_proper_time_scale, stationName );
+
+        // Station-position term (reported for context, NOT subtracted): the body-fixed-vs-
+        // inertial difference delta(t) = -v_C * ( R(t)*y - y ) / c^2, where v_C is the central
+        // body's barycentric velocity and R(t) its rotation to the inertial frame. The
+        // converters already apply this correction on the SH path (raw residual << |delta|);
+        // it is shown only to gauge whether a rung's residual is dominated by it.
+        auto centralEphemeris = bodiesDirect.getBody( scenario.centralBody )->getEphemeris( );
+        auto centralRotation = bodiesDirect.getBody( scenario.centralBody )->getRotationalEphemeris( );
+        const double inv_c2 = physical_constants::INVERSE_SQUARE_SPEED_OF_LIGHT;
+        auto stationPositionTerm = [ & ]( const double t ) {
+            const Eigen::Vector3d velocityCentral = centralEphemeris->getCartesianState( t ).segment( 3, 3 );
+            const Eigen::Matrix3d rotationToInertial = centralRotation->getRotationToBaseFrame( t ).toRotationMatrix( );
+            const Eigen::Vector3d stationInertial = rotationToInertial * equatorStationPosition;
+            return -velocityCentral.dot( stationInertial - equatorStationPosition ) * inv_c2;
+        };
+
+        std::vector< double > sampleTimes, residualsRaw, stationTermValues;
+        double maxAbsRaw = 0.0;
+        for( double currentTime = initialEphemerisTime + integrationStep;
+             currentTime <= finalEphemerisTime - integrationStep;
+             currentTime += integrationStep )
+        {
+            const double raw = directFunction( currentTime ) - pnFunction( currentTime );
+            sampleTimes.push_back( currentTime );
+            residualsRaw.push_back( raw );
+            stationTermValues.push_back( stationPositionTerm( currentTime ) );
+            maxAbsRaw = std::max( maxAbsRaw, std::fabs( raw ) );
+        }
+        BOOST_REQUIRE( !residualsRaw.empty( ) );
+
+        // Linear detrend (remove the physically irrelevant constant rate offset) and report the
+        // remaining periodic amplitude.
+        auto detrend = [ & ]( const std::vector< double >& residuals ) {
+            double sumTime = 0.0, sumResidual = 0.0, sumTimeSquared = 0.0, sumTimeResidual = 0.0;
+            for( size_t i = 0; i < sampleTimes.size( ); ++i )
+            {
+                sumTime += sampleTimes[ i ]; sumResidual += residuals[ i ];
+                sumTimeSquared += sampleTimes[ i ] * sampleTimes[ i ];
+                sumTimeResidual += sampleTimes[ i ] * residuals[ i ];
+            }
+            const double N = static_cast< double >( residuals.size( ) );
+            const double den = N * sumTimeSquared - sumTime * sumTime;
+            const double slope = std::fabs( den ) > std::numeric_limits< double >::epsilon( ) ?
+                    ( N * sumTimeResidual - sumTime * sumResidual ) / den : 0.0;
+            const double offset = ( sumResidual - slope * sumTime ) / N;
+            double amplitude = 0.0;
+            for( size_t i = 0; i < residuals.size( ); ++i )
+            {
+                amplitude = std::max( amplitude, std::fabs( residuals[ i ] - ( offset + slope * sampleTimes[ i ] ) ) );
+            }
+            return std::make_tuple( slope, offset, amplitude );
+        };
+
+        const auto [ slopeRaw, offsetRaw, amplitudeRaw ] = detrend( residualsRaw );
+        const auto [ slopeStation, offsetStation, amplitudeStation ] = detrend( stationTermValues );
+        ( void ) slopeStation; ( void ) offsetStation;
+
+        std::cout << std::scientific << std::setprecision( 3 )
+                  << "  samples=" << residualsRaw.size( ) << std::endl
+                  << "  raw (direct - chain):  slope=" << slopeRaw
+                  << " s/s  offset=" << offsetRaw << " s  max|raw|=" << maxAbsRaw
+                  << " s  det_amp=" << amplitudeRaw << " s" << std::endl
+                  << "  station-position term |delta| det_amp=" << amplitudeStation << " s (context)";
+        if( scenario.detrendedTolerance > 0.0 )
+        {
+            std::cout << "  tol=" << scenario.detrendedTolerance << " s (on raw)";
+        }
+        std::cout << std::endl;
+
+        BOOST_CHECK( std::isfinite( amplitudeRaw ) );
+        BOOST_CHECK( std::isfinite( amplitudeStation ) );
+        if( scenario.detrendedTolerance > 0.0 )
+        {
+            BOOST_CHECK_SMALL( amplitudeRaw, scenario.detrendedTolerance );
+        }
+
+        // DIAG: which side is wrong? Reconstruct the analytic first-order proper-time rate at the
+        // rotating station, rate(t) = -( 1/2 |v_st|^2 + sum_i GM_i/|r_st - r_i| ) / c^2, integrate it
+        // (trapezoid) on the same grid, and compare against BOTH converters. The correct side tracks
+        // this truth (to ~ns 2nd-order level); the buggy side shows the us-scale deviation.
+        std::vector< std::function< Eigen::Vector6d( double ) > > bodyStateFns;
+        std::vector< double > bodyGms;
+        for( const std::string& body : bodyNames )
+        {
+            bodyStateFns.push_back( [ &, body ]( double t ) {
+                return bodiesDirect.getBody( body )->getEphemeris( )->getCartesianState( t ); } );
+            bodyGms.push_back( bodiesDirect.getBody( body )->getGravityFieldModel( )->getGravitationalParameter( ) );
+        }
+        auto truthRate = [ & ]( const double t ) {
+            const Eigen::Vector6d centralState = centralEphemeris->getCartesianState( t );
+            const Eigen::Matrix3d rotationToInertial = centralRotation->getRotationToBaseFrame( t ).toRotationMatrix( );
+            const Eigen::Vector3d stationInertial = rotationToInertial * equatorStationPosition;
+            const Eigen::Vector3d omega = centralRotation->getRotationalVelocityVectorInBaseFrame( t );
+            const Eigen::Vector3d stationBcrsPos = centralState.segment( 0, 3 ) + stationInertial;
+            const Eigen::Vector3d stationBcrsVel = centralState.segment( 3, 3 ) + omega.cross( stationInertial );
+            double potential = 0.0;
+            for( size_t b = 0; b < bodyStateFns.size( ); ++b )
+            {
+                potential += bodyGms[ b ] / ( stationBcrsPos - bodyStateFns[ b ]( t ).segment( 0, 3 ) ).norm( );
+            }
+            return -( 0.5 * stationBcrsVel.squaredNorm( ) + potential ) * inv_c2;
+        };
+        std::vector< double > truthCumulative( sampleTimes.size( ), 0.0 );
+        for( size_t i = 1; i < sampleTimes.size( ); ++i )
+        {
+            truthCumulative[ i ] = truthCumulative[ i - 1 ] +
+                    0.5 * ( truthRate( sampleTimes[ i ] ) + truthRate( sampleTimes[ i - 1 ] ) ) *
+                    ( sampleTimes[ i ] - sampleTimes[ i - 1 ] );
+        }
+        std::vector< double > directVsTruth( sampleTimes.size( ) ), chainVsTruth( sampleTimes.size( ) );
+        for( size_t i = 0; i < sampleTimes.size( ); ++i )
+        {
+            directVsTruth[ i ] = directFunction( sampleTimes[ i ] ) - truthCumulative[ i ];
+            chainVsTruth[ i ]  = pnFunction( sampleTimes[ i ] ) - truthCumulative[ i ];
+        }
+        const auto [ sD, oD, ampDirectVsTruth ] = detrend( directVsTruth );
+        const auto [ sC, oC, ampChainVsTruth ] = detrend( chainVsTruth );
+        ( void ) sD; ( void ) oD; ( void ) sC; ( void ) oC;
+        std::cout << "  vs analytic 1st-order truth:  direct det_amp=" << ampDirectVsTruth
+                  << " s   chain det_amp=" << ampChainVsTruth << " s" << std::endl;
+
+        // Strong validation, enforced on EVERY rung (Earth and Moon): the post-Newtonian chain
+        // must track the independent analytic first-order proper-time integral to sub-ns. This is
+        // the cross-check that isolates the direct-from-metric point-mass defect to the direct side.
+        BOOST_CHECK( std::isfinite( ampDirectVsTruth ) );
+        BOOST_CHECK( std::isfinite( ampChainVsTruth ) );
+        BOOST_CHECK_SMALL( ampChainVsTruth, 1.0e-9 );
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END( )

--- a/tests/test_tudat/src/astro/relativity/unitTestSchwarzSchildMetric.cpp
+++ b/tests/test_tudat/src/astro/relativity/unitTestSchwarzSchildMetric.cpp
@@ -12,7 +12,9 @@
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MAIN
 
+#include <algorithm>
 #include <limits>
+#include <vector>
 
 #include <boost/test/unit_test.hpp>
 
@@ -78,6 +80,77 @@ BOOST_AUTO_TEST_CASE( testSchwarzschildMetricPerturbation )
     const Eigen::Matrix4d identityCheck = covariantMetric * contravariantMetric;
 
     TUDAT_CHECK_MATRIX_CLOSE_FRACTION( identityCheck, Eigen::Matrix4d::Identity( ), 5.0E-13 );
+}
+
+// Analytic vs numeric partials: the harmonic-Schwarzschild metric provides analytic Christoffel
+// symbols. Validate them against the defining relation
+//   Gamma^lambda_{mu nu} = 1/2 g^{lambda sigma} ( d_mu g_{sigma nu} + d_nu g_{sigma mu} - d_sigma g_{mu nu} )
+// using central finite differences of the metric. The metric is static, so d_0 g = 0 and only
+// spatial derivatives appear. The perturbation h (~1e-9) is differenced rather than the full
+// metric (~1) to avoid catastrophic roundoff in the ~1e-16 derivatives.
+BOOST_AUTO_TEST_CASE( testSchwarzschildChristoffelAgainstFiniteDifferences )
+{
+    const double earthGravitationalParameter = 3.986004418E14;
+    auto ppnParameterSet = std::make_shared< PPNParameterSet >( 1.0, 1.0 );
+    auto metric = std::make_shared< HarmonicSchwarzschildMetric >(
+            [ = ]( ) { return earthGravitationalParameter; }, ppnParameterSet, "Earth", false );
+
+    // Generic (non-symmetric, off-axis) evaluation position.
+    Eigen::Vector6d state = Eigen::Vector6d::Zero( );
+    state.segment( 0, 3 ) = ( Eigen::Vector3d( ) << 7.0E6, -3.0E6, 4.0E6 ).finished( );
+
+    metric->update( state, 0.0, true, true );
+    const std::vector< Eigen::Matrix4d > analyticChristoffel = metric->getCurrentChristoffelSymbols( );
+    const Eigen::Matrix4d contravariantMetric = metric->getCurrentContravariantMetric( );
+
+    // Spatial central differences of the metric PERTURBATION (d_0 h = 0, static metric).
+    auto perturbationAt = [ & ]( const Eigen::Vector3d& position ) {
+        Eigen::Vector6d s = state;
+        s.segment( 0, 3 ) = position;
+        metric->update( s, 0.0, true, false );
+        return metric->getCurrentCovariantMetricPeturbation( );
+    };
+    const double step = 100.0;  // m
+    std::vector< Eigen::Matrix4d > metricDerivative( 4, Eigen::Matrix4d::Zero( ) );  // d_sigma g (sigma=0 stays zero)
+    for( int axis = 0; axis < 3; ++axis )
+    {
+        Eigen::Vector3d plus = state.segment( 0, 3 ), minus = state.segment( 0, 3 );
+        plus( axis ) += step;
+        minus( axis ) -= step;
+        metricDerivative[ axis + 1 ] = ( perturbationAt( plus ) - perturbationAt( minus ) ) / ( 2.0 * step );
+    }
+
+    // Numeric Christoffel from the defining relation.
+    std::vector< Eigen::Matrix4d > numericChristoffel( 4, Eigen::Matrix4d::Zero( ) );
+    for( int lambda = 0; lambda < 4; ++lambda )
+    {
+        for( int mu = 0; mu < 4; ++mu )
+        {
+            for( int nu = 0; nu < 4; ++nu )
+            {
+                double value = 0.0;
+                for( int sigma = 0; sigma < 4; ++sigma )
+                {
+                    value += 0.5 * contravariantMetric( lambda, sigma ) *
+                            ( metricDerivative[ mu ]( sigma, nu ) + metricDerivative[ nu ]( sigma, mu )
+                            - metricDerivative[ sigma ]( mu, nu ) );
+                }
+                numericChristoffel[ lambda ]( mu, nu ) = value;
+            }
+        }
+    }
+
+    // Compare against the largest analytic Christoffel magnitude (components span 0 .. ~1e-16,
+    // so a per-element fractional tolerance is ill-conditioned on the near-zero entries).
+    double maxMagnitude = 0.0, maxDifference = 0.0;
+    for( int lambda = 0; lambda < 4; ++lambda )
+    {
+        maxMagnitude = std::max( maxMagnitude, analyticChristoffel[ lambda ].cwiseAbs( ).maxCoeff( ) );
+        maxDifference = std::max( maxDifference,
+                ( analyticChristoffel[ lambda ] - numericChristoffel[ lambda ] ).cwiseAbs( ).maxCoeff( ) );
+    }
+    BOOST_CHECK_GT( maxMagnitude, 0.0 );
+    BOOST_CHECK_SMALL( maxDifference / maxMagnitude, 1.0E-6 );
 }
 
 BOOST_AUTO_TEST_SUITE_END( )

--- a/tests/test_tudat/src/astro/relativity/unitTestSolarSystemMetric.cpp
+++ b/tests/test_tudat/src/astro/relativity/unitTestSolarSystemMetric.cpp
@@ -12,6 +12,8 @@
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MAIN
 
+#include <algorithm>
+#include <cmath>
 #include <limits>
 #include <stdexcept>
 #include <vector>
@@ -256,6 +258,203 @@ BOOST_AUTO_TEST_CASE( testSphericalHarmonicGravityInMetric )
             }
         }
     }
+}
+
+// Evaluate the metric VALUE directly (no propagator/converter) at a genuinely rotating
+// ground-station BCRS state over a day, for a point-mass central body (no SH wrapper) vs an SH
+// central body. This guards the metric-value path the direct-from-metric propagator relies on:
+//   (a) the point-mass perturbation matches the analytic post-Newtonian form at every epoch;
+//   (b) the central-body distance is rotation-invariant (constant station radius);
+//   (c) the point-mass and SH perturbations differ only by a TIME-CONSTANT (the SH J2 term),
+//       i.e. neither carries a spurious diurnal term.
+BOOST_AUTO_TEST_CASE( testPointMassVsShMetricAtRotatingStation )
+{
+    loadStandardSpiceKernels( );
+
+    const double t0 = 1.0E7;
+    const double buffer = 5.0 * 3600.0;
+    const std::vector< std::string > bodyNames{ "Sun", "Earth" };
+    const double inv_c2 = physical_constants::INVERSE_SQUARE_SPEED_OF_LIGHT;
+    const double inv_c4 = inv_c2 * inv_c2;
+
+    // Two environments sharing identical ephemerides/rotation; only Earth's gravity-field TYPE differs.
+    auto makeBodies = [ & ]( const bool earthAsPointMass ) {
+        BodyListSettings bodySettings = getDefaultBodySettings( bodyNames, t0 - buffer, t0 + 26.0 * 3600.0 + buffer );
+        bodySettings.at( "Sun" )->gravityFieldSettings = std::make_shared< SpiceCentralGravityFieldSettings >( "Sun" );
+        if( earthAsPointMass )
+        {
+            bodySettings.at( "Earth" )->gravityFieldSettings = std::make_shared< SpiceCentralGravityFieldSettings >( "Earth" );
+        }
+        bodySettings.at( "Earth" )->bodyDeformationSettings.clear( );
+        bodySettings.at( "Earth" )->gravityFieldVariationSettings.clear( );
+        return createSystemOfBodies( bodySettings );
+    };
+
+    SystemOfBodies bodiesPm = makeBodies( true );
+    SystemOfBodies bodiesSh = makeBodies( false );
+
+    auto pmMetric = createSpaceTimeMetric(
+            std::make_shared< SolarSystemSpaceTimeMetricSettings >( bodyNames,
+                                                                    std::vector< std::string >( ),
+                                                                    std::map< std::string, std::pair< int, int > >( ),
+                                                                    std::vector< std::string >( ) ),
+            bodiesPm );
+    auto shMetric = createSpaceTimeMetric(
+            std::make_shared< SolarSystemSpaceTimeMetricSettings >( bodyNames,
+                                                                    std::vector< std::string >( ),
+                                                                    std::map< std::string, std::pair< int, int > >{ { "Earth", { 2, 2 } } },
+                                                                    std::vector< std::string >( ) ),
+            bodiesSh );
+
+    const double earthGm = bodiesPm.getBody( "Earth" )->getGravityFieldModel( )->getGravitationalParameter( );
+    const double sunGm = bodiesPm.getBody( "Sun" )->getGravityFieldModel( )->getGravitationalParameter( );
+
+    const double earthRadius = 6378137.0;
+    const Eigen::Vector3d stationBodyFixed =
+            ( Eigen::Vector3d( ) << earthRadius / std::sqrt( 2.0 ), earthRadius / std::sqrt( 2.0 ), 0.0 ).finished( );
+
+    double firstH00Difference = 0.0;
+    double maxH00DifferenceVariation = 0.0;
+    for( int hour = 0; hour <= 26; ++hour )
+    {
+        const double t = t0 + hour * 3600.0;
+        for( SystemOfBodies* bodies : { &bodiesPm, &bodiesSh } )
+        {
+            bodies->getBody( "Sun" )->setStateFromEphemeris( t );
+            bodies->getBody( "Earth" )->setStateFromEphemeris( t );
+            bodies->getBody( "Earth" )->setCurrentRotationalStateToLocalFrameFromEphemeris( t );
+        }
+        auto earthRot = bodiesPm.getBody( "Earth" )->getRotationalEphemeris( );
+        const Eigen::Matrix3d R = earthRot->getRotationToBaseFrame( t ).toRotationMatrix( );
+        const Eigen::Vector3d omega = earthRot->getRotationalVelocityVectorInBaseFrame( t );
+        const Eigen::Vector6d earthState = bodiesPm.getBody( "Earth" )->getState( );
+        const Eigen::Vector6d sunState = bodiesPm.getBody( "Sun" )->getState( );
+        const Eigen::Vector3d stationInertial = R * stationBodyFixed;
+        Eigen::Vector6d stationState;
+        stationState.segment( 0, 3 ) = earthState.segment( 0, 3 ) + stationInertial;
+        stationState.segment( 3, 3 ) = earthState.segment( 3, 3 ) + omega.cross( stationInertial );
+
+        pmMetric->update( stationState, t, true, false );
+        shMetric->update( stationState, t, true, false );
+        const Eigen::Matrix4d hPm = pmMetric->getCurrentCovariantMetricPeturbation( );
+        const Eigen::Matrix4d hSh = shMetric->getCurrentCovariantMetricPeturbation( );
+
+        // (a) Point-mass perturbation vs analytic post-Newtonian form (beta=gamma=1):
+        //     h00 = 2 U/c^2 - 2 (sum U_i^2)/c^4 ;  h_ii = 2 U/c^2 ;  h_0i = -4 w_i/c^3.
+        const double uEarth = earthGm / ( stationState.segment( 0, 3 ) - earthState.segment( 0, 3 ) ).norm( );
+        const double uSun = sunGm / ( stationState.segment( 0, 3 ) - sunState.segment( 0, 3 ) ).norm( );
+        const double uTotal = uEarth + uSun;
+        const double uSquaredSum = uEarth * uEarth + uSun * uSun;
+        const Eigen::Vector3d vectorPotential = uEarth * earthState.segment( 3, 3 ) + uSun * sunState.segment( 3, 3 );
+
+        const double expectedH00 = 2.0 * ( uTotal * inv_c2 - uSquaredSum * inv_c4 );
+        BOOST_CHECK_CLOSE_FRACTION( hPm( 0, 0 ), expectedH00, 1.0E-12 );
+        for( int i = 1; i < 4; ++i )
+        {
+            BOOST_CHECK_CLOSE_FRACTION( hPm( i, i ), 2.0 * uTotal * inv_c2, 1.0E-12 );
+        }
+        const Eigen::Vector3d expectedSpaceTime = -4.0 * vectorPotential * inv_c2 / physical_constants::SPEED_OF_LIGHT;
+        TUDAT_CHECK_MATRIX_CLOSE_FRACTION( hPm.block( 1, 0, 3, 1 ), expectedSpaceTime, 1.0E-10 );
+
+        // (b) Central-body (Earth) distance is rotation-invariant: equals the station radius.
+        auto pmSolar = std::dynamic_pointer_cast< SolarSystemMetric >( pmMetric );
+        BOOST_CHECK_CLOSE_FRACTION( pmSolar->getCurrentBodyDistance( 1 ), earthRadius, 1.0E-9 );
+
+        // (c) Point-mass vs SH h00 differ only by a TIME-CONSTANT (the SH J2 term).
+        const double h00Difference = hPm( 0, 0 ) - hSh( 0, 0 );
+        if( hour == 0 )
+        {
+            firstH00Difference = h00Difference;
+        }
+        maxH00DifferenceVariation = std::max( maxH00DifferenceVariation, std::fabs( h00Difference - firstH00Difference ) );
+    }
+    // The SH J2 contribution to h00 is ~7.5e-13; its variation over a day must be far below that.
+    BOOST_CHECK_SMALL( maxH00DifferenceVariation, 1.0E-16 );
+}
+
+// Analytic vs numeric partials: the SolarSystemMetric computes analytic position- and
+// time-partials of the scalar potential (updatePotentialPartials, used to build the Christoffel
+// symbols). Validate them against central finite differences of the scalar-potential VALUE.
+BOOST_AUTO_TEST_CASE( testSolarSystemMetricPotentialPartialsAgainstFiniteDifferences )
+{
+    loadStandardSpiceKernels( );
+
+    const double t0 = 1.0E7;
+    const double buffer = 5.0 * 3600.0;
+    const std::vector< std::string > bodyNames{ "Sun", "Earth" };
+
+    BodyListSettings bodySettings = getDefaultBodySettings( bodyNames, t0 - buffer, t0 + buffer );
+    bodySettings.at( "Sun" )->gravityFieldSettings = std::make_shared< SpiceCentralGravityFieldSettings >( "Sun" );
+    bodySettings.at( "Earth" )->gravityFieldSettings = std::make_shared< SpiceCentralGravityFieldSettings >( "Earth" );
+    bodySettings.at( "Earth" )->bodyDeformationSettings.clear( );
+    bodySettings.at( "Earth" )->gravityFieldVariationSettings.clear( );
+    SystemOfBodies bodies = createSystemOfBodies( bodySettings );
+
+    auto metric = std::dynamic_pointer_cast< SolarSystemMetric >( createSpaceTimeMetric(
+            std::make_shared< SolarSystemSpaceTimeMetricSettings >( bodyNames,
+                                                                    std::vector< std::string >( ),
+                                                                    std::map< std::string, std::pair< int, int > >( ),
+                                                                    std::vector< std::string >( ) ),
+            bodies ) );
+    BOOST_REQUIRE( metric != nullptr );
+
+    auto tickBodies = [ & ]( const double t ) {
+        bodies.getBody( "Sun" )->setStateFromEphemeris( t );
+        bodies.getBody( "Earth" )->setStateFromEphemeris( t );
+    };
+
+    // Evaluation point: a fixed BCRS position offset from Earth at a low-orbit-like radius, where
+    // the scalar-potential gradient is large enough that a 1 m position step is roundoff-clean.
+    tickBodies( t0 );
+    Eigen::Vector6d evaluationState = Eigen::Vector6d::Zero( );
+    evaluationState.segment( 0, 3 ) =
+            bodies.getBody( "Earth" )->getState( ).segment( 0, 3 ) + ( Eigen::Vector3d( ) << 7.0E6, 1.0E6, 2.0E6 ).finished( );
+
+    // Analytic partials (populated by the Christoffel update).
+    metric->update( evaluationState, t0, true, true );
+    const Eigen::Vector3d analyticPositionPartial = metric->getCurrentScalarPotentialPositionPartial( );
+    const double analyticTimePartial = metric->getCurrentScalarPotentialTimePartial( );
+
+    auto scalarPotentialAt = [ & ]( const Eigen::Vector6d& state, const double t ) {
+        metric->update( state, t, true, false );
+        return metric->getCurrentScalarPotential( );
+    };
+    // 4th-order central difference: f'(x) = [ -f(x+2h) + 8 f(x+h) - 8 f(x-h) + f(x-2h) ] / (12 h).
+    auto fourthOrder = [ ]( const double fm2, const double fm1, const double fp1, const double fp2, const double h ) {
+        return ( -fp2 + 8.0 * fp1 - 8.0 * fm1 + fm2 ) / ( 12.0 * h );
+    };
+
+    // Numeric position partial: perturb the evaluation point (bodies fixed at t0).
+    const double positionStep = 1.0;  // m
+    Eigen::Vector3d numericPositionPartial;
+    tickBodies( t0 );
+    for( int axis = 0; axis < 3; ++axis )
+    {
+        auto shifted = [ & ]( const double delta ) {
+            Eigen::Vector6d s = evaluationState;
+            s( axis ) += delta;
+            return scalarPotentialAt( s, t0 );
+        };
+        numericPositionPartial( axis ) = fourthOrder( shifted( -2.0 * positionStep ),
+                                                      shifted( -positionStep ),
+                                                      shifted( positionStep ),
+                                                      shifted( 2.0 * positionStep ),
+                                                      positionStep );
+    }
+    TUDAT_CHECK_MATRIX_CLOSE_FRACTION( analyticPositionPartial, numericPositionPartial, 1.0E-7 );
+
+    // Numeric time partial: perturb time (move the bodies), evaluation point fixed.
+    const double timeStep = 1.0;  // s
+    auto potentialAtTime = [ & ]( const double dt ) {
+        tickBodies( t0 + dt );
+        return scalarPotentialAt( evaluationState, t0 + dt );
+    };
+    const double numericTimePartial = fourthOrder( potentialAtTime( -2.0 * timeStep ),
+                                                   potentialAtTime( -timeStep ),
+                                                   potentialAtTime( timeStep ),
+                                                   potentialAtTime( 2.0 * timeStep ),
+                                                   timeStep );
+    BOOST_CHECK_CLOSE_FRACTION( analyticTimePartial, numericTimePartial, 1.0E-7 );
 }
 
 BOOST_AUTO_TEST_SUITE_END( )


### PR DESCRIPTION
…tion

The direct-from-metric proper-time propagator evaluates the space-time metric at a ground station's inertial BCRS state, which is built from the central body's stored rotation (Body::getCurrentRotationToGlobalFrame, via createReferencePointStateFunctionDuringPropagation). However, the direct_from_metric case of createProperTimeEquationEnvironmentUpdaterSettings requested only body_translational_state_update and spherical_harmonic_gravity_field_update for the metric bodies, never a body_rotational_state_update for the reference body. As a result the station's body-fixed->inertial rotation was frozen at the initial epoch during integration, introducing a ~microsecond diurnal error in the integrated proper time.

A spherical-harmonic central body masked the defect (the SH-field update already pulls in the rotation update); a point-mass central body did not. The post-Newtonian chain was unaffected, since its topocentric calculator reads the rotational ephemeris directly each step.

Fix: request body_rotational_state_update for the central body whenever the direct-from-metric reference point is a ground station.

Impact: direct-from-metric vs. post-Newtonian-chain station proper time now agree, and match an independent analytic first-order reference, to ~10 ps for Earth and Moon central bodies (point-mass and spherical-harmonic). The one-year Earth equator benchmark improves from ~3.9 ns to ~0.1 ns.

Unit tests:
- unitTestSolarSystemMetric: add testPointMassVsShMetricAtRotatingStation (metric value at a rotating station: point-mass matches the analytic post-Newtonian form, distance is rotation-invariant, point-mass vs SH differ only by the constant J2 term) and testSolarSystemMetricPotentialPartialsAgainstFiniteDifferences (analytic scalar-potential position/time partials vs 4th-order finite differences).
- unitTestSchwarzSchildMetric: add testSchwarzschildChristoffelAgainstFiniteDifferences (analytic Christoffel symbols vs finite differences of the metric).
- unitTestRelativisticTimePropagation: add testDirectVsChainComplexityLadder (data-driven Earth->Moon ladder cross-checking direct vs chain vs analytic truth, hard 1 ns guards) and tighten the one-year benchmark to 1 ns.