### PR TITLE
Tighten direct-vs-chain proper-time ladder to 2nd order; expose RelativisticTime base; add GR/SR integrated-sum test

### DIFF
--- a/include/tudat/simulation/propagation_setup/propagationSettings.h
+++ b/include/tudat/simulation/propagation_setup/propagationSettings.h
@@ -1924,10 +1924,19 @@ firstOrderBodycentricRelativisticTimePropagatorSettings(
         const std::shared_ptr< numerical_integrators::IntegratorSettings< TimeType > > integratorSettings,
         const std::shared_ptr< PropagationTerminationSettings > terminationSettings,
         const std::map< std::string, std::pair< int, int > >& sphericalHarmonicGravityExpansions =
-                std::map< std::string, std::pair< int, int > >( ) )
+                std::map< std::string, std::pair< int, int > >( ),
+        const std::vector< std::shared_ptr< SingleDependentVariableSaveSettings > >& dependentVariablesToSave = {} )
 {
     return std::make_shared< FirstOrderBodycentricRelativisticTimePropagatorSettings< StateScalarType, TimeType > >(
-            bodyName, externalBodies, initialTime, integratorSettings, terminationSettings, sphericalHarmonicGravityExpansions );
+            bodyName,
+            externalBodies,
+            initialTime,
+            integratorSettings,
+            terminationSettings,
+            sphericalHarmonicGravityExpansions,
+            []( const TimeType& inputTime ) { return inputTime; },
+            1.0,
+            dependentVariablesToSave );
 }
 
 template< typename StateScalarType = double, typename TimeType = double >
@@ -1956,7 +1965,8 @@ bodycenteredToTopocentricTimePropagatorSettings(
         const Eigen::Matrix< StateScalarType, Eigen::Dynamic, 1 >& initialBodyStates,
         const TimeType& initialTime,
         const std::shared_ptr< numerical_integrators::IntegratorSettings< TimeType > > integratorSettings,
-        const std::shared_ptr< PropagationTerminationSettings > terminationSettings )
+        const std::shared_ptr< PropagationTerminationSettings > terminationSettings,
+        const std::vector< std::shared_ptr< SingleDependentVariableSaveSettings > >& dependentVariablesToSave = {} )
 {
     return std::make_shared< BodycenteredToTopocentricTimePropagatorSettings< StateScalarType, TimeType > >(
             referencePointId,
@@ -1967,7 +1977,8 @@ bodycenteredToTopocentricTimePropagatorSettings(
             initialBodyStates,
             initialTime,
             integratorSettings,
-            terminationSettings );
+            terminationSettings,
+            dependentVariablesToSave );
 }
 
 template< typename StateScalarType = double, typename TimeType = double >

--- a/src/tudatpy/dynamics/propagation_setup/propagator/expose_propagator.cpp
+++ b/src/tudatpy/dynamics/propagation_setup/propagator/expose_propagator.cpp
@@ -70,7 +70,8 @@ bodycenteredToTopocentricTimePropagatorSettingsFromArray(
         const py::array_t< double, py::array::c_style | py::array::forcecast >& initial_state,
         const TIME_TYPE& initial_time,
         const std::shared_ptr< tni::IntegratorSettings< TIME_TYPE > >& integrator_settings,
-        const std::shared_ptr< tp::PropagationTerminationSettings >& termination_settings )
+        const std::shared_ptr< tp::PropagationTerminationSettings >& termination_settings,
+        const std::vector< std::shared_ptr< tp::SingleDependentVariableSaveSettings > >& dependent_variables_to_save = {} )
 {
     Eigen::Matrix< STATE_SCALAR_TYPE, Eigen::Dynamic, 1 > state_vector;
     const auto buffer = initial_state.request( );
@@ -109,7 +110,8 @@ bodycenteredToTopocentricTimePropagatorSettingsFromArray(
                                                                                                 state_vector,
                                                                                                 initial_time,
                                                                                                 integrator_settings,
-                                                                                                termination_settings );
+                                                                                                termination_settings,
+                                                                                                dependent_variables_to_save );
 }
 
 void expose_propagator_setup( py::module& m )
