### PR TITLE
Minor fixes to docstrings and failing gravitational constant unit test

### DIFF
--- a/src/tudatpy/data/expose_data.cpp
+++ b/src/tudatpy/data/expose_data.cpp
@@ -580,7 +580,10 @@ Read a mapping from DOMES id to station name.
            R"doc(
  Reads a space weather data file and produces a dictionary with solar activity data for a range of epochs. Data files can be obtained from http://celestrak.com/SpaceData and should follow the legacy format.
 
- :param file_path: Path to the space weather data file.
+ Parameters
+ ----------
+ file_path : str
+     Path to the space weather data file.
  )doc" );
 
     py::class_< tio::solar_activity::SolarActivityContainer, std::shared_ptr< tio::solar_activity::SolarActivityContainer > >(
@@ -657,7 +660,10 @@ Read a mapping from DOMES id to station name.
 
                   The file is created if it does not exist, and it can have, for example, txt extension
 
-                  :param output_file: Contents will be written to the file defined by this path
+                  Parameters
+                  ----------
+                  output_file : str
+                      Contents will be written to the file defined by this path
                   )doc" );
 
     py::class_< tio::OdfDataSpecificBlock, std::shared_ptr< tio::OdfDataSpecificBlock > >(
@@ -692,7 +698,10 @@ Read a mapping from DOMES id to station name.
 
                   The file is created if it does not exist, and it can have, for example, txt extension
 
-                  :param output_file: Contents will be written to the file defined by this path
+                  Parameters
+                  ----------
+                  output_file : str
+                      Contents will be written to the file defined by this path
                   )doc" );
 
     py::class_< tio::OdfRampBlock, std::shared_ptr< tio::OdfRampBlock > >(
@@ -789,11 +798,19 @@ Read a mapping from DOMES id to station name.
 
            Two of the columns of an IFMS file contain, respectively, the Doppler averaged frequency and a tropospheric correction for the station. When the `apply_tropospheric_correction` option is set to true, the content of the first column is modified by subtracting the values in the second.
 
-           :param file_name: String representing the path to the file to be loaded
-           :param apply_tropospheric_correction: Whether to modify the averaged Doppler frequency as described above (Default: True)
-           :param remove_invalid_lines: Boolean defining whether a line is skipped if the transmit frequency, observed frequency, or troposphere correction is undefined (Default: True)
+           Parameters
+           ----------
+           file_name : str
+               String representing the path to the file to be loaded
+           apply_tropospheric_correction : bool
+               Whether to modify the averaged Doppler frequency as described above (Default: True)
+           remove_invalid_lines : bool
+               Boolean defining whether a line is skipped if the transmit frequency, observed frequency, or troposphere correction is undefined (Default: True)
 
-           :return ifms_contents: Dictionary with contents of the IFMS file as lists of strings
+           Returns
+           -------
+           ifms_contents : TrackingTxtFileContents
+               Dictionary with contents of the IFMS file as lists of strings
            )doc" );
     m.def( "set_estrack_weather_data_in_ground_stations",
            py::overload_cast< tudat::simulation_setup::SystemOfBodies&,
@@ -828,9 +845,17 @@ Read a mapping from DOMES id to station name.
            - Doppler measured frequency [Hz]
            - Doppler noise [Hz]
 
-           :param file_name: String representing the path to the file to be loaded
-           :param column_types: Identifiers of the columns present in the Fdets file
-           :return fdets_contents: Dictionary with contents of the Fdets file as lists of strings
+           Parameters
+           ----------
+           file_name : str
+               String representing the path to the file to be loaded
+           column_types : List[str]
+               Identifiers of the columns present in the Fdets file
+
+           Returns
+           -------
+           fdets_contents : TrackingTxtFileContents
+               Dictionary with contents of the Fdets file as lists of strings
            )doc" );
 };
 

