### PR TITLE
DSN custom seasonal troposphere calibration input

### DIFF
--- a/include/tudat/astro/observation_models/corrections/atmosphereCorrection.h
+++ b/include/tudat/astro/observation_models/corrections/atmosphereCorrection.h
@@ -237,7 +237,7 @@ public:
     /*!
      * Constructor.
      */
-    TabulatedMediaReferenceCorrectionManager( ): isLookupSchemeUpdated_( false ) {}
+    TabulatedMediaReferenceCorrectionManager( ) {}
 
     /*!
      * Constructor.
@@ -245,7 +245,7 @@ public:
      * @param correctionVector Vector of objects computing media corrections.
      */
     TabulatedMediaReferenceCorrectionManager( std::vector< std::shared_ptr< TabulatedMediaReferenceCorrection > > correctionVector ):
-        correctionVector_( correctionVector ), isLookupSchemeUpdated_( false )
+        correctionVector_( correctionVector )
     {
         for( unsigned int i = 0; i < correctionVector_.size( ); ++i )
         {
@@ -261,26 +261,28 @@ public:
      */
     void pushReferenceCorrectionCalculator( std::shared_ptr< TabulatedMediaReferenceCorrection > correctionCalculator )
     {
-        if( correctionVector_.empty( ) ||
-            ( !correctionVector_.empty( ) && correctionCalculator->getStartTime( ) > startTimes_.back( ) &&
-              correctionCalculator->getEndTime( ) > endTimes_.back( ) ) )
-        {
-            startTimes_.push_back( correctionCalculator->getStartTime( ) );
-            endTimes_.push_back( correctionCalculator->getEndTime( ) );
-            correctionVector_.push_back( correctionCalculator );
-        }
-        else
-        {
-            throw std::runtime_error( "Inconsistency in times when pushing tabulated media reference correction calculator. " );
-        }
+        startTimes_.push_back( correctionCalculator->getStartTime( ) );
+        endTimes_.push_back( correctionCalculator->getEndTime( ) );
+        correctionVector_.push_back( correctionCalculator );
+    }
 
-        isLookupSchemeUpdated_ = false;
+    /*!
+     * Adds the correction calculation objects from another manager to this manager.
+     *
+     * @param other Manager from which to add the correction calculation objects.
+     */
+    void addOther( const TabulatedMediaReferenceCorrectionManager& other )
+    {
+        for( auto const& correctionCalculator : other.correctionVector_ )
+        {
+            pushReferenceCorrectionCalculator( correctionCalculator );
+        }
     }
 
     /*!
      * Function to compute the atmospheric correction as a function of time.
-     * For the specified time, the function selects the appropriate correction calculation object and the uses it
-     * to compute the time.
+     * For the specified time, the function finds the appropriate correction calculation objects and
+     * sums their contributions.
      *
      * @param time Time at which to compute the correction.
      * @return Atmospheric correction value.
@@ -296,13 +298,6 @@ private:
 
     // Vector containing the objects that compute the media corrections
     std::vector< std::shared_ptr< TabulatedMediaReferenceCorrection > > correctionVector_;
-
-    // Boolean indicating whether the lookup scheme is updated (it gets out of date in case the start times vector
-    // is modified)
-    bool isLookupSchemeUpdated_;
-
-    //! Lookup scheme to find the nearest correction object start time for a given time
-    std::shared_ptr< interpolators::LookUpScheme< double > > startTimeLookupScheme_;
 };
 
 // Enum listing the available tropospheric mapping models.

--- a/include/tudat/astro/observation_models/corrections/atmosphereCorrection.h
+++ b/include/tudat/astro/observation_models/corrections/atmosphereCorrection.h
@@ -279,6 +279,12 @@ public:
         }
     }
 
+    // Returns the correction objects held by this manager.
+    const std::vector< std::shared_ptr< TabulatedMediaReferenceCorrection > >& getCorrectionVector( ) const
+    {
+        return correctionVector_;
+    }
+
     /*!
      * Function to compute the atmospheric correction as a function of time.
      * For the specified time, the function finds the appropriate correction calculation objects and

--- a/include/tudat/simulation/estimation_setup/createLightTimeCorrection.h
+++ b/include/tudat/simulation/estimation_setup/createLightTimeCorrection.h
@@ -523,7 +523,8 @@ inline std::shared_ptr< LightTimeCorrectionSettings > firstOrderRelativisticLigh
 inline std::shared_ptr< LightTimeCorrectionSettings > tabulatedTroposphericCorrectionSettings(
         const std::vector< std::string >& troposphericCorrectionFileNames,
         const std::string& bodyWithAtmosphere = "Earth",
-        const TroposphericMappingModel troposphericMappingModel = TroposphericMappingModel::niell )
+        const TroposphericMappingModel troposphericMappingModel = TroposphericMappingModel::niell,
+        const std::string& seasonalCorrectionFileName = "" )
 {
     std::vector< std::shared_ptr< input_output::CspRawFile > > troposphericCspFiles;
     for( const std::string& cspFile : troposphericCorrectionFileNames )
@@ -531,10 +532,26 @@ inline std::shared_ptr< LightTimeCorrectionSettings > tabulatedTroposphericCorre
         troposphericCspFiles.push_back( std::make_shared< input_output::CspRawFile >( cspFile ) );
     }
 
+    AtmosphericCorrectionPerStationAndSpacecraftType dryCorrection;
+    AtmosphericCorrectionPerStationAndSpacecraftType wetCorrection;
+    if( seasonalCorrectionFileName.empty( ) )
+    {
+        dryCorrection = extractDefaultTroposphericDryCorrection( );
+        wetCorrection = extractDefaultTroposphericWetCorrection( );
+    }
+    else
+    {
+        auto seasonalCspFile = std::make_shared< input_output::CspRawFile >( seasonalCorrectionFileName );
+        dryCorrection = extractTroposphericDryCorrectionAdjustment( { seasonalCspFile } );
+        wetCorrection = extractTroposphericWetCorrectionAdjustment( { seasonalCspFile } );
+    }
+
     return std::make_shared< TabulatedTroposphericCorrectionSettings >( extractTroposphericDryCorrectionAdjustment( troposphericCspFiles ),
                                                                         extractTroposphericWetCorrectionAdjustment( troposphericCspFiles ),
                                                                         bodyWithAtmosphere,
-                                                                        troposphericMappingModel );
+                                                                        troposphericMappingModel,
+                                                                        dryCorrection,
+                                                                        wetCorrection );
 }
 
 inline std::shared_ptr< LightTimeCorrectionSettings > saastamoinenTroposphericCorrectionSettings(

--- a/src/tudat/astro/observation_models/corrections/atmosphereCorrection.cpp
+++ b/src/tudat/astro/observation_models/corrections/atmosphereCorrection.cpp
@@ -125,21 +125,21 @@ double TabulatedMediaReferenceCorrectionManager::computeMediaCorrection( double 
 {
     if( correctionVector_.empty( ) )
     {
-        throw std::runtime_error( "Error when computing reference media correction: no correction object provided. " );
+        throw std::runtime_error( "Error when computing reference media correction: no correction object provided." );
     }
 
-    int lowerNearestNeighbour = 0;
-    if( startTimes_.size( ) > 1 )
+    double correction = 0.0;
+    for( unsigned int i = 0; i < correctionVector_.size( ); ++i )
     {
-        if( !isLookupSchemeUpdated_ )
+        // for seasonal corrections, start and end times might be NaN, in which case the correction is always valid
+        bool startOk = std::isnan( startTimes_.at( i ) ) || time >= startTimes_.at( i );
+        bool endOk = std::isnan( endTimes_.at( i ) ) || time <= endTimes_.at( i );
+        if( startOk && endOk )
         {
-            startTimeLookupScheme_ = std::make_shared< interpolators::HuntingAlgorithmLookupScheme< double > >( startTimes_ );
-            isLookupSchemeUpdated_ = true;
+            correction += correctionVector_.at( i )->computeReferenceCorrection( time );
         }
-        lowerNearestNeighbour = startTimeLookupScheme_->findNearestLowerNeighbour( time );
     }
-
-    return correctionVector_.at( lowerNearestNeighbour )->computeReferenceCorrection( time );
+    return correction;
 }
 
 double SimplifiedChaoTroposphericMapping::troposphericSimplifiedChaoMapping( const double elevation, const bool dryCorrection )

--- a/src/tudat/io/readTabulatedMediaCorrections.cpp
+++ b/src/tudat/io/readTabulatedMediaCorrections.cpp
@@ -31,6 +31,8 @@ AtmosphericCorrectionCspCommand::AtmosphericCorrectionCspCommand( std::vector< s
 {
     for( unsigned int i = 0; i < cspCommand.size( ); ++i )
     {
+        boost::algorithm::trim( cspCommand.at( i ) );
+
         if( cspCommand.at( i ) == "MODEL" )
         {
             modelIdentifier_ = cspCommand.at( i + 1 );
@@ -80,7 +82,7 @@ AtmosphericCorrectionCspCommand::AtmosphericCorrectionCspCommand( std::vector< s
         }
         else
         {
-            throw std::runtime_error( "Invalid CSP command for atmospheric correction file." );
+            throw std::runtime_error( "Invalid CSP command for atmospheric correction file.:" + cspCommand.at( i ) );
         }
     }
 }
@@ -258,7 +260,7 @@ std::vector< std::string > getGroundStationsNames( const std::string& groundStat
     }
     else
     {
-        groundStations = { "DSS-" + groundStationIdentifier };
+        groundStations = { "DSS-" + std::to_string( std::stoi( groundStationIdentifier ) ) };
     }
 
     return groundStations;

--- a/src/tudat/simulation/estimation_setup/createAtmosphericLightTimeCorrection.cpp
+++ b/src/tudat/simulation/estimation_setup/createAtmosphericLightTimeCorrection.cpp
@@ -127,8 +127,21 @@ AtmosphericCorrectionPerStationAndSpacecraftType extractAtmosphericCorrection(
             {
                 for( const observation_models::ObservableType& observableType : observableTypes )
                 {
-                    troposphericCorrection[ std::make_pair( groundStation, source ) ][ observableType ] =
+                    auto stationSourceKey = std::make_pair( groundStation, source );
+                    auto incomingManager =
                             correctionsPerStationsAndSourcePerType.at( stationsAndSourceIt->first ).at( observableIt->first );
+
+                    if( troposphericCorrection.count( stationSourceKey ) &&
+                        troposphericCorrection.at( stationSourceKey ).count( observableType ) )
+                    {
+                        troposphericCorrection.at( stationSourceKey ).at( observableType )->addOther( *incomingManager );
+                    }
+                    else
+                    {
+                        auto newManager = std::make_shared< observation_models::TabulatedMediaReferenceCorrectionManager >( );
+                        newManager->addOther( *incomingManager );
+                        troposphericCorrection[ stationSourceKey ][ observableType ] = newManager;
+                    }
                 }
             }
         }

--- a/src/tudatpy/estimation/observable_models_setup/light_time_corrections/expose_light_time_corrections.cpp
+++ b/src/tudatpy/estimation/observable_models_setup/light_time_corrections/expose_light_time_corrections.cpp
@@ -373,23 +373,76 @@ Examples
             .value( "vmf3", tom::TroposphericMappingModel::vmf3 );
 
     py::enum_< tom::WaterVaporPartialPressureModel >(
-            m, "WaterVaporPartialPressureModel", "enum.IntEnum", R"doc(No documentation found.)doc" )
-            .value( "tabulated", tom::WaterVaporPartialPressureModel::tabulated )
-            .value( "bean_and_dutton", tom::WaterVaporPartialPressureModel::bean_and_dutton );
+            m, "WaterVaporPartialPressureModel", "enum.IntEnum", R"doc(Enumeration for water vapor partial pressure models.)doc" )
+            .value( "tabulated",
+                    tom::WaterVaporPartialPressureModel::tabulated,
+                    R"doc(Use the water vapor partial pressure values directly from the GroundStation's water vapor partial pressure data.)doc" )
+            .value( "bean_and_dutton",
+                    tom::WaterVaporPartialPressureModel::bean_and_dutton,
+                    R"doc(Compute the water vapor partial pressure using the Bean and Dutton (1966) model as given in Eq. 16 of Estefan and Sovers (1994), based on the GroundStation's temperature and relative humidity.)doc" );
 
     m.def( "dsn_tabulated_tropospheric_light_time_correction",
            &tom::tabulatedTroposphericCorrectionSettings,
            py::arg( "file_names" ),
            py::arg( "body_with_atmosphere_name" ) = "Earth",
            py::arg( "mapping_model" ) = tom::TroposphericMappingModel::niell,
-           R"doc(No documentation found.)doc" );
+           py::arg( "seasonal_correction_file_name" ) = "",
+           R"doc(
+
+           Function for creating settings for DSN tabulated tropospheric light-time corrections.
+
+           The tabulated tropospheric correction settings are created based on files according to the TRK-2-23 Media Calibration Interface document.
+           The tropospheric correction files contain time-series coefficients for the dry and wet tropospheric zenit delay, which are then mapped to the slant range using the specified mapping function.
+           The correction is composed of a seasonal correction and an adjustment to that, based on measured data.
+           The tropospheric corrections are spacecraft-independent.
+
+           Parameters
+           ----------
+
+           file_names : list[str]
+               List of paths to the tropospheric correction files. These files should only include the monthly adjustments to the seasonal model as given by the DSN, not the seasonal model.
+           body_with_atmosphere_name : str, default = "Earth"
+               Name of the body with the troposphere.
+           mapping_model : TroposphericMappingModel, default = niell
+               Mapping model used to map the zenith delay to the slant range.
+           seasonal_correction_file_name : str, default = ""
+               Path to the CSP file containing the seasonal tropospheric correction model. If empty, the DSN default seasonal model from the `PDS <https://pds-geosciences.wustl.edu/radiosciencedocs/urn-nasa-pds-jpl_dsn_mmm/tro/1972_001_2048_001_tro.csp>`_ is used, without the constant terms.
+
+           Returns
+           -------
+           :class:`~tudatpy.estimation.observable_models_setup.light_time_corrections.LightTimeCorrectionSettings`
+               Instance of the :class:`~tudatpy.estimation.observable_models_setup.light_time_corrections.LightTimeCorrectionSettings` configured for DSN tabulated tropospheric corrections.
+
+           )doc" );
 
     m.def( "saastamoinen_tropospheric_light_time_correction",
            &tom::saastamoinenTroposphericCorrectionSettings,
            py::arg( "body_with_atmosphere_name" ) = "Earth",
            py::arg( "mapping_model" ) = tom::TroposphericMappingModel::niell,
            py::arg( "water_vapor_partial_pressure_model" ) = tom::WaterVaporPartialPressureModel::tabulated,
-           R"doc(No documentation found.)doc" );
+           R"doc(
+           
+           Function for creating settings for Saastamoinen tropospheric light-time corrections.
+
+           The Saastamoinen tropospheric correction compute the tropospheric zenith delay based on the local meterological conditions at the ground station.
+           This requires the meteorological data to be set in the :class:`~tudatpy.dynamics.environment.GroundStation` object.
+           The dry delay is computed according to Eq. (12,13) in Estefan and Sovers (1994), while the wet delay is computed according to Eq. (18).
+           The zenith delay is then mapped to the slant range using the specified mapping function.
+           
+           Parameters
+           ----------
+           body_with_atmosphere_name : str, default = "Earth"
+               Name of the body with the troposphere.
+           mapping_model : TroposphericMappingModel, default = niell
+               Mapping model used to map the zenith delay to the slant range.
+           water_vapor_partial_pressure_model : WaterVaporPartialPressureModel, default = tabulated
+               Model used to compute the water vapor partial pressure required for the wet delay computation.
+
+           Returns
+           -------
+           :class:`~tudatpy.estimation.observable_models_setup.light_time_corrections.LightTimeCorrectionSettings`
+               Instance of the :class:`~tudatpy.estimation.observable_models_setup.light_time_corrections.LightTimeCorrectionSettings` configured for Saastamoinen tropospheric corrections.
+           )doc" );
 
     m.def( "dsn_tabulated_ionospheric_light_time_correction",
            &tom::tabulatedIonosphericCorrectionSettings,
@@ -398,7 +451,33 @@ Examples
            py::arg( "quasar_name_per_id" ) = std::map< int, std::string >( ),
            py::arg( "reference_frequency" ) = 2295e6,
            py::arg( "body_with_atmosphere_name" ) = "Earth",
-           R"doc(No documentation found.)doc" );
+           R"doc(
+           
+           Function for creating settings for DSN tabulated ionospheric light-time corrections.
+
+           The tabulated ionospheric correction settings are created based on files according to the TRK-2-23 Media Calibration Interface document.
+           The ionospheric correction files contain time-series coefficients for the delay due to charged particles in the ionosphere at the reference frequency.
+           The ionospheric corrections are spacecraft-specific.
+
+           Parameters
+           ----------
+           file_names : list[str]
+               List of paths to the ionospheric correction files.
+           spacecraft_name_per_id : dict[int, str], default = {}
+               Map with the name of the body associated with each spacecraft ID in the CSP file.
+           quasar_name_per_id : dict[int, str], default = {}
+               Map with the name of the body associated with each quasar ID in the CSP file.
+           reference_frequency : float, default = 2295e6
+               Reference frequency at which the ionospheric correction coefficients are given, in Hz. The correction is scaled to the actual frequency of the signal using the inverse-square law.
+           body_with_atmosphere_name : str, default = "Earth"
+               Name of the body with the ionosphere.
+
+           Returns
+           -------
+           :class:`~tudatpy.estimation.observable_models_setup.light_time_corrections.LightTimeCorrectionSettings`
+               Instance of the :class:`~tudatpy.estimation.observable_models_setup.light_time_corrections.LightTimeCorrectionSettings` configured for DSN tabulated ionospheric corrections.
+           
+           )doc" );
 
     m.def( "jakowski_ionospheric_light_time_correction",
            &tom::jakowskiIonosphericCorrectionSettings,

--- a/tests/test_tudat/src/astro/observation_models/unitTestAtmosphereCorrection.cpp
+++ b/tests/test_tudat/src/astro/observation_models/unitTestAtmosphereCorrection.cpp
@@ -866,6 +866,114 @@ BOOST_AUTO_TEST_CASE( testVmf3oCorrectionType )
                        std::runtime_error );
 }
 
+// Verify that TabulatedMediaReferenceCorrectionManager sums all active corrections,
+// and that NaN time bounds make a correction always-valid.
+BOOST_AUTO_TEST_CASE( testMultipleTabulatedCorrectionsSimultaneously )
+{
+    using namespace observation_models;
+    const double correction1 = 0.3;
+    const double correction2 = 0.5;
+    const double eps = 1e-15;
+
+    // Case 1: two overlapping constant corrections are summed
+    {
+        TabulatedMediaReferenceCorrectionManager manager;
+        manager.pushReferenceCorrectionCalculator( std::make_shared< ConstantReferenceCorrection >( 0.0, 1000.0, correction1 ) );
+        manager.pushReferenceCorrectionCalculator( std::make_shared< ConstantReferenceCorrection >( 0.0, 1000.0, correction2 ) );
+
+        BOOST_CHECK_CLOSE_FRACTION( manager.computeMediaCorrection( 500.0 ), correction1 + correction2, eps );
+    }
+
+    // Case 2: non-overlapping corrections: only the active one contributes
+    {
+        TabulatedMediaReferenceCorrectionManager manager;
+        manager.pushReferenceCorrectionCalculator( std::make_shared< ConstantReferenceCorrection >( 0.0, 500.0, correction1 ) );
+        manager.pushReferenceCorrectionCalculator( std::make_shared< ConstantReferenceCorrection >( 500.0, 1000.0, correction2 ) );
+
+        BOOST_CHECK_CLOSE_FRACTION( manager.computeMediaCorrection( 100.0 ), correction1, eps );
+        BOOST_CHECK_CLOSE_FRACTION( manager.computeMediaCorrection( 600.0 ), correction2, eps );
+    }
+
+    // Case 3: addOther merges corrections from a second manager
+    {
+        TabulatedMediaReferenceCorrectionManager managerA, managerB;
+        managerA.pushReferenceCorrectionCalculator( std::make_shared< ConstantReferenceCorrection >( 0.0, 1000.0, correction1 ) );
+        managerB.pushReferenceCorrectionCalculator( std::make_shared< ConstantReferenceCorrection >( 0.0, 1000.0, correction2 ) );
+        managerA.addOther( managerB );
+
+        BOOST_CHECK_CLOSE_FRACTION( managerA.computeMediaCorrection( 500.0 ), correction1 + correction2, eps );
+    }
+
+    // Case 4: NaN-bounded seasonal + time-bounded adjustment
+    // Seasonal model has NaN start/end (always valid); adjustment is only valid in [0, 1000].
+    {
+        const double seasonalVal = 0.7;
+        const double adjustmentVal = 0.1;
+
+        TabulatedMediaReferenceCorrectionManager manager;
+        manager.pushReferenceCorrectionCalculator( std::make_shared< ConstantReferenceCorrection >( TUDAT_NAN, TUDAT_NAN, seasonalVal ) );
+        manager.pushReferenceCorrectionCalculator( std::make_shared< ConstantReferenceCorrection >( 0.0, 1000.0, adjustmentVal ) );
+
+        // Inside adjustment range: both contribute
+        BOOST_CHECK_CLOSE_FRACTION( manager.computeMediaCorrection( 500.0 ), seasonalVal + adjustmentVal, eps );
+
+        // Outside adjustment range: only seasonal contributes
+        BOOST_CHECK_CLOSE_FRACTION( manager.computeMediaCorrection( 2000.0 ), seasonalVal, eps );
+    }
+}
+
+BOOST_AUTO_TEST_CASE( testSeasonalPlusAdjustmentTroposphericCorrections )
+{
+    spice_interface::loadStandardSpiceKernels( );
+
+    simulation_setup::BodyListSettings bodySettings = simulation_setup::getDefaultBodySettings( { "Earth", "Mars" } );
+    bodySettings.at( "Earth" )->groundStationSettings = simulation_setup::getDsnStationSettings( );
+    bodySettings.addSettings( "MRO" );
+    bodySettings.at( "MRO" )->ephemerisSettings = std::make_shared< simulation_setup::DirectSpiceEphemerisSettings >( );
+    simulation_setup::SystemOfBodies bodies = createSystemOfBodies( bodySettings );
+
+    auto seasonalCspFile =
+            std::make_shared< input_output::CspRawFile >( tudat::paths::getTudatTestDataPath( ) + "1972_001_2048_001_tro.csp" );
+    auto adjustmentCspFile =
+            std::make_shared< input_output::CspRawFile >( tudat::paths::getTudatTestDataPath( ) + "mromagr2017_091_2017_121.tro.txt" );
+
+    auto dryAdjustment = extractTroposphericDryCorrectionAdjustment( { adjustmentCspFile } );
+    auto wetAdjustment = extractTroposphericWetCorrectionAdjustment( { adjustmentCspFile } );
+    auto drySeasonal = extractTroposphericDryCorrectionAdjustment( { seasonalCspFile } );
+    auto wetSeasonal = extractTroposphericWetCorrectionAdjustment( { seasonalCspFile } );
+
+    auto stationKey = std::make_pair( std::string( "DSS-26" ), std::string( "" ) );
+    auto seasonalManager = drySeasonal.at( stationKey ).at( one_way_doppler );
+    auto adjustmentManager = dryAdjustment.at( stationKey ).at( one_way_doppler );
+
+    // the seasonal manager should have two corrections per complex and observation, one trigonometric and one constant
+    BOOST_CHECK_EQUAL( seasonalManager->getCorrectionVector( ).size( ), 2u );
+
+    auto correctionSettings = std::make_shared< TabulatedTroposphericCorrectionSettings >(
+            dryAdjustment, wetAdjustment, "Earth", TroposphericMappingModel::niell, drySeasonal, wetSeasonal );
+
+    LinkEnds linkEnds;
+    linkEnds[ transmitter ] = LinkEndId( "MRO" );
+    linkEnds[ receiver ] = LinkEndId( "Earth", "DSS-26" );
+
+    auto correctionBase = createLightTimeCorrections( correctionSettings, bodies, linkEnds, transmitter, receiver, one_way_doppler );
+    auto tabulatedCorrection = std::dynamic_pointer_cast< MappedTroposphericCorrection >( correctionBase );
+    BOOST_REQUIRE( tabulatedCorrection != nullptr );
+
+    // Within adjustment window: correction object must equal seasonal + adjustment computed directly
+    double tInWindow = 544795200.0;
+    BOOST_CHECK_CLOSE_FRACTION(
+            tabulatedCorrection->getDryZenithRangeCorrectionFunction( )( tInWindow ),
+            seasonalManager->computeMediaCorrection( tInWindow ) + adjustmentManager->computeMediaCorrection( tInWindow ),
+            1e-15 );
+
+    // Outside adjustment window: adjustment contributes 0, only seasonal active
+    double tOutside = 0.0;
+    BOOST_CHECK_CLOSE_FRACTION( tabulatedCorrection->getDryZenithRangeCorrectionFunction( )( tOutside ),
+                                seasonalManager->computeMediaCorrection( tOutside ),
+                                1e-15 );
+}
+
 BOOST_AUTO_TEST_SUITE_END( )
 
 }  // namespace unit_tests


### PR DESCRIPTION
This PR adds the option to load a custom seasonal troposphere calibration file from the python interface. The current default troposphere seasonal correction model only contains the trigonometric coefficients, while the default file from the PDS (https://pds-geosciences.wustl.edu/radiosciencedocs/urn-nasa-pds-jpl_dsn_mmm/tro/1972_001_2048_001_tro.csp) contains additional constant terms per single DSN station. The constant corrections are in the order of cm to mm for all active stations, for backwards compatibility the default behavior is unchanged.

The current implementation checks that only one adjustment is added per time window. This check is removed, since the constant corrections are specified per time window and are added on top of the trigonometric corrections, therefore multiple corrections are active at the same time and summed up.