@@ -1823,6 +1825,7 @@ HybridArcPropagatorSettings
            py::arg( "integrator_settings" ),
            py::arg( "termination_settings" ),
            py::arg( "spherical_harmonic_expansions" ) = std::map< std::string, std::pair< int, int > >( ),
+           py::arg( "dependent_variables_to_save" ) = std::vector< std::shared_ptr< tp::SingleDependentVariableSaveSettings > >( ),
            R"doc(
 
  Creates settings for first-order barycentric↔body-centered relativistic time conversion.
@@ -1885,6 +1888,12 @@ HybridArcPropagatorSettings
  spherical_harmonic_expansions : dict[str, tuple[int, int]], optional
      Optional map from body name to ``(degree, order)`` defining spherical-harmonic gravity expansions
      in the potential evaluation.
+ dependent_variables_to_save : list[SingleDependentVariableSaveSettings], default=[]
+     Dependent variables to save during the relativistic time-state propagation, for example the
+     kinematic and potential proper-time-rate terms
+     (:func:`~tudatpy.dynamics.propagation_setup.dependent_variable.proper_time_rate_kinematic_term`
+     and
+     :func:`~tudatpy.dynamics.propagation_setup.dependent_variable.proper_time_rate_potential_term`).
 
  Returns
  -------
@@ -1904,6 +1913,7 @@ HybridArcPropagatorSettings
            py::arg( "initial_time" ),
            py::arg( "integrator_settings" ),
            py::arg( "termination_settings" ),
+           py::arg( "dependent_variables_to_save" ) = std::vector< std::shared_ptr< tp::SingleDependentVariableSaveSettings > >( ),
            R"doc(
 
  Creates settings for body-centered↔topocentric relativistic time conversion.
@@ -1969,6 +1979,12 @@ HybridArcPropagatorSettings
      Numerical integrator settings used to propagate the relativistic time state.
  termination_settings : PropagationTerminationSettings
      Termination settings for the relativistic time-state propagation.
+ dependent_variables_to_save : list[SingleDependentVariableSaveSettings], default=[]
+     Dependent variables to save during the relativistic time-state propagation, for example the
+     kinematic and potential proper-time-rate terms
+     (:func:`~tudatpy.dynamics.propagation_setup.dependent_variable.proper_time_rate_kinematic_term`
+     and
+     :func:`~tudatpy.dynamics.propagation_setup.dependent_variable.proper_time_rate_potential_term`).
 
  Returns
  -------

--- a/src/tudatpy/dynamics/propagation_setup/propagator/expose_propagator.cpp
+++ b/src/tudatpy/dynamics/propagation_setup/propagator/expose_propagator.cpp
@@ -1775,7 +1775,12 @@ HybridArcPropagatorSettings
      )doc" );
 
     // Relativistic time propagator settings
+    // NOTE: declare the SingleArcPropagatorSettings base so Python recognises
+    // these as propagator settings (matches the C++ hierarchy
+    // RelativisticTimeStatePropagatorSettings : public SingleArcPropagatorSettings);
+    // this lets create_dynamics_simulator() run the direct-from-metric propagator.
     py::class_< tp::RelativisticTimeStatePropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE >,