--- a/src/tudatpy/data/mission_data_downloader/mission_data_downloader.py
+++ b/src/tudatpy/data/mission_data_downloader/mission_data_downloader.py
@@ -54,7 +54,7 @@ class LoadPDS:
             },
             "mex": {
                 "ck": r"^(?P<mission>MEX)?_?(?P<data>ATNM)?_?(?P<purpose>(MEASURED|T6|SA))?_?(?P<start_date_file>(\d{4}|\d{6}|P\d{12}))?_?(?P<end_date_file>\d{6})?_?(?P<sclk>S\d{6})?_?(?P<version>(V\d+|\d+))?(?P<extension>\.BC)?$",
-                "spk": "^(?P<data>(ORMM|ORMF))_(?P<SPK_type>T19)_(?P<start_date_file>\d{6})_?(?P<end_date_file>\d{6})_(?P<version>\d{5})(?P<extension>\.BSP)?$",
+                "spk": r"^(?P<data>(ORMM|ORMF))_(?P<SPK_type>T19)_(?P<start_date_file>\d{6})_?(?P<end_date_file>\d{6})_(?P<version>\d{5})(?P<extension>\.BSP)?$",
                 "ifms": r"^(?P<mission>[a-zA-Z0-9]+)_(?P<band>[a-zA-Z0-9]+)_(?P<date_file>[0-9]{9})_(?P<version>[0-9]{2})(?P<extension>\.tab$)",
                 "dp2": r"^(?P<mission>[a-zA-Z0-9]+)_(?P<band>[a-zA-Z0-9]+)_(?P<date_file>[0-9]{9})_(?P<version>[0-9]{2})(?P<extension>\.tab$)",
                 "dpx": r"^(?P<mission>[a-zA-Z0-9]+)_(?P<band>[a-zA-Z0-9]+)_(?P<date_file>[0-9]{9})_(?P<version>[0-9]{2})(?P<extension>\.tab$)",
@@ -572,7 +572,7 @@ class LoadPDS:
             - `input_mission` (`str`): The name of the mission
             - `url` (`str`): The base URL where the kernel files are hosted.
             - `wanted_files` (`list`, optional): A list of specific filenames to be downloaded from the URL.
-            - `wanted_files_pattern` (`str`, optional): A pattern (e.g., '\*.tf') to match filenames for downloading.
+            - `wanted_files_pattern` (`str`, optional): A pattern (e.g., '\\*.tf') to match filenames for downloading.
             - `custom_output` (`str`, optional): The local directory where the downloaded files will be stored.
 
         Output:
@@ -1278,7 +1278,7 @@ class LoadPDS:
         # BeautifulSoup package to look for all pattern-matching names at the targeted url (without any a priori information on the date and/or
         # wildcard present in the file name)
         reduced_filename = filename_split[-1]
-        reduced_filename = reduced_filename.replace("\w", "*")
+        reduced_filename = reduced_filename.replace(r"\w", "*")
 
         # Retrieve all filenames present at the "local_path" location that match the specified filename format
 

--- a/src/tudatpy/dynamics/environment_setup/atmosphere/expose_atmosphere.cpp
+++ b/src/tudatpy/dynamics/environment_setup/atmosphere/expose_atmosphere.cpp
@@ -83,7 +83,10 @@ The values in this class may be recomputed every time step to reflect changing a
 
                          Currently, the ideal gas law is used to compute the speed of sound and the specific heat ratio is assumed to be constant and equal to 1.4.
 
-                         :param solar_activity_data: Solar activity data for a range of epochs as produced by tudatpy.data.read_solar_activity_data.
+                         Parameters
+                         ----------
+                         solar_activity_data : Dict[float, SolarActivityData]
+                             Solar activity data for a range of epochs as produced by tudatpy.data.read_solar_activity_data.
                          )doc" )
             .def( py::init< const std::map< double, std::shared_ptr< tio::solar_activity::SolarActivityData > >,
                             const bool,
@@ -108,11 +111,21 @@ The values in this class may be recomputed every time step to reflect changing a
                              Returns the local density at the given altitude,
                              longitude, latitude and time.
 
-                             :param altitude: Altitude at which to get the density. [m]
-                             :param longitude: Longitude at which to get the density [rad].
-                             :param latitude: Latitude at which to get the density [rad].
-                             :param time: Time at which density is to be computed [seconds since J2000].
-                             :return: Local density. [kg/m^3]
+                             Parameters
+                             ----------
+                             altitude : float
+                                 Altitude at which to get the density. [m]
+                             longitude : float
+                                 Longitude at which to get the density [rad].
+                             latitude : float
+                                 Latitude at which to get the density [rad].
+                             time : float
+                                 Time at which density is to be computed [seconds since J2000].
+
+                             Returns
+                             -------
+                             float
+                                 Local density. [kg/m^3]
                              )doc" );
 
     // END OF NRLMSISE00

--- a/tests/test_tudatpy/test_constants.py
+++ b/tests/test_tudatpy/test_constants.py
@@ -24,7 +24,7 @@ def test_constant_values():
 
     assert constants.SPEED_OF_LIGHT_LONG == 299792458.0
 
-    assert constants.GRAVITATIONAL_CONSTANT == 6.67259e-11
+    assert constants.GRAVITATIONAL_CONSTANT == 6.67430e-11
 
     assert constants.MOLAR_GAS_CONSTANT == 8.3144598
 


### PR DESCRIPTION
- Fix outdated gravitational constant in python unit test
- Make docstrings in sphinx format consistent with remaining docstrings
- Fix literal characters in mission data downloader module that print warning on import