### PR TITLE
Fix/ NaN in aerodynamic partials when a wind model is present

### DIFF
--- a/include/tudat/astro/aerodynamics/comaModel.h
+++ b/include/tudat/astro/aerodynamics/comaModel.h
@@ -170,10 +170,10 @@ private:
     // ========== Hot path: Frequently accessed cached values (grouped for cache locality) ==========
 
     //! Cached solar longitude value to avoid redundant state function calls [rad]
-    double cachedSolarLongitude_;
+    mutable double cachedSolarLongitude_;
 
     //! Time at which solar longitude was last cached [s]
-    double cachedTime_;
+    mutable double cachedTime_;
 
     //! Pre-allocated coefficient matrices to avoid repeated allocations
     Eigen::MatrixXd cachedCosineCoefficients_;
@@ -204,9 +204,9 @@ private:
     Eigen::MatrixXd cachedTemperatureSineCoefficients_;
 
     //! Cached state function results
-    Eigen::Vector6d cachedSunState_;
-    Eigen::Vector6d cachedCometState_;
-    Eigen::Matrix3d cachedRotationMatrix_;
+    mutable Eigen::Vector6d cachedSunState_;
+    mutable Eigen::Vector6d cachedCometState_;
+    mutable Eigen::Matrix3d cachedRotationMatrix_;
 
     //! Pre-allocated interpolation point vectors to avoid repeated allocations
     std::vector< double > interpolationPoint2D_;
@@ -226,7 +226,7 @@ private:
             temperatureValid( false )
         {}
     };
-    CacheFlags cacheFlags_;
+    mutable CacheFlags cacheFlags_;
 
     // ========== Configuration: Model parameters (small, accessed during initialization and queries) ==========
 
@@ -395,7 +395,7 @@ private:
      * @param time Time at which to compute solar longitude [s]
      * @return Solar longitude [rad]
      */
-    double calculateSolarLongitude( double time );
+    double calculateSolarLongitude( double time ) const;
 
     /*!
      * @brief Initialize interpolators for Stokes coefficients (called only for STOKES_COEFFICIENTS data type)

--- a/include/tudat/simulation/propagation_setup/propagationOutput.h
+++ b/include/tudat/simulation/propagation_setup/propagationOutput.h
@@ -1129,15 +1129,14 @@ std::pair< std::function< Eigen::VectorXd( ) >, int > getVectorDependentVariable
             // If target frame is corotating frame, return wind velocity directly
             if( targetFrame == reference_frames::corotating_frame )
             {
-                variableFunction = std::bind( &reference_frames::AerodynamicAngleCalculator::getCurrentLocalWindVelocity,
-                                              aerodynamicAngleCalculator );
+                variableFunction =
+                        std::bind( &reference_frames::AerodynamicAngleCalculator::getCurrentLocalWindVelocity, aerodynamicAngleCalculator );
             }
             else
             {
                 // Create function to transform wind velocity to target frame
                 std::function< Eigen::Vector3d( ) > windVelocityCorotatingFunction =
-                        std::bind( &reference_frames::AerodynamicAngleCalculator::getCurrentLocalWindVelocity,
-                                   aerodynamicAngleCalculator );
+                        std::bind( &reference_frames::AerodynamicAngleCalculator::getCurrentLocalWindVelocity, aerodynamicAngleCalculator );
 
                 std::function< Eigen::Matrix3d( ) > rotationMatrixFunction =
                         std::bind( &reference_frames::AerodynamicAngleCalculator::getRotationMatrixBetweenFrames,
@@ -1145,8 +1144,7 @@ std::pair< std::function< Eigen::VectorXd( ) >, int > getVectorDependentVariable
                                    reference_frames::corotating_frame,
                                    targetFrame );
 
-                variableFunction = [ windVelocityCorotatingFunction, rotationMatrixFunction ]( )
-                {
+                variableFunction = [ windVelocityCorotatingFunction, rotationMatrixFunction ]( ) {
                     // Evaluate before returning; the Eigen product expression would otherwise
                     // reference temporaries created by the function calls above.
                     Eigen::Vector3d transformedWindVelocity = rotationMatrixFunction( ) * windVelocityCorotatingFunction( );

--- a/include/tudat/simulation/propagation_setup/propagationOutput.h
+++ b/include/tudat/simulation/propagation_setup/propagationOutput.h
@@ -1123,27 +1123,34 @@ std::pair< std::function< Eigen::VectorXd( ) >, int > getVectorDependentVariable
 
             reference_frames::AerodynamicsReferenceFrames targetFrame = windVelocitySettings->targetFrame_;
 
+            std::shared_ptr< reference_frames::AerodynamicAngleCalculator > aerodynamicAngleCalculator =
+                    bodies.at( bodyWithProperty )->getFlightConditions( )->getAerodynamicAngleCalculator( );
+
             // If target frame is corotating frame, return wind velocity directly
             if( targetFrame == reference_frames::corotating_frame )
             {
                 variableFunction = std::bind( &reference_frames::AerodynamicAngleCalculator::getCurrentLocalWindVelocity,
-                                              bodies.at( bodyWithProperty )->getFlightConditions( )->getAerodynamicAngleCalculator( ) );
+                                              aerodynamicAngleCalculator );
             }
             else
             {
                 // Create function to transform wind velocity to target frame
                 std::function< Eigen::Vector3d( ) > windVelocityCorotatingFunction =
                         std::bind( &reference_frames::AerodynamicAngleCalculator::getCurrentLocalWindVelocity,
-                                   bodies.at( bodyWithProperty )->getFlightConditions( )->getAerodynamicAngleCalculator( ) );
+                                   aerodynamicAngleCalculator );
 
                 std::function< Eigen::Matrix3d( ) > rotationMatrixFunction =
                         std::bind( &reference_frames::AerodynamicAngleCalculator::getRotationMatrixBetweenFrames,
-                                   bodies.at( bodyWithProperty )->getFlightConditions( )->getAerodynamicAngleCalculator( ),
+                                   aerodynamicAngleCalculator,
                                    reference_frames::corotating_frame,
                                    targetFrame );
 
-                variableFunction = [ windVelocityCorotatingFunction, rotationMatrixFunction ]( ) {
-                    return rotationMatrixFunction( ) * windVelocityCorotatingFunction( );
+                variableFunction = [ windVelocityCorotatingFunction, rotationMatrixFunction ]( )
+                {
+                    // Evaluate before returning; the Eigen product expression would otherwise
+                    // reference temporaries created by the function calls above.
+                    Eigen::Vector3d transformedWindVelocity = rotationMatrixFunction( ) * windVelocityCorotatingFunction( );
+                    return transformedWindVelocity;
                 };
             }
 

--- a/src/tudat/astro/aerodynamics/comaModel.cpp
+++ b/src/tudat/astro/aerodynamics/comaModel.cpp
@@ -455,7 +455,7 @@ int ComaModel::findTimeIntervalIndex( const double time )
  * \return Solar longitude angle from X-axis in XY plane [rad]
  * \throws std::runtime_error If state functions are not initialized
  */