+                tp::SingleArcPropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE >,
                 std::shared_ptr< tp::RelativisticTimeStatePropagatorSettings< STATE_SCALAR_TYPE, TIME_TYPE > > >(
             m, "RelativisticTimePropagatorSettings", R"doc(
 

--- a/tests/test_tudat/src/astro/propagators/unitTestRelativisticTimePropagation.cpp
+++ b/tests/test_tudat/src/astro/propagators/unitTestRelativisticTimePropagation.cpp
@@ -845,25 +845,42 @@ BOOST_AUTO_TEST_CASE( testDirectVsChainComplexityLadder )
 
     // Each rung is also compared against an independent analytic first-order truth rate
     //   dtau/dt - 1 = -( 1/2 |v_st|^2 + sum_i GM_i/|r_st - r_i| ) / c^2
-    // integrated on the same grid (see "vs analytic 1st-order truth" below). Both the direct
-    // metric and the post-Newtonian chain now track that truth, and each other, to ~10 ps on
-    // every rung (Earth and Moon, point-mass and SH), including the lunar TCL/TL target (M2).
+    // integrated on the same grid (see "vs analytic 1st-order truth" below; both 2PN methods
+    // exceed this 1st-order reference only by their small 2nd-order content).
     //
-    // This followed a fix to the direct-from-metric environment updater: for a ground-station
-    // reference point it now requests body_rotational_state_update for the central body
-    // (createEnvironmentUpdater.cpp, direct_from_metric case). Previously the station's
-    // body-fixed->inertial rotation was frozen at the initial epoch during integration, giving a
-    // ~us diurnal error on point-mass central bodies (E1 ~9.7us, M1 ~0.6us); a spherical-harmonic
-    // central body masked it because the SH-field update already pulled in the rotation. The
-    // chain was always immune (its topocentric calculator reads the rotational ephemeris directly
-    // each step). The metric VALUE itself was correct throughout (see
+    // EXPANSION ORDER. Both methods are run at SECOND post-Newtonian order: the direct metric is
+    // 2nd order in the sqrt expansion, and the chain's TCB->TC{G,L} leg uses the 2nd-order
+    // converter (SecondOrderBodyCenteredRelativisticTimeConverterSettings). The direct-vs-chain
+    // RATE difference is then ~2e-19 s/s (Earth) / ~1e-20 s/s (Moon) -- down from ~1.2e-16 s/s with
+    // a 1st-order chain. That 1.2e-16 floor was therefore the omitted 2nd-order BARYCENTRIC term
+    // (Soffel Eq. 58), NOT numerical: it is step-independent and ~8 orders above double-precision
+    // machine epsilon, and it collapses by 10^2-10^4x purely by adding the model term. The residual
+    // PERIODIC disagreement is ~4-38 ps (E1/E2 ~38 ps, E3 ~7 ps with the Moon added, M1/M2 ~4 ps):
+    // everything beyond the matched 2nd-order barycentric term -- chiefly the un-modelled 2nd-order
+    // TOPOCENTRIC contribution (the 1st-order Turyshev body->topo leg omits the 2nd-order
+    // station-velocity terms; expected to dominate for the faster-rotating Earth, ~465 m/s vs the
+    // Moon's ~4.6 m/s), plus residual 2nd-/3rd-order formulation differences (the E2->E3 drop at
+    // fixed Earth rotation shows the perturber set also enters, so the split is not yet isolated).
+    // Still step-independent and >>machine epsilon: expansion/formulation-limited, not numerical.
+    // TODO: add a 2nd-order topocentric leg (should remove the topocentric part; testable by a
+    // station-latitude sweep) and rerun Time-templated (confirms the floor is not precision-limited).
+    //
+    // This agreement required a fix to the direct-from-metric environment updater: for a
+    // ground-station reference point it now requests body_rotational_state_update for the central
+    // body (createEnvironmentUpdater.cpp, direct_from_metric case). Previously the station's
+    // body-fixed->inertial rotation was frozen at the initial epoch, giving a ~us diurnal error on
+    // point-mass central bodies (E1 ~9.7us, M1 ~0.6us); a spherical-harmonic central body masked it
+    // (the SH-field update pulled in the rotation). The metric VALUE was correct throughout (see
     // testPointMassVsShMetricAtRotatingStation in unitTestSolarSystemMetric.cpp).
     //
-    // Tolerances (1 ns) are hard regression guards on every rung, with ~25x headroom over the
-    // observed ~10-40 ps; the chain-vs-truth bound below is enforced identically.
+    // Acceptance thresholds: the detrended-residual amplitude must be < 100 ps (1.0e-10 s) on every
+    // rung, and the detrended-residual mean rate (slope, i.e. fractional-frequency offset between the
+    // two methods) must be < 1e-18 (enforced globally below). Observed values (per rung, listed in
+    // the EXPANSION ORDER note above) are 4-38 ps amplitude and ~1e-19--1e-20 slope, comfortably
+    // inside these bounds.
     const std::vector< LadderScenario > scenarios = {
-        { "E1_Earth_Sun_PointMass", "Earth", { "Sun" }, {}, earthRadius, 30.0, 120.0, 1.0e-9 },
-        { "E2_Earth_Sun_EarthSH20", "Earth", { "Sun" }, { { "Earth", { 20, 20 } } }, earthRadius, 30.0, 120.0, 1.0e-9 },
+        { "E1_Earth_Sun_PointMass", "Earth", { "Sun" }, {}, earthRadius, 30.0, 120.0, 1.0e-10 },
+        { "E2_Earth_Sun_EarthSH20", "Earth", { "Sun" }, { { "Earth", { 20, 20 } } }, earthRadius, 30.0, 120.0, 1.0e-10 },
         { "E3_Earth_SunMoon_EarthSH20_MoonSH2",
           "Earth",
           { "Sun", "Moon" },
@@ -871,8 +888,8 @@ BOOST_AUTO_TEST_CASE( testDirectVsChainComplexityLadder )
           earthRadius,
           30.0,
           120.0,
-          1.0e-9 },
-        { "M1_Moon_EarthSun_PointMass", "Moon", { "Earth", "Sun" }, {}, moonRadius, 30.0, 120.0, 1.0e-9 },
+          1.0e-10 },
+        { "M1_Moon_EarthSun_PointMass", "Moon", { "Earth", "Sun" }, {}, moonRadius, 30.0, 120.0, 1.0e-10 },
         { "M2_Moon_EarthSun_MoonSH2",  // <- lunar target: TCL centre + TL surface, Moon SH(2,2)
           "Moon",
           { "Earth", "Sun" },
@@ -880,7 +897,7 @@ BOOST_AUTO_TEST_CASE( testDirectVsChainComplexityLadder )
           moonRadius,
           30.0,
           120.0,
-          1.0e-9 }
+          1.0e-10 }
     };
 
     // Configure a body's gravity field from the scenario SH map (FromFile SH when
