### PR TITLE
Fix estimation analysis typehints

### DIFF
--- a/src/tudatpy/estimation/expose_estimation.cpp
+++ b/src/tudatpy/estimation/expose_estimation.cpp
@@ -53,9 +53,9 @@ void expose_estimation( py::module& m )
     observations_setup::expose_observations_setup( observations_setup_submodule );
 
     auto estimation_analysis_submodule = m.def_submodule( "estimation_analysis" );
+    estimation_analysis::expose_estimation_analysis( estimation_analysis_submodule );
     estimation_analysis::expose_estimation_analysis_estimator( estimation_analysis_submodule );
     estimation_analysis::expose_estimation_analysis_ephemeris_fit( estimation_analysis_submodule );
-    estimation_analysis::expose_estimation_analysis( estimation_analysis_submodule );
 };
 
 }  // namespace estimation


### PR DESCRIPTION
The `perform_estimation` and `compute_covariance` methods of the `Estimator` class both contain a function argument `tudat`. This is because the type of the actual argument is not yet registered when the `Estimator` class is exposed, and pybind11-stubgen parses the `tudat::Time` template argument incorrectly:

<img width="1384" height="431" alt="image" src="https://github.com/user-attachments/assets/ec310f3c-499e-48e9-9752-64e3c0050da4" />


This temporarily fixes the erroneous argument by reordering the exposures before a more stable solution is found (see #288), such that the Covariance/Estimation In/Output types are registered before the Estimator class:

<img width="1384" height="431" alt="image" src="https://github.com/user-attachments/assets/8e4a3c20-82bc-4f42-9649-7e033b5ba547" />
