### PR TITLE
Fix TRK2-34 open ramp tables

### DIFF
--- a/docs/tudatpy/source/data/processTrk234.rst
+++ b/docs/tudatpy/source/data/processTrk234.rst
@@ -8,6 +8,17 @@ This module provides tools to read, parse, and convert DSN radiometric tracking 
 (Doppler, range, and ramp data) from TNF/TRK files into Tudat observation formats.
 
 
+Enums
+-----
+.. currentmodule:: tudatpy.data.processTrk234
+
+.. autosummary::
+
+   converters.OpenRampHandling
+
+.. autoclass:: tudatpy.data.processTrk234.converters.OpenRampHandling
+   :members:
+
 Classes
 -------
 .. currentmodule:: tudatpy.data.processTrk234

--- a/include/tudat/astro/ground_stations/transmittingFrequencies.h
+++ b/include/tudat/astro/ground_stations/transmittingFrequencies.h
@@ -360,6 +360,12 @@ public:
         return startFrequencies_;
     }
 
+    //! Function to retrieve the gap handling option
+    FrequencyGapHandling getGapHandling( )
+    {
+        return gapHandling_;
+    }
+
     void addFrequencyInterpolator( const std::shared_ptr< PiecewiseLinearFrequencyInterpolator > rampsToAdd );
 
 private:

--- a/src/tudat/astro/ground_stations/transmittingFrequencies.cpp
+++ b/src/tudat/astro/ground_stations/transmittingFrequencies.cpp
@@ -132,6 +132,12 @@ void PiecewiseLinearFrequencyInterpolator::initialize( )
 void PiecewiseLinearFrequencyInterpolator::addFrequencyInterpolator(
         const std::shared_ptr< PiecewiseLinearFrequencyInterpolator > rampsToAdd )
 {
+    if( rampsToAdd->getGapHandling( ) != gapHandling_ )
+    {
+        std::cerr << "Warning: gap handling of ramp table to add (" << rampsToAdd->getGapHandling( )
+                  << ") differs from base ramp table gap handling (" << gapHandling_ << "). Using base gap handling." << std::endl;
+    }
+
     std::vector< Time > startTimesToAdd = rampsToAdd->getStartTimes( );
     std::vector< Time > endTimesToAdd = rampsToAdd->getEndTimes( );
     std::vector< double > rampRatesToAdd = rampsToAdd->getRampRates( );

--- a/src/tudatpy/data/processTrk234/__init__.py
+++ b/src/tudatpy/data/processTrk234/__init__.py
@@ -1,1 +1,2 @@
 from .processor import Trk234Processor
+from .converters.ramp import OpenRampHandling

--- a/src/tudatpy/data/processTrk234/converters/__init__.py
+++ b/src/tudatpy/data/processTrk234/converters/__init__.py
@@ -1,6 +1,6 @@
 from .converter import Converter
 from .radioBase import RadioBase
-from .ramp import RampConverter
+from .ramp import RampConverter, OpenRampHandling
 from .derivedDoppler import DerivedDopplerConverter
 from .derivedSraRange import DerivedSraRangeConverter
 
@@ -8,6 +8,7 @@ __all__ = [
     "Converter",
     "RadioBase",
     "RampConverter",
+    "OpenRampHandling",
     "DerivedDopplerConverter",
     "DerivedSraRangeConverter",
 ]

--- a/src/tudatpy/data/processTrk234/converters/ramp.py
+++ b/src/tudatpy/data/processTrk234/converters/ramp.py
@@ -3,13 +3,32 @@ Ramp converter
 """
 
 import datetime
-
-from trk234 import bands, SFDU
+from enum import Enum, auto
 
 from pandas import DataFrame, concat
+from trk234 import SFDU, bands
+
+
+class OpenRampHandling(Enum):
+    """Strategy for closing open-ended ramp intervals (i.e. ramps without a `trk_chdo.ramp_type` event of type 4 or 5 in the file)."""
+
+    raise_exception = auto()
+    """Raise a ``ValueError`` if any open ramp is found."""
+
+    close_silently = auto()
+    """Close open ramps silently by setting ``end_time = start_time + 1 s``. This implies that the frequency needs to be extrapolated."""
+
+    print_warning = auto()
+    """Close open ramps with a unit interval and print a warning every time."""
+
+    print_warning_once = auto()
+    """Close open ramps with a unit interval and print a warning only on the first occurrence."""
 
 
 class RampConverter:
+    def __init__(self) -> None:
+        self.warning_printed = False
+
     def extract(self, sfdu_list: list[SFDU]) -> DataFrame:
         # Filter SFDU objects that represent ramp data.
         # - Ramp format_code == 9
@@ -123,17 +142,20 @@ class RampConverter:
 
         return merged_df
 
-    @staticmethod
-    def close_open_ramps(ramp_df: DataFrame) -> DataFrame:
+    def handle_open_ramps(
+        self,
+        ramp_df: DataFrame,
+        handling: OpenRampHandling = OpenRampHandling.print_warning_once,
+    ) -> DataFrame:
         """
-        Close open-ended ramp intervals.
-
-        In case the ramp DataFrame has any open-ended intervals (e.g. if the station doesn't provide a terminating ramp record), this method will set the ``end_time`` of these intervals to an arbitrary epoch (``start_time`` + 1 s) and rely on the frequency extrapolation from the ramp start to compute the frequency at any time after the start.
+        Handle open-ended ramp intervals.
 
         Parameters
         ----------
         ramp_df : pandas.DataFrame
             Processed ramp DataFrame with "start_time" and "end_time" columns.
+        handling : OpenRampHandling
+            Strategy for closing open ramp intervals.
 
         Returns
         -------
@@ -141,10 +163,25 @@ class RampConverter:
             Copy of ``ramp_df`` with ``end_time`` values of ``NaT`` populated.
         """
         ramp_df = ramp_df.copy()
+        open_mask = ramp_df["end_time"].isna()
+        if not open_mask.any():
+            return ramp_df
 
-        open_ramp_intervals = ramp_df["end_time"].isna()
-        if open_ramp_intervals.any():
-            ramp_df.loc[open_ramp_intervals, "end_time"] = ramp_df.loc[
-                open_ramp_intervals, "start_time"
-            ] + datetime.timedelta(seconds=1)
+        match handling:
+            case OpenRampHandling.raise_exception:
+                raise ValueError("Open-ended ramp intervals found in ramp DataFrame.")
+            case OpenRampHandling.print_warning:
+                print("Warning: open-ended ramp intervals found. Closing with default duration.")
+            case OpenRampHandling.print_warning_once:
+                if not self.warning_printed:
+                    print(
+                        "Warning: open-ended ramp intervals found. Closing with default duration."
+                    )
+                    self.warning_printed = True
+            case OpenRampHandling.close_silently:
+                pass
+
+        ramp_df.loc[open_mask, "end_time"] = ramp_df.loc[
+            open_mask, "start_time"
+        ] + datetime.timedelta(seconds=1)
         return ramp_df

--- a/src/tudatpy/data/processTrk234/converters/ramp.py
+++ b/src/tudatpy/data/processTrk234/converters/ramp.py
@@ -2,6 +2,8 @@
 Ramp converter
 """
 
+import datetime
+
 from trk234 import bands, SFDU
 
 from pandas import DataFrame, concat
@@ -120,3 +122,29 @@ class RampConverter:
         merged_df = merged_df.rename(columns={"epoch": "start_time"})
 
         return merged_df
+
+    @staticmethod
+    def close_open_ramps(ramp_df: DataFrame) -> DataFrame:
+        """
+        Close open-ended ramp intervals.
+
+        In case the ramp DataFrame has any open-ended intervals (e.g. if the station doesn't provide a terminating ramp record), this method will set the ``end_time`` of these intervals to an arbitrary epoch (``start_time`` + 1 s) and rely on the frequency extrapolation from the ramp start to compute the frequency at any time after the start.
+
+        Parameters
+        ----------
+        ramp_df : pandas.DataFrame
+            Processed ramp DataFrame with "start_time" and "end_time" columns.
+
+        Returns
+        -------
+        pandas.DataFrame
+            Copy of ``ramp_df`` with ``end_time`` values of ``NaT`` populated.
+        """
+        ramp_df = ramp_df.copy()
+
+        open_ramp_intervals = ramp_df["end_time"].isna()
+        if open_ramp_intervals.any():
+            ramp_df.loc[open_ramp_intervals, "end_time"] = ramp_df.loc[
+                open_ramp_intervals, "start_time"
+            ] + datetime.timedelta(seconds=1)
+        return ramp_df

--- a/src/tudatpy/data/processTrk234/processor.py
+++ b/src/tudatpy/data/processTrk234/processor.py
@@ -8,6 +8,7 @@ from tudatpy.dynamics.environment import (
     SystemOfBodies,
     FrequencyGapHandling,
 )
+from .converters.ramp import OpenRampHandling
 
 
 class Trk234Processor:
@@ -111,7 +112,12 @@ class Trk234Processor:
 
         return ObservationCollection(observation_sets)
 
-    def set_tnf_information_in_bodies(self, bodies: SystemOfBodies) -> None:
+    def set_tnf_information_in_bodies(
+        self,
+        bodies: SystemOfBodies,
+        gap_handling: FrequencyGapHandling = FrequencyGapHandling.extrapolate_at_gaps,
+        open_ramp_handling: OpenRampHandling = OpenRampHandling.print_warning_once,
+    ) -> None:
         """
         Update stations in bodies by setting the frequency interpolators from the ramp data.
         Set the transponder turnaround ratio for the spacecraft.
@@ -122,6 +128,10 @@ class Trk234Processor:
         ----------
         bodies : SystemOfBodies
             The simulation bodies container.
+        gap_handling : FrequencyGapHandling
+            The gap handling strategy for the frequency interpolators. Defaults to ``FrequencyGapHandling.extrapolate_at_gaps``.
+        open_ramp_handling : OpenRampHandling
+            Strategy for closing open-ended ramp intervals. Defaults to ``OpenRampHandling.print_warning_once``.
         """
 
         ramp_data_list = []
@@ -137,7 +147,7 @@ class Trk234Processor:
         all_ramps.reset_index(drop=True, inplace=True)
 
         ramp_df = self.ramp_converter.process(all_ramps)
-        ramp_df = self.ramp_converter.close_open_ramps(ramp_df)
+        ramp_df = self.ramp_converter.handle_open_ramps(ramp_df, open_ramp_handling)
 
         ramp_df["start_time_seconds"] = ramp_df["start_time"].apply(
             lambda x: time_representation.DateTime.from_python_datetime(x).to_epoch()
@@ -153,7 +163,7 @@ class Trk234Processor:
                 station_df["end_time_seconds"].tolist(),
                 station_df["rate"].tolist(),
                 station_df["freq"].tolist(),
-                gap_handling=FrequencyGapHandling.extrapolate_at_gaps,
+                gap_handling=gap_handling,
             )
             ground_station = earth.get_ground_station(station)
 

--- a/src/tudatpy/data/processTrk234/processor.py
+++ b/src/tudatpy/data/processTrk234/processor.py
@@ -3,7 +3,11 @@ from . import converters as cnv
 from pandas import concat as pd_concat
 from tudatpy.estimation.observations import ObservationCollection
 from tudatpy.astro import time_representation
-from tudatpy.dynamics.environment import PiecewiseLinearFrequencyInterpolator, SystemOfBodies
+from tudatpy.dynamics.environment import (
+    PiecewiseLinearFrequencyInterpolator,
+    SystemOfBodies,
+    FrequencyGapHandling,
+)
 
 
 class Trk234Processor:
@@ -133,6 +137,7 @@ class Trk234Processor:
         all_ramps.reset_index(drop=True, inplace=True)
 
         ramp_df = self.ramp_converter.process(all_ramps)
+        ramp_df = self.ramp_converter.close_open_ramps(ramp_df)
 
         ramp_df["start_time_seconds"] = ramp_df["start_time"].apply(
             lambda x: time_representation.DateTime.from_python_datetime(x).to_epoch()
@@ -143,14 +148,21 @@ class Trk234Processor:
         earth = bodies.get("Earth")
         for station in ramp_df["station"].unique():
             station_df = ramp_df[ramp_df["station"] == station]
-            frequencyInterpolator = PiecewiseLinearFrequencyInterpolator(
+            frequency_interpolator = PiecewiseLinearFrequencyInterpolator(
                 station_df["start_time_seconds"].tolist(),
                 station_df["end_time_seconds"].tolist(),
                 station_df["rate"].tolist(),
                 station_df["freq"].tolist(),
+                gap_handling=FrequencyGapHandling.extrapolate_at_gaps,
             )
-            groundStation = earth.get_ground_station(station)
-            groundStation.set_transmitting_frequency_calculator(frequencyInterpolator)
+            ground_station = earth.get_ground_station(station)
+
+            if not ground_station.has_frequency_calculator():
+                ground_station.set_transmitting_frequency_calculator(frequency_interpolator)
+            else:
+                ground_station.transmitting_frequency_calculator.add_frequency_interpolator(
+                    frequency_interpolator
+                )
 
         if self.spacecraft_name:
             spacecraft = bodies.get(self.spacecraft_name)

--- a/src/tudatpy/dynamics/environment/expose_environment.cpp
+++ b/src/tudatpy/dynamics/environment/expose_environment.cpp
@@ -2707,6 +2707,16 @@ bool
             .def( "set_transmitting_frequency_calculator",
                   &tgs::GroundStation::setTransmittingFrequencyCalculator,
                   py::arg( "transmitting_frequency_calculator" ) )
+            .def( "has_frequency_calculator", &tgs::GroundStation::hasFrequencyCalculator, R"doc(
+
+         Check if the ground station has a frequency calculator.
+
+         Returns
+         -------
+         bool
+            True if the ground station has a frequency calculator, False otherwise.
+
+     )doc" )
             //            .def( "set_water_vapor_partial_pressure_function",
             //                  &tgs::GroundStation::setWaterVaporPartialPressureFunction,
             //                  py::arg( "water_vapor_partial_pressure_function" ) )
@@ -2808,7 +2818,20 @@ bool
             .def_property_readonly( "start_frequencies", &tgs::PiecewiseLinearFrequencyInterpolator::getStartFrequencies )
             .def( "compute_current_frequency",
                   &tgs::PiecewiseLinearFrequencyInterpolator::computeCurrentFrequency< double, tudat::Time >,
-                  py::arg( "lookup_time_original" ) );
+                  py::arg( "lookup_time_original" ) )
+            .def( "add_frequency_interpolator",
+                  &tgs::PiecewiseLinearFrequencyInterpolator::addFrequencyInterpolator,
+                  py::arg( "frequency_interpolator_to_add" ),
+                  R"doc(
+                  
+                Function to add a frequency interpolator to the current interpolator. This will add the start times, end times, ramp rates and start frequencies of the provided interpolator to those of the current interpolator. 
+
+                Parameters
+                ----------
+                frequency_interpolator_to_add : PiecewiseLinearFrequencyInterpolator
+                    The frequency interpolator to add to the current interpolator.
+                  
+                  )doc" );
 
     py::class_< tgs::PointingAnglesCalculator, std::shared_ptr< tgs::PointingAnglesCalculator > >( m, "PointingAnglesCalculator" )
             .def( "calculate_elevation_angle",

--- a/tests/test_tudatpy/test_processTrk234.py
+++ b/tests/test_tudatpy/test_processTrk234.py
@@ -13,6 +13,7 @@ from tudatpy.estimation.observations_setup import ancillary_settings
 from tudatpy.estimation.observable_models_setup import links
 from tudatpy.data.processTrk234.processor import Trk234Processor
 from tudatpy.data.processTrk234 import converters as cnv
+from tudatpy.data.processTrk234 import OpenRampHandling
 
 
 # -----------------------------------------------------------------------------
@@ -261,8 +262,44 @@ def test_open_final_ramp_left_unbounded():
     assert pd.isna(result["end_time"].iloc[0])
 
 
-def test_close_open_ramp_uses_offset():
-    """An open final ramp is closed with a nominal 1 s offset past its start."""
+def test_handle_open_ramps_raise_exception():
+    """raise_exception raises ValueError when an open ramp is present."""
+    ramp_df = pd.DataFrame(
+        [
+            {
+                "start_time": pd.Timestamp("2021-01-01 10:00:00"),
+                "end_time": pd.NaT,
+                "station": "A",
+                "type": 1,
+                "freq": 50.0,
+                "rate": 0.0,
+            }
+        ]
+    )
+    with pytest.raises(ValueError):
+        cnv.RampConverter().handle_open_ramps(ramp_df, OpenRampHandling.raise_exception)
+
+
+def test_handle_open_ramps_raise_exception_no_open_ramps():
+    """raise_exception does not raise when all ramps are already closed."""
+    ramp_df = pd.DataFrame(
+        [
+            {
+                "start_time": pd.Timestamp("2021-01-01 10:00:00"),
+                "end_time": pd.Timestamp("2021-01-01 10:05:00"),
+                "station": "A",
+                "type": 1,
+                "freq": 50.0,
+                "rate": 0.0,
+            }
+        ]
+    )
+    result = cnv.RampConverter().handle_open_ramps(ramp_df, OpenRampHandling.raise_exception)
+    assert result["end_time"].iloc[0] == pd.Timestamp("2021-01-01 10:05:00")
+
+
+def test_handle_open_ramps_close_silently():
+    """close_silently closes an open ramp with end_time = start_time + 1 s."""
     start = pd.Timestamp("2021-01-01 10:00:00")
     ramp_df = pd.DataFrame(
         [
@@ -273,20 +310,30 @@ def test_close_open_ramp_uses_offset():
                 "type": 1,
                 "freq": 50.0,
                 "rate": 0.0,
-            },
+            }
         ]
     )
-    result = cnv.RampConverter().close_open_ramps(ramp_df)
-    assert result["end_time"].iloc[0] == pytest.approx(start + pd.Timedelta(seconds=1))
+    result = cnv.RampConverter().handle_open_ramps(ramp_df, OpenRampHandling.close_silently)
+    assert result["end_time"].iloc[0] == start + pd.Timedelta(seconds=1)
 
 
-def test_close_open_ramp_leaves_closed_intervals_untouched():
-    """Ramps that already have an end time are not modified."""
+def test_handle_open_ramps_close_silently_leaves_closed_untouched():
+    """close_silently only modifies open ramps; closed intervals are unchanged."""
+    closed_end = pd.Timestamp("2021-01-01 10:05:00")
+    open_start = pd.Timestamp("2021-01-01 10:10:00")
     ramp_df = pd.DataFrame(
         [
             {
                 "start_time": pd.Timestamp("2021-01-01 10:00:00"),
-                "end_time": pd.Timestamp("2021-01-01 10:05:00"),
+                "end_time": closed_end,
+                "station": "A",
+                "type": 1,
+                "freq": 50.0,
+                "rate": 0.0,
+            },
+            {
+                "start_time": open_start,
+                "end_time": pd.NaT,
                 "station": "A",
                 "type": 1,
                 "freq": 50.0,
@@ -294,8 +341,9 @@ def test_close_open_ramp_leaves_closed_intervals_untouched():
             },
         ]
     )
-    result = cnv.RampConverter().close_open_ramps(ramp_df)
-    assert result["end_time"].iloc[0] == pd.Timestamp("2021-01-01 10:05:00")
+    result = cnv.RampConverter().handle_open_ramps(ramp_df, OpenRampHandling.close_silently)
+    assert result["end_time"].iloc[0] == closed_end
+    assert result["end_time"].iloc[1] == open_start + pd.Timedelta(seconds=1)
 
 
 def test_reader():

--- a/tests/test_tudatpy/test_processTrk234.py
+++ b/tests/test_tudatpy/test_processTrk234.py
@@ -245,6 +245,59 @@ def test_multiple_stations():
     pd.testing.assert_frame_equal(result, expected)
 
 
+def test_open_final_ramp_left_unbounded():
+    """A final ramp with no end event (no following start, no type 4/5) is returned by process() with end_time NaT."""
+    data = [
+        {
+            "station": "A",
+            "epoch": pd.Timestamp("2021-01-01 10:00:00"),
+            "type": 1,
+            "freq": 50.0,
+            "rate": 0.0,
+        },
+    ]
+    result = cnv.RampConverter().process(pd.DataFrame(data))
+    assert len(result) == 1
+    assert pd.isna(result["end_time"].iloc[0])
+
+
+def test_close_open_ramp_uses_offset():
+    """An open final ramp is closed with a nominal 1 s offset past its start."""
+    start = pd.Timestamp("2021-01-01 10:00:00")
+    ramp_df = pd.DataFrame(
+        [
+            {
+                "start_time": start,
+                "end_time": pd.NaT,
+                "station": "A",
+                "type": 1,
+                "freq": 50.0,
+                "rate": 0.0,
+            },
+        ]
+    )
+    result = cnv.RampConverter().close_open_ramps(ramp_df)
+    assert result["end_time"].iloc[0] == pytest.approx(start + pd.Timedelta(seconds=1))
+
+
+def test_close_open_ramp_leaves_closed_intervals_untouched():
+    """Ramps that already have an end time are not modified."""
+    ramp_df = pd.DataFrame(
+        [
+            {
+                "start_time": pd.Timestamp("2021-01-01 10:00:00"),
+                "end_time": pd.Timestamp("2021-01-01 10:05:00"),
+                "station": "A",
+                "type": 1,
+                "freq": 50.0,
+                "rate": 0.0,
+            },
+        ]
+    )
+    result = cnv.RampConverter().close_open_ramps(ramp_df)
+    assert result["end_time"].iloc[0] == pd.Timestamp("2021-01-01 10:05:00")
+
+
 def test_reader():
     # Use the current directory as temporary path.
     tmp_dir = os.getcwd()


### PR DESCRIPTION
#805 introduced a check that the end time of a ramp table entry is after the start time of the ramp table. This causes issues for TNF files, as some ground stations only have starting records with no corresponding end record.
In this case, the end time is `None` and gets implicitly converted a 0 posix epoch, which now throws an error with the new behavior. 

This PR
- adds a check for open ramp intervals, depending on the user choice lets them close it artificially, print a warning or throw an exception
- checks if a frequency interpolator already exists for the ground station, if so, adds the new one to the existing one, instead of overwriting it

Instead of using an arbitrary epoch I tried to retrieve the epoch of the last SFDU in the processed TNF files, but couldn't get this to work reliably in the MRO example.