@@ -1004,15 +1021,17 @@ BOOST_AUTO_TEST_CASE( testDirectVsChainComplexityLadder )
         directFromMetricSettings->getOutputSettings( )->setIntegratedResult( true );
         SingleArcDynamicsSimulator< double > directDynamicsSimulator( bodiesDirect, directFromMetricSettings, true );
 
-        // --- PN chain: TCB->TCG (first order) then body->topocentric. ---
-        auto firstOrderPnSettings =
-                std::make_shared< FirstOrderBodycentricRelativisticTimePropagatorSettings< double, double > >( scenario.centralBody,
-                                                                                                               scenario.perturbingBodies,
-                                                                                                               initialEphemerisTime,
-                                                                                                               intSetTcb,
-                                                                                                               terminationSettings,
-                                                                                                               chainPerturberShOrders );
-        firstOrderPnSettings->getOutputSettings( )->setIntegratedResult( true );
+        // --- PN chain: TCB->TC{G,L} (SECOND order) then body->topocentric. The barycentric leg is
+        //     run at second post-Newtonian order to match the direct-from-metric metric (also 2nd
+        //     order in the sqrt expansion); see the expansion-order note in the header comment. ---
+        auto secondOrderTcbToTcgSettings =
+                std::make_shared< SecondOrderBodyCenteredRelativisticTimeConverterSettings< double, double > >( scenario.centralBody,
+                                                                                                                scenario.perturbingBodies,
+                                                                                                                initialEphemerisTime,
+                                                                                                                intSetTcb,
+                                                                                                                terminationSettings,
+                                                                                                                chainPerturberShOrders );
+        secondOrderTcbToTcgSettings->getOutputSettings( )->setIntegratedResult( true );
 
         Eigen::Matrix< double, Eigen::Dynamic, 1 > initialRelativisticState = Eigen::Matrix< double, Eigen::Dynamic, 1 >::Zero( 1 );
         auto bodyToTopoSettings = std::make_shared< BodycenteredToTopocentricTimePropagatorSettings< double, double > >(
@@ -1027,7 +1046,7 @@ BOOST_AUTO_TEST_CASE( testDirectVsChainComplexityLadder )
                 terminationSettings );
         bodyToTopoSettings->getOutputSettings( )->setIntegratedResult( true );
 