-double ComaModel::calculateSolarLongitude( const double time )
+double ComaModel::calculateSolarLongitude( const double time ) const
 {
     constexpr double timeTolerance = 1e-10;
     constexpr double timeToleranceSq = timeTolerance * timeTolerance;

--- a/tests/test_tudat/src/astro/orbit_determination/CMakeLists.txt
+++ b/tests/test_tudat/src/astro/orbit_determination/CMakeLists.txt
@@ -257,11 +257,6 @@ TUDAT_ADD_TEST_CASE(EstimationDragWithWind
          ${ORBIT_DETERMINATION_TEST_PRIVATE_LINKS}
          )
 
-TUDAT_ADD_TEST_CASE(EstimationComaModelDrag
-         PRIVATE_LINKS
-         ${ORBIT_DETERMINATION_TEST_PRIVATE_LINKS}
-         )
-
  TUDAT_ADD_TEST_CASE(ParameterPropagatorConsistency
          PRIVATE_LINKS
          ${ORBIT_DETERMINATION_TEST_PRIVATE_LINKS}

--- a/tests/test_tudat/src/astro/orbit_determination/CMakeLists.txt
+++ b/tests/test_tudat/src/astro/orbit_determination/CMakeLists.txt
@@ -252,6 +252,16 @@ TUDAT_ADD_TEST_CASE(EstimationDragScaling
          ${ORBIT_DETERMINATION_TEST_PRIVATE_LINKS}
          )
 
+TUDAT_ADD_TEST_CASE(EstimationDragWithWind
+         PRIVATE_LINKS
+         ${ORBIT_DETERMINATION_TEST_PRIVATE_LINKS}
+         )
+
+TUDAT_ADD_TEST_CASE(EstimationComaModelDrag
+         PRIVATE_LINKS
+         ${ORBIT_DETERMINATION_TEST_PRIVATE_LINKS}
+         )
+
  TUDAT_ADD_TEST_CASE(ParameterPropagatorConsistency
          PRIVATE_LINKS
          ${ORBIT_DETERMINATION_TEST_PRIVATE_LINKS}

--- a/tests/test_tudat/src/astro/orbit_determination/acceleration_partials/unitTestAccelerationPartials.cpp
+++ b/tests/test_tudat/src/astro/orbit_determination/acceleration_partials/unitTestAccelerationPartials.cpp
@@ -11,9 +11,11 @@
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MAIN
 
+#include <cmath>
 #include <limits>
 #include <string>
 #include "tudat/basics/testMacros.h"
+#include "tudat/simulation/environment_setup/createAtmosphereModel.h"
 #include "tudat/astro/basic_astro/orbitalElementConversions.h"
 #include "tudat/astro/basic_astro/unitConversions.h"
 
@@ -1018,6 +1020,169 @@ BOOST_AUTO_TEST_CASE( testAerodynamicAccelerationPartials )
         TUDAT_CHECK_MATRIX_CLOSE_FRACTION( testPartialWrtArcWiseDragDirectionScaling, partialWrtArcWiseDragDirection, 1.0e-7 );
         TUDAT_CHECK_MATRIX_CLOSE_FRACTION( testPartialWrtArcWiseSideDirectionScaling, partialWrtArcWiseSideDirection, 1.0e-7 );
         TUDAT_CHECK_MATRIX_CLOSE_FRACTION( testPartialWrtArcWiseLiftDirectionScaling, partialWrtArcWiseLiftDirection, 1.0e-7 );
+    }
+}
+
+// Regression test for NaN bug in AerodynamicAccelerationPartial when a wind model is present.
+// Pre-fit residuals path (observation simulators reading SPICE ephemerides) does not exercise the
+// partial code; variational equations propagation inside the Estimator constructor does, and was
+// producing NaN entries that broke the Lagrange interpolator construction downstream
+// (lagrangeInterpolator.h:131). This test isolates AerodynamicAccelerationPartial::update() and
+// wrtParameter(constantDragCoefficient) under different wind magnitudes — including a magnitude
+// that drives airspeed through zero (where the aerodynamic frame becomes singular).
+BOOST_AUTO_TEST_CASE( testAerodynamicAccelerationPartialsWithWind )
+{
+    spice_interface::loadStandardSpiceKernels( );
+
+    // Sweep wind magnitude (m/s) in the vertical frame — the radial (z) component.
+    // 0 = no wind (sanity baseline)
+    // 1000 / 3000 = wind larger than but not exactly matching airspeed
+    // 7700 = wind magnitude tuned to ~vehicle ground speed, driving airspeed near zero
+    // -1500 = wind opposing vehicle motion (large airspeed regime, like Rosetta + 700 m/s outflow)
+    const std::vector< double > windSpeeds = { 0.0, 1000.0, 3000.0, 7700.0, -1500.0 };
+
+    for( const double windZ: windSpeeds )
+    {
+        BOOST_TEST_MESSAGE( "Sub-case: wind_z = " << windZ << " m/s in vertical frame" );
+
+        BodyListSettings defaultBodySettings = getDefaultBodySettings( { "Earth" } );
+        defaultBodySettings.at( "Earth" )->ephemerisSettings = std::make_shared< ConstantEphemerisSettings >( Eigen::Vector6d::Zero( ) );
+
+        // Wire a constant wind into the Earth atmosphere — radial outflow in the vertical frame,
+        // matching the way the failing Rosetta cases set up their wind models.
+        const Eigen::Vector3d constantWindVerticalFrame( 0.0, 0.0, windZ );
+        const auto windFunction = [ constantWindVerticalFrame ]( const double, const double, const double, const double ) {
+            return constantWindVerticalFrame;
+        };
+        defaultBodySettings.at( "Earth" )->atmosphereSettings->setWindSettings(
+                std::make_shared< CustomWindModelSettings >( windFunction, reference_frames::vertical_frame ) );
+
+        SystemOfBodies bodies = createSystemOfBodies( defaultBodySettings );
+
+        // Create vehicle (mirrors testAerodynamicAccelerationPartials).
+        const double vehicleMass = 5.0E3;
+        bodies.createEmptyBody( "Vehicle" );
+        bodies.at( "Vehicle" )->setConstantBodyMass( vehicleMass );
+
+        const bool areCoefficientsInAerodynamicFrame = true;
+        const Eigen::Vector3d aerodynamicCoefficients = ( Eigen::Vector3d( ) << 2.5, -0.1, 0.5 ).finished( );
+
+        std::shared_ptr< AerodynamicCoefficientSettings > aerodynamicCoefficientSettings =
+                std::make_shared< ConstantAerodynamicCoefficientSettings >(
+                        2.0,
+                        4.0,
+                        Eigen::Vector3d::Zero( ),
+                        aerodynamicCoefficients,
+                        Eigen::Vector3d::Zero( ),
+                        aerodynamics::getAerodynamicCoefficientFrame( areCoefficientsInAerodynamicFrame, true ),
+                        aerodynamics::getAerodynamicCoefficientFrame( areCoefficientsInAerodynamicFrame, true ) );
+        bodies.at( "Vehicle" )
+                ->setAerodynamicCoefficientInterface(
+                        createAerodynamicCoefficientInterface( aerodynamicCoefficientSettings, "Vehicle", bodies ) );
+
+        // Spherical → Cartesian initial state at 120 km altitude, ~7.7 km/s ground speed.
+        Eigen::Vector6d vehicleSphericalEntryState;
+        vehicleSphericalEntryState( SphericalOrbitalStateElementIndices::radiusIndex ) =
+                spice_interface::getAverageRadius( "Earth" ) + 120.0E3;
+        vehicleSphericalEntryState( SphericalOrbitalStateElementIndices::latitudeIndex ) = 0.0;
+        vehicleSphericalEntryState( SphericalOrbitalStateElementIndices::longitudeIndex ) = 1.2;
+        vehicleSphericalEntryState( SphericalOrbitalStateElementIndices::speedIndex ) = 7.7E3;
+        vehicleSphericalEntryState( SphericalOrbitalStateElementIndices::flightPathIndex ) =
+                -0.9 * mathematical_constants::PI / 180.0;
+        vehicleSphericalEntryState( SphericalOrbitalStateElementIndices::headingAngleIndex ) = 0.6;
+
+        const Eigen::Vector6d systemInitialState = tudat::ephemerides::transformStateToTargetFrame(
+                convertSphericalOrbitalToCartesianState( vehicleSphericalEntryState ),
+                0.0,
+                bodies.at( "Earth" )->getRotationalEphemeris( ) );
+
+        bodies.at( "Earth" )->setStateFromEphemeris( 0.0 );
+        bodies.at( "Earth" )->setCurrentRotationToLocalFrameFromEphemeris( 0.0 );
+        bodies.at( "Vehicle" )->setState( systemInitialState );
+
+        std::shared_ptr< basic_astrodynamics::AccelerationModel3d > accelerationModel =
+                simulation_setup::createAerodynamicAcceleratioModel(
+                        bodies.at( "Vehicle" ), bodies.at( "Earth" ), "Vehicle", "Earth" );
+        bodies.at( "Vehicle" )->getFlightConditions( )->updateConditions( 0.0 );
+        accelerationModel->updateMembers( 0.0 );
+
+        std::shared_ptr< AccelerationPartial > aerodynamicAccelerationPartial =
+                createAnalyticalAccelerationPartial( accelerationModel,
+                                                     std::make_pair( "Vehicle", bodies.at( "Vehicle" ) ),
+                                                     std::make_pair( "Earth", bodies.at( "Earth" ) ),
+                                                     bodies );
+
+        std::shared_ptr< EstimatableParameter< double > > dragCoefficientParameter =
+                std::make_shared< ConstantDragCoefficient >(
+                        std::dynamic_pointer_cast< aerodynamics::CustomAerodynamicCoefficientInterface >(
+                                bodies.at( "Vehicle" )->getAerodynamicCoefficientInterface( ) ),
+                        "Vehicle",
+                        bodies.at( "Vehicle" )->getFlightConditions( )->getAerodynamicAngleCalculator( ) );
+
+        // === The actual bug surface: update() and parameter partials must be finite. ===
+        BOOST_REQUIRE_NO_THROW( aerodynamicAccelerationPartial->update( 0.0 ) );
+
+        Eigen::MatrixXd partialWrtVehiclePosition = Eigen::Matrix3d::Zero( );
+        aerodynamicAccelerationPartial->wrtPositionOfAcceleratedBody( partialWrtVehiclePosition.block( 0, 0, 3, 3 ) );
+        Eigen::MatrixXd partialWrtVehicleVelocity = Eigen::Matrix3d::Zero( );
+        aerodynamicAccelerationPartial->wrtVelocityOfAcceleratedBody( partialWrtVehicleVelocity.block( 0, 0, 3, 3 ), 1, 0, 0 );
+
+        const Eigen::Vector3d partialWrtDragCoefficient =
+                aerodynamicAccelerationPartial->wrtParameter( dragCoefficientParameter );
+
+        // No NaN/Inf anywhere — this is what fails today.
+        for( int i = 0; i < 3; ++i )
+        {
+            for( int j = 0; j < 3; ++j )
+            {
+                BOOST_CHECK_MESSAGE( std::isfinite( partialWrtVehiclePosition( i, j ) ),
+                                     "partialWrtVehiclePosition(" << i << "," << j << ") = "
+                                                                  << partialWrtVehiclePosition( i, j ) << " (wind_z=" << windZ << ")" );
+                BOOST_CHECK_MESSAGE( std::isfinite( partialWrtVehicleVelocity( i, j ) ),
+                                     "partialWrtVehicleVelocity(" << i << "," << j << ") = "
+                                                                  << partialWrtVehicleVelocity( i, j ) << " (wind_z=" << windZ << ")" );
+            }
+            BOOST_CHECK_MESSAGE( std::isfinite( partialWrtDragCoefficient( i ) ),
+                                 "partialWrtDragCoefficient(" << i << ") = "
+                                                              << partialWrtDragCoefficient( i ) << " (wind_z=" << windZ << ")" );
+        }
+
+        // Numerical-vs-analytical cross-check for the non-singular sub-cases. The airspeed-zero
+        // sub-case (wind_z = 7700) is excluded from the tolerance check because the partial there
+        // is genuinely ill-conditioned even when finite — but it must still be NaN-free.
+        if( std::abs( windZ - 7700.0 ) > 1.0 )
+        {
+            std::function< void( ) > environmentUpdateFunction = std::bind(
+                    &updateFlightConditionsWithPerturbedState, bodies.at( "Vehicle" )->getFlightConditions( ), 0.0 );
+            Eigen::Vector3d positionPerturbation;
+            positionPerturbation << 1.0, 1.0, 1.0;
+            Eigen::Vector3d velocityPerturbation;
+            velocityPerturbation << 1.0E-3, 1.0E-3, 1.0E-3;
+
+            std::function< void( Eigen::Vector6d ) > vehicleStateSetFunction =
+                    std::bind( &Body::setState, bodies.at( "Vehicle" ), std::placeholders::_1 );
+
+            const Eigen::Matrix3d testPartialWrtVehiclePosition = calculateAccelerationWrtStatePartials(
+                    vehicleStateSetFunction,
+                    accelerationModel,
+                    bodies.at( "Vehicle" )->getState( ),
+                    positionPerturbation,
+                    0,
+                    environmentUpdateFunction );
+            const Eigen::Matrix3d testPartialWrtVehicleVelocity = calculateAccelerationWrtStatePartials(
+                    vehicleStateSetFunction,
+                    accelerationModel,
+                    bodies.at( "Vehicle" )->getState( ),
+                    velocityPerturbation,
+                    3,
+                    environmentUpdateFunction );
+            const Eigen::Vector3d testPartialWrtDragCoefficient = calculateAccelerationWrtParameterPartials(
+                    dragCoefficientParameter, accelerationModel, 1.0E-4, environmentUpdateFunction );
+
+            TUDAT_CHECK_MATRIX_CLOSE_FRACTION( testPartialWrtVehiclePosition, partialWrtVehiclePosition, 1.0E-5 );
+            TUDAT_CHECK_MATRIX_CLOSE_FRACTION( testPartialWrtVehicleVelocity, partialWrtVehicleVelocity, 1.0E-5 );
+            TUDAT_CHECK_MATRIX_CLOSE_FRACTION( testPartialWrtDragCoefficient, partialWrtDragCoefficient, 1.0E-8 );
+        }
     }
 }
 

--- a/tests/test_tudat/src/astro/orbit_determination/acceleration_partials/unitTestAccelerationPartials.cpp
+++ b/tests/test_tudat/src/astro/orbit_determination/acceleration_partials/unitTestAccelerationPartials.cpp
@@ -1041,7 +1041,7 @@ BOOST_AUTO_TEST_CASE( testAerodynamicAccelerationPartialsWithWind )
     // -1500 = wind opposing vehicle motion (large airspeed regime, like Rosetta + 700 m/s outflow)
     const std::vector< double > windSpeeds = { 0.0, 1000.0, 3000.0, 7700.0, -1500.0 };
 
-    for( const double windZ: windSpeeds )
+    for( const double windZ : windSpeeds )
     {
         BOOST_TEST_MESSAGE( "Sub-case: wind_z = " << windZ << " m/s in vertical frame" );
 
@@ -1087,22 +1087,20 @@ BOOST_AUTO_TEST_CASE( testAerodynamicAccelerationPartialsWithWind )
         vehicleSphericalEntryState( SphericalOrbitalStateElementIndices::latitudeIndex ) = 0.0;
         vehicleSphericalEntryState( SphericalOrbitalStateElementIndices::longitudeIndex ) = 1.2;
         vehicleSphericalEntryState( SphericalOrbitalStateElementIndices::speedIndex ) = 7.7E3;
-        vehicleSphericalEntryState( SphericalOrbitalStateElementIndices::flightPathIndex ) =
-                -0.9 * mathematical_constants::PI / 180.0;
+        vehicleSphericalEntryState( SphericalOrbitalStateElementIndices::flightPathIndex ) = -0.9 * mathematical_constants::PI / 180.0;
         vehicleSphericalEntryState( SphericalOrbitalStateElementIndices::headingAngleIndex ) = 0.6;
 
-        const Eigen::Vector6d systemInitialState = tudat::ephemerides::transformStateToTargetFrame(
-                convertSphericalOrbitalToCartesianState( vehicleSphericalEntryState ),
-                0.0,
-                bodies.at( "Earth" )->getRotationalEphemeris( ) );
+        const Eigen::Vector6d systemInitialState =
+                tudat::ephemerides::transformStateToTargetFrame( convertSphericalOrbitalToCartesianState( vehicleSphericalEntryState ),
+                                                                 0.0,
+                                                                 bodies.at( "Earth" )->getRotationalEphemeris( ) );
 
         bodies.at( "Earth" )->setStateFromEphemeris( 0.0 );
         bodies.at( "Earth" )->setCurrentRotationToLocalFrameFromEphemeris( 0.0 );
         bodies.at( "Vehicle" )->setState( systemInitialState );
 
         std::shared_ptr< basic_astrodynamics::AccelerationModel3d > accelerationModel =
-                simulation_setup::createAerodynamicAcceleratioModel(
-                        bodies.at( "Vehicle" ), bodies.at( "Earth" ), "Vehicle", "Earth" );
+                simulation_setup::createAerodynamicAcceleratioModel( bodies.at( "Vehicle" ), bodies.at( "Earth" ), "Vehicle", "Earth" );
         bodies.at( "Vehicle" )->getFlightConditions( )->updateConditions( 0.0 );
         accelerationModel->updateMembers( 0.0 );
 
@@ -1112,12 +1110,11 @@ BOOST_AUTO_TEST_CASE( testAerodynamicAccelerationPartialsWithWind )
                                                      std::make_pair( "Earth", bodies.at( "Earth" ) ),
                                                      bodies );
 
-        std::shared_ptr< EstimatableParameter< double > > dragCoefficientParameter =
-                std::make_shared< ConstantDragCoefficient >(
-                        std::dynamic_pointer_cast< aerodynamics::CustomAerodynamicCoefficientInterface >(
-                                bodies.at( "Vehicle" )->getAerodynamicCoefficientInterface( ) ),
-                        "Vehicle",
-                        bodies.at( "Vehicle" )->getFlightConditions( )->getAerodynamicAngleCalculator( ) );
+        std::shared_ptr< EstimatableParameter< double > > dragCoefficientParameter = std::make_shared< ConstantDragCoefficient >(
+                std::dynamic_pointer_cast< aerodynamics::CustomAerodynamicCoefficientInterface >(
+                        bodies.at( "Vehicle" )->getAerodynamicCoefficientInterface( ) ),
+                "Vehicle",
+                bodies.at( "Vehicle" )->getFlightConditions( )->getAerodynamicAngleCalculator( ) );
 
         // === The actual bug surface: update() and parameter partials must be finite. ===
         BOOST_REQUIRE_NO_THROW( aerodynamicAccelerationPartial->update( 0.0 ) );
@@ -1127,8 +1124,7 @@ BOOST_AUTO_TEST_CASE( testAerodynamicAccelerationPartialsWithWind )
         Eigen::MatrixXd partialWrtVehicleVelocity = Eigen::Matrix3d::Zero( );
         aerodynamicAccelerationPartial->wrtVelocityOfAcceleratedBody( partialWrtVehicleVelocity.block( 0, 0, 3, 3 ), 1, 0, 0 );
 
-        const Eigen::Vector3d partialWrtDragCoefficient =
-                aerodynamicAccelerationPartial->wrtParameter( dragCoefficientParameter );
+        const Eigen::Vector3d partialWrtDragCoefficient = aerodynamicAccelerationPartial->wrtParameter( dragCoefficientParameter );
 
         // No NaN/Inf anywhere — this is what fails today.
         for( int i = 0; i < 3; ++i )
@@ -1136,15 +1132,15 @@ BOOST_AUTO_TEST_CASE( testAerodynamicAccelerationPartialsWithWind )
             for( int j = 0; j < 3; ++j )
             {
                 BOOST_CHECK_MESSAGE( std::isfinite( partialWrtVehiclePosition( i, j ) ),
-                                     "partialWrtVehiclePosition(" << i << "," << j << ") = "
-                                                                  << partialWrtVehiclePosition( i, j ) << " (wind_z=" << windZ << ")" );
+                                     "partialWrtVehiclePosition(" << i << "," << j << ") = " << partialWrtVehiclePosition( i, j )
+                                                                  << " (wind_z=" << windZ << ")" );
                 BOOST_CHECK_MESSAGE( std::isfinite( partialWrtVehicleVelocity( i, j ) ),
-                                     "partialWrtVehicleVelocity(" << i << "," << j << ") = "
-                                                                  << partialWrtVehicleVelocity( i, j ) << " (wind_z=" << windZ << ")" );
+                                     "partialWrtVehicleVelocity(" << i << "," << j << ") = " << partialWrtVehicleVelocity( i, j )
+                                                                  << " (wind_z=" << windZ << ")" );
             }