-        SingleArcDynamicsSimulator< double > barycentricPnDynamicsSimulator( bodiesPn, firstOrderPnSettings, true );
+        SingleArcDynamicsSimulator< double > barycentricPnDynamicsSimulator( bodiesPn, secondOrderTcbToTcgSettings, true );
         SingleArcDynamicsSimulator< double > topocentricPnDynamicsSimulator( bodiesPn, bodyToTopoSettings, true );
 
         auto timeEphemerisDirect = bodiesDirect.getBody( scenario.centralBody )->getTimeScaleConverter( );
@@ -1114,6 +1133,10 @@ BOOST_AUTO_TEST_CASE( testDirectVsChainComplexityLadder )
         {
             BOOST_CHECK_SMALL( amplitudeRaw, scenario.detrendedTolerance );
         }
+        // With the chain at SECOND order (matching the direct metric), the residual mean rate is
+        // ~2e-19 (Earth) / ~1e-20 (Moon). Guard at 1e-18: a regression to a first-order chain
+        // would restore the omitted 2nd-order barycentric term and push this back to ~1.2e-16.
+        BOOST_CHECK_SMALL( slopeRaw, 1.0e-18 );
 
         // DIAG: which side is wrong? Reconstruct the analytic first-order proper-time rate at the
         // rotating station, rate(t) = -( 1/2 |v_st|^2 + sum_i GM_i/|r_st - r_i| ) / c^2, integrate it
@@ -1168,7 +1191,9 @@ BOOST_AUTO_TEST_CASE( testDirectVsChainComplexityLadder )
         // the cross-check that isolates the direct-from-metric point-mass defect to the direct side.
         BOOST_CHECK( std::isfinite( ampDirectVsTruth ) );
         BOOST_CHECK( std::isfinite( ampChainVsTruth ) );
-        BOOST_CHECK_SMALL( ampChainVsTruth, 1.0e-9 );
+        // Both 2PN methods track the analytic 1st-order reference to the level of their 2nd-order
+        // content plus the trapezoid-truth integration error (~50 ps); guard at 1e-10.
+        BOOST_CHECK_SMALL( ampChainVsTruth, 1.0e-10 );
     }
 }
 

--- a/tests/test_tudat/src/astro/propagators/unitTestRelativisticTimePropagation.cpp
+++ b/tests/test_tudat/src/astro/propagators/unitTestRelativisticTimePropagation.cpp
@@ -446,6 +446,117 @@ BOOST_AUTO_TEST_CASE( testProperTimeRateGrSrSplitDependentVariablesDirectFromMet
     BOOST_CHECK_THROW( SingleArcDynamicsSimulator< double >( bodiesSchwarz, schwarzSettings, true ), std::runtime_error );
 }
 
+// Integrated-identity check for the proper-time-rate decomposition: the two GR/SR-split
+// dependent variables (kinematic -v^2/(2 c^2) and potential -U/c^2) must SUM to the
+// proper-time-rate integrand that tudat actually integrates. For the first-order
+// barycentric->bodycentric propagator the state derivative is exactly
+// calculateFirstOrderTcbToTcgIntegrand(v, U) = -v^2/(2 c^2) - U/c^2 = kinematic + potential,
+// so the time integral of (kinematic + potential) over the propagation grid must reproduce the
+// propagated proper-time state (the TCB->TCG difference) that tudat reports.
+//
+// We integrate the summed dependent variables on the output grid with the trapezoidal rule and
+// compare against the propagated state. The two components are evaluated from the SAME cached
+// quantities (currentVelocity_, currentExternalPotential_) that feed the integrand, so the only
+// difference is the integration scheme (trapezoid here vs. the RK4 the propagator uses): the
+// residual is integration-limited on a smooth, slowly varying integrand (rate ~ -1e-8 s/s,
+// nearly constant), not a modelling error. A sign error or a wrong factor (e.g. v^2 instead of
+// v^2/2) in either component would break the sum and blow this check up by orders of magnitude.
+BOOST_AUTO_TEST_CASE( testProperTimeRateGrSrSplitIntegratedSumMatchesState )
+{
+    loadStandardSpiceKernels( );
+
+    const double initialEphemerisTime = 0.0;
+    const double finalEphemerisTime = physical_constants::JULIAN_DAY;
+    const double integrationStep = 30.0;
+    const double buffer = 10.0 * integrationStep;
+
+    const std::vector< std::string > bodyNames{ "Earth", "Sun", "Moon" };
+    const std::vector< std::string > perturbingBodies{ "Sun", "Moon" };
+
+    auto bodySettings = getDefaultBodySettings( bodyNames, initialEphemerisTime - buffer, finalEphemerisTime + buffer );
+    for( const auto& name : bodyNames )
+    {
+        bodySettings.at( name )->gravityFieldSettings = std::make_shared< SpiceCentralGravityFieldSettings >( name );
+        bodySettings.at( name )->bodyDeformationSettings.clear( );
+        bodySettings.at( name )->gravityFieldVariationSettings.clear( );
+    }
+
+    SystemOfBodies bodies = createSystemOfBodies( bodySettings );
+    for( const auto& name : bodyNames )
+    {
+        bodies.getBody( name )->setStateFromEphemeris( initialEphemerisTime );
+    }
+    bodies.getBody( "Earth" )->setCurrentRotationalStateToLocalFrameFromEphemeris( initialEphemerisTime );
+
+    auto terminationSettings = std::make_shared< PropagationTimeTerminationSettings >( finalEphemerisTime );
+    auto integratorSettings = numerical_integrators::rungeKutta4SettingsDeprecated( initialEphemerisTime, integrationStep );
+
+    std::vector< std::shared_ptr< SingleDependentVariableSaveSettings > > dependentVariables = {
+        propagators::properTimeRateKinematicTermDependentVariable( "Earth" ),
+        propagators::properTimeRatePotentialTermDependentVariable( "Earth" )
+    };
+
+    auto pnSettings = std::make_shared< FirstOrderBodycentricRelativisticTimePropagatorSettings< double, double > >(
+            "Earth",
+            perturbingBodies,
+            initialEphemerisTime,
+            integratorSettings,
+            terminationSettings,
+            std::map< std::string, std::pair< int, int > >( ),
+            []( const double t ) { return t; },
+            1.0,
+            dependentVariables );
+    pnSettings->getOutputSettings( )->setIntegratedResult( true );
+
+    SingleArcDynamicsSimulator< double > simulator( bodies, pnSettings, true );
+    auto results = simulator.getSingleArcPropagationResults( );
+    const std::map< double, Eigen::VectorXd > dependentHistory = results->getDependentVariableHistory( );
+    const std::map< double, Eigen::VectorXd > stateHistory = results->getEquationsOfMotionNumericalSolution( );
+
+    BOOST_REQUIRE( !dependentHistory.empty( ) );
+    BOOST_REQUIRE_EQUAL( dependentHistory.size( ), stateHistory.size( ) );
+
+    // Trapezoidal integral of (kinematic + potential) on the output grid, anchored at the
+    // propagated state's first sample so any initial-offset convention cancels. The two maps are
+    // keyed by the same output epochs (asserted equal size above), so we iterate them in lockstep.
+    double cumulativeIntegral = stateHistory.begin( )->second( 0 );
+    double previousTime = dependentHistory.begin( )->first;
+    double previousRate = dependentHistory.begin( )->second( 0 ) + dependentHistory.begin( )->second( 1 );
+
+    double maxAbsDifference = 0.0;
+    double maxAbsState = 0.0;
+    auto stateIt = stateHistory.begin( );
+    for( auto depIt = dependentHistory.begin( ); depIt != dependentHistory.end( ); ++depIt, ++stateIt )
+    {
+        BOOST_REQUIRE_EQUAL( depIt->second.size( ), 2 );
+        const double t = depIt->first;
+        const double rate = depIt->second( 0 ) + depIt->second( 1 );
+        if( depIt != dependentHistory.begin( ) )
+        {
+            cumulativeIntegral += 0.5 * ( rate + previousRate ) * ( t - previousTime );
+        }
+        previousTime = t;
+        previousRate = rate;
+
+        const double propagatedState = stateIt->second( 0 );
+        maxAbsDifference = std::max( maxAbsDifference, std::fabs( cumulativeIntegral - propagatedState ) );
+        maxAbsState = std::max( maxAbsState, std::fabs( propagatedState ) );
+    }
+
+    const double finalState = stateHistory.rbegin( )->second( 0 );
+    std::cout << "[GrSrSplit-IntegratedSum] samples=" << dependentHistory.size( ) << "  final_state=" << finalState
+              << " s  trapezoid_sum=" << cumulativeIntegral << " s  max_abs_diff=" << maxAbsDifference
+              << " s  rel=" << ( maxAbsState > 0.0 ? maxAbsDifference / maxAbsState : 0.0 ) << std::endl;
+
+    // The integrated decomposition reproduces the propagated proper-time state to roundoff: the
+    // integrand is nearly constant, so the trapezoid rule on the output grid agrees with the RK4
+    // the propagator uses to ~1e-16 s against a ~1.3e-3 s state (observed max_abs_diff ~1.7e-16 s,
+    // rel ~1e-13). Guard at 1e-12 s -- ~4 orders of magnitude over the observed roundoff (safe
+    // across platforms) yet many orders below any sign/factor regression in either component.
+    BOOST_REQUIRE_GT( maxAbsState, 0.0 );
+    BOOST_CHECK_SMALL( maxAbsDifference, 1.0e-12 );
+}
+
 // Progressive-complexity diagnostic. Runs several configurations from simplest
 // (Sun + Earth point-mass, equator station) up through Earth SH(20) and Moon,
 // sampling BOTH the full station residual AND the body-center TCB<->TCG-only


### PR DESCRIPTION
Follow-up to #821 (merged). Tightens the direct-vs-chain ladder to matched (2nd) PN order, fixes the Python binding for the direct-from-metric propagator, and adds an integrated-identity test for the proper-time-rate kinematic/potential (dependent variable) split.

- Ladder: PN chain TCB->TC{G,L} leg run at 2nd order to match the direct metric; new guards per rung: detrended amplitude < 100 ps, slope < 1e-18, chain-vs-truth < 100 ps. All 5 rungs pass locally (slopes -8e-21..5e-19, amps 1.4-5.1e-11 s).
- Binding: RelativisticTimeStatePropagatorSettings declares its SingleArcPropagatorSettings base so create_dynamics_simulator() accepts it from Python.
- Test: testProperTimeRateGrSrSplitIntegratedSumMatchesState - integral of (kinematic + potential) dependent variables reproduces the propagated TCB->TCG state to ~1.7e-16 s (roundoff), guarded at 1e-12 s.

Full test_propagators_RelativisticTimePropagation suite passes locally; expose_propagator.cpp compiles; clang-format clean.