-            BOOST_CHECK_MESSAGE( std::isfinite( partialWrtDragCoefficient( i ) ),
-                                 "partialWrtDragCoefficient(" << i << ") = "
-                                                              << partialWrtDragCoefficient( i ) << " (wind_z=" << windZ << ")" );
+            BOOST_CHECK_MESSAGE(
+                    std::isfinite( partialWrtDragCoefficient( i ) ),
+                    "partialWrtDragCoefficient(" << i << ") = " << partialWrtDragCoefficient( i ) << " (wind_z=" << windZ << ")" );
         }
 
         // Numerical-vs-analytical cross-check for the non-singular sub-cases. The airspeed-zero
@@ -1152,8 +1148,8 @@ BOOST_AUTO_TEST_CASE( testAerodynamicAccelerationPartialsWithWind )
         // is genuinely ill-conditioned even when finite — but it must still be NaN-free.
         if( std::abs( windZ - 7700.0 ) > 1.0 )
         {
-            std::function< void( ) > environmentUpdateFunction = std::bind(
-                    &updateFlightConditionsWithPerturbedState, bodies.at( "Vehicle" )->getFlightConditions( ), 0.0 );
+            std::function< void( ) > environmentUpdateFunction =
+                    std::bind( &updateFlightConditionsWithPerturbedState, bodies.at( "Vehicle" )->getFlightConditions( ), 0.0 );
             Eigen::Vector3d positionPerturbation;
             positionPerturbation << 1.0, 1.0, 1.0;
             Eigen::Vector3d velocityPerturbation;
@@ -1162,20 +1158,20 @@ BOOST_AUTO_TEST_CASE( testAerodynamicAccelerationPartialsWithWind )
             std::function< void( Eigen::Vector6d ) > vehicleStateSetFunction =
                     std::bind( &Body::setState, bodies.at( "Vehicle" ), std::placeholders::_1 );
 
-            const Eigen::Matrix3d testPartialWrtVehiclePosition = calculateAccelerationWrtStatePartials(
-                    vehicleStateSetFunction,
-                    accelerationModel,
-                    bodies.at( "Vehicle" )->getState( ),
-                    positionPerturbation,
-                    0,
-                    environmentUpdateFunction );
-            const Eigen::Matrix3d testPartialWrtVehicleVelocity = calculateAccelerationWrtStatePartials(
-                    vehicleStateSetFunction,
-                    accelerationModel,
-                    bodies.at( "Vehicle" )->getState( ),
-                    velocityPerturbation,
-                    3,
-                    environmentUpdateFunction );
+            const Eigen::Matrix3d testPartialWrtVehiclePosition =
+                    calculateAccelerationWrtStatePartials( vehicleStateSetFunction,
+                                                           accelerationModel,
+                                                           bodies.at( "Vehicle" )->getState( ),
+                                                           positionPerturbation,
+                                                           0,
+                                                           environmentUpdateFunction );
+            const Eigen::Matrix3d testPartialWrtVehicleVelocity =
+                    calculateAccelerationWrtStatePartials( vehicleStateSetFunction,
+                                                           accelerationModel,
+                                                           bodies.at( "Vehicle" )->getState( ),
+                                                           velocityPerturbation,
+                                                           3,
+                                                           environmentUpdateFunction );
             const Eigen::Vector3d testPartialWrtDragCoefficient = calculateAccelerationWrtParameterPartials(
                     dragCoefficientParameter, accelerationModel, 1.0E-4, environmentUpdateFunction );
 

--- a/tests/test_tudat/src/astro/orbit_determination/unitTestEstimationDragWithWind.cpp
+++ b/tests/test_tudat/src/astro/orbit_determination/unitTestEstimationDragWithWind.cpp
@@ -1,0 +1,187 @@
+/*    Copyright (c) 2010-2019, Delft University of Technology
+ *    All rigths reserved
+ *
+ *    This file is part of the Tudat. Redistribution and use in source and
+ *    binary forms, with or without modification, are permitted exclusively
+ *    under the terms of the Modified BSD license. You should have received
+ *    a copy of the license with this file. If not, please or visit:
+ *    http://tudat.tudelft.nl/LICENSE.
+ */
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MAIN
+
+#include <cmath>
+#include <iostream>
+
+#include <boost/test/unit_test.hpp>
+
+#include "tudat/simulation/environment_setup/createAtmosphereModel.h"
+#include "tudat/simulation/environment_setup/createBodiesFactory.h"
+#include "tudat/simulation/environment_setup/defaultBodies.h"
+#include "tudat/simulation/estimation_setup/createEstimatableParametersFactory.h"
+#include "tudat/simulation/estimation_setup/orbitDeterminationManager.h"
+#include "tudat/simulation/estimation_setup/simulatePseudoObservations.h"
+#include "tudat/simulation/estimation_setup/simulateObservations.h"
+#include "tudat/simulation/propagation_setup/singleArcDynamicsSimulator.h"
+
+namespace tudat
+{
+namespace unit_tests
+{
+
+using namespace tudat;
+using namespace tudat::observation_models;
+using namespace tudat::orbit_determination;
+using namespace tudat::estimatable_parameters;
+using namespace tudat::simulation_setup;
+using namespace tudat::basic_astrodynamics;
+using namespace tudat::propagators;
+
+BOOST_AUTO_TEST_SUITE( test_estimation_drag_with_wind )
+
+// Regression test for the NaN bug in variational-equations propagation when a wind model is
+// active together with aerodynamic drag and Cd is estimated. The bug surfaces in Python as:
+//
+//     RuntimeError: Error: Lagrange interpolator cannot identify zero entry.
+//
+// thrown from lagrangeInterpolator.h:131 — the integrated state map fed to the interpolator
+// contains NaN entries because AerodynamicAccelerationPartial::update() produces NaN partials
+// when wind is present.
+//
+// This test mirrors the structure of unitTestEstimationDragScaling.cpp::test_EstimationDragScaling
+// but adds a wind model. It uses ExponentialAtmosphere (no coma — that's covered by a separate
+// test) so it isolates the aerodynamic-partial + wind interaction.
+BOOST_AUTO_TEST_CASE( test_VariationalEquationsWithWindModel )
+{
+    spice_interface::loadStandardSpiceKernels( );
+
+    spice_interface::loadSpiceKernelInTudat( paths::getTudatTestDataPath( ) +
+                                             "/dsn_n_way_doppler_observation_model/mgs_map1_ipng_mgs95j.bsp" );
+
+    // Sweep wind reference frame: corotating and vertical (both are used in production setups).
+    for( int frameIndex = 0; frameIndex < 2; ++frameIndex )
+    {
+        const reference_frames::AerodynamicsReferenceFrames windFrame =
+                ( frameIndex == 0 ) ? reference_frames::corotating_frame : reference_frames::vertical_frame;
+        BOOST_TEST_MESSAGE( "Sub-case: wind frame = " << ( frameIndex == 0 ? "corotating" : "vertical" ) );
+
+        const double initialTime = DateTime( 1999, 3, 10, 0, 0, 0.0 ).epoch< double >( );
+        const double finalTime = initialTime + 3600 * 6;
+
+        std::vector< std::string > bodyNames = { "Mars", "Sun" };
+        BodyListSettings bodySettings = getDefaultBodySettings( bodyNames, "Mars" );
+        bodySettings.addSettings( "MGS" );
+        bodySettings.at( "MGS" )->ephemerisSettings =
+                std::make_shared< InterpolatedSpiceEphemerisSettings >( initialTime - 3600.0, finalTime + 3600.0, 30.0, "Mars" );
+        bodySettings.at( "MGS" )->radiationPressureTargetModelSettings = cannonballRadiationPressureTargetModelSettings( 10.0, 1.2 );
+
+        // Mars atmosphere with a constant wind. The wind is non-zero so the aerodynamic partial
+        // exercises the same code path as the failing Rosetta cases.
+        const Eigen::Vector3d constantWindInFrame( 100.0, -50.0, 200.0 );
+        const auto windFunction = [ constantWindInFrame ]( const double, const double, const double, const double ) {
+            return constantWindInFrame;
+        };
+        bodySettings.at( "Mars" )->atmosphereSettings = std::make_shared< ExponentialAtmosphereSettings >( aerodynamics::mars );
+        bodySettings.at( "Mars" )->atmosphereSettings->setWindSettings(
+                std::make_shared< CustomWindModelSettings >( windFunction, windFrame ) );
+
+        SystemOfBodies bodies = createSystemOfBodies( bodySettings );
+        bodies.at( "MGS" )->setConstantBodyMass( 2.0 );
+
+        // Aerodynamic coefficients.
+        const Eigen::Vector3d forceCoefficients( 1.0, 0.0, 0.0 );
+        std::shared_ptr< AerodynamicCoefficientSettings > aerodynamicCoefficientSettings =
+                std::make_shared< ConstantAerodynamicCoefficientSettings >(
+                        2000.0, forceCoefficients, aerodynamics::negative_aerodynamic_frame_coefficients );
+        bodies.at( "MGS" )->setAerodynamicCoefficientInterface(
+                createAerodynamicCoefficientInterface( aerodynamicCoefficientSettings, "MGS", bodies ) );
+
+        // Acceleration setup: aerodynamic + point-mass gravity (drag is what exercises the bug).
+        SelectedAccelerationMap accelerationMap;
+        std::map< std::string, std::vector< std::shared_ptr< AccelerationSettings > > > accelerationsOfSpacecraft;
+        accelerationsOfSpacecraft[ "Mars" ].push_back( std::make_shared< AccelerationSettings >( aerodynamic ) );
+        accelerationsOfSpacecraft[ "Mars" ].push_back( std::make_shared< AccelerationSettings >( point_mass_gravity ) );
+        accelerationMap[ "MGS" ] = accelerationsOfSpacecraft;
+
+        std::vector< std::string > bodiesToEstimate = { "MGS" };
+        std::vector< std::string > centralBodies = { "Mars" };
+        AccelerationMap accelerationModelMap = createAccelerationModelsMap( bodies, accelerationMap, bodiesToEstimate, centralBodies );
+
+        // Estimate initial state + Cd — the exact parameter combination that triggers the bug.
+        std::vector< std::shared_ptr< estimatable_parameters::EstimatableParameterSettings > > additionalParameterNames;
+        additionalParameterNames.push_back( estimatable_parameters::constantDragCoefficient( "MGS" ) );
+
+        const Eigen::Matrix< double, Eigen::Dynamic, 1 > initialState =
+                getInitialStatesOfBodies( bodiesToEstimate, centralBodies, bodies, initialTime );
+
+        std::vector< std::shared_ptr< SingleDependentVariableSaveSettings > > dependentVariablesList;
+        dependentVariablesList.push_back( singleAccelerationDependentVariable( basic_astrodynamics::aerodynamic, "MGS", "Mars" ) );
+
+        std::shared_ptr< TranslationalStatePropagatorSettings< double > > propagatorSettings =
+                std::make_shared< TranslationalStatePropagatorSettings< double > >(
+                        centralBodies,
+                        accelerationModelMap,
+                        bodiesToEstimate,
+                        initialState,
+                        initialTime,
+                        numerical_integrators::rungeKuttaFixedStepSettings( 120.0, numerical_integrators::rungeKuttaFehlberg78 ),
+                        std::make_shared< PropagationTimeTerminationSettings >( finalTime ),
+                        cowell,
+                        dependentVariablesList );
+
+        std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNames =
+                getInitialStateParameterSettings< double, double >( propagatorSettings, bodies );
+        parameterNames.insert( parameterNames.end( ), additionalParameterNames.begin( ), additionalParameterNames.end( ) );
+
+        std::shared_ptr< estimatable_parameters::EstimatableParameterSet< double > > parametersToEstimate =
+                createParametersToEstimate< double, double >( parameterNames, bodies, propagatorSettings );
+
+        // Pseudo-observations — needed by OrbitDeterminationManager constructor.
+        std::pair< std::vector< std::shared_ptr< observation_models::ObservationModelSettings > >,
+                   std::shared_ptr< observation_models::ObservationCollection< double > > >
+                observationCollectionAndModelSettings =
+                        simulatePseudoObservations( bodies, bodiesToEstimate, centralBodies, initialTime, finalTime, 120.0 );
+        const std::vector< std::shared_ptr< observation_models::ObservationModelSettings > > observationModelSettingsList =
+                observationCollectionAndModelSettings.first;
+
+        // === The actual bug surface. ===
+        // The OrbitDeterminationManager constructor propagates the variational equations together
+        // with the dynamics. If AerodynamicAccelerationPartial::update() produces NaN partials,
+        // the integrated variational state has NaN entries; the subsequent Lagrange interpolator
+        // construction (state ephemeris) throws with the message the user sees in Python.
+        std::shared_ptr< OrbitDeterminationManager< double > > orbitDeterminationManager;
+        BOOST_REQUIRE_NO_THROW( orbitDeterminationManager = std::make_shared< OrbitDeterminationManager< double > >(
+                                        bodies, parametersToEstimate, observationModelSettingsList, propagatorSettings ) );
+        BOOST_REQUIRE( orbitDeterminationManager != nullptr );
+
+        // Probe the state-transition + sensitivity interface at a few epochs. If the
+        // interpolators inside it were built from NaN-laden matrices, query results are NaN —
+        // catches the case where the upstream catch block silently swallowed the Lagrange
+        // exception and left the interface populated with null interpolators that produce NaN
+        // when queried.
+        auto stateTransitionInterface = orbitDeterminationManager->getStateTransitionAndSensitivityMatrixInterface( );
+        BOOST_REQUIRE( stateTransitionInterface != nullptr );
+
+        const std::vector< double > probeTimes = { initialTime + 600.0, initialTime + 1800.0, initialTime + 3600.0, initialTime + 5400.0 };
+        for( const double t : probeTimes )
+        {
+            Eigen::MatrixXd combined;
+            BOOST_REQUIRE_NO_THROW( combined = stateTransitionInterface->getCombinedStateTransitionAndSensitivityMatrix( t ) );
+            for( int row = 0; row < combined.rows( ); ++row )
+            {
+                for( int col = 0; col < combined.cols( ); ++col )
+                {
+                    BOOST_CHECK_MESSAGE( std::isfinite( combined( row, col ) ),
+                                         "combined state transition + sensitivity matrix has non-finite entry at t="
+                                                 << t << " (" << row << "," << col << ") = " << combined( row, col ) );
+                }
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END( )
+
+}  // namespace unit_tests
+}  // namespace tudat


### PR DESCRIPTION
**The bug**

Running an estimation with drag + a wind model crashed with:

`Error: Lagrange interpolator cannot identify zero entry.`

The NaN came from this line in `propagationOutput.h`, which computes the wind velocity in the output frame:

`return rotationMatrixFunction() * windVelocityCorotatingFunction();`

Eigen returns this product as an expression that points at the two temporary values from the function calls. Those temporaries die when the line returns, so the result reads dead memory → NaN. 

**The fix**

Store the result in a real vector before returning, so nothing points at dead memory:

```
Eigen::Vector3d transformedWindVelocity =
    rotationMatrixFunction() * windVelocityCorotatingFunction();
return transformedWindVelocity;
```

**Additions**

- Some additional clean-up for coma model 
- using `getAerodynamicAngleCalculator() ` in `propagationOutput.h` for readability