### PR TITLE
Fix multi-body Love number parameter setup

### DIFF
--- a/include/tudat/astro/gravitation/gravityFieldVariations.h
+++ b/include/tudat/astro/gravitation/gravityFieldVariations.h
@@ -413,15 +413,19 @@ public:
 
     //! Function to retrieve all compatible tidal gravity field variations covering the requested deforming bodies
     /*!
-     * Selects variation models of the requested tidal type that together cover the requested deforming bodies.
-     * An empty deformingBodies list selects every compatible model of the requested type. Models whose deforming-body
-     * set only partially overlaps the request are rejected. Duplicate coverage of a requested body is rejected.
-     * \param deformingBodies List of tide-raising bodies that must be covered (empty = select all compatible models)
+     * Selects variation models of the requested tidal type that provide the requested Love-number degree and together
+     * cover the requested deforming bodies. Models that do not contain the requested degree are ignored before any
+     * coverage checks. An empty deformingBodies list selects every degree-compatible model of the requested type, but
+     * still rejects duplicate coverage of any deforming body. Models whose deforming-body set only partially overlaps
+     * an explicit request are rejected.
+     * \param deformingBodies List of tide-raising bodies that must be covered (empty = select all degree-compatible models)
+     * \param requestedDegree Spherical-harmonic degree that must be available in each selected model
      * \param tideType Type of tidal gravity field variation to select
      * \return Selected variation models in environment order
      */
     std::vector< std::shared_ptr< GravityFieldVariations > > getDirectTidalGravityFieldVariations(
             const std::vector< std::string >& deformingBodies,
+            const int requestedDegree,
             const BodyDeformationTypes tideType = basic_solid_body );
 
     //! Function to retrieve the tidal gravity field variations

--- a/include/tudat/astro/gravitation/gravityFieldVariations.h
+++ b/include/tudat/astro/gravitation/gravityFieldVariations.h
@@ -411,6 +411,19 @@ public:
     std::shared_ptr< GravityFieldVariations > getDirectTidalGravityFieldVariation( const std::vector< std::string >& deformingBodies,
                                                                                    const BodyDeformationTypes tideType = basic_solid_body );
 
+    //! Function to retrieve all compatible tidal gravity field variations covering the requested deforming bodies
+    /*!
+     * Selects variation models of the requested tidal type that together cover the requested deforming bodies.
+     * An empty deformingBodies list selects every compatible model of the requested type. Models whose deforming-body
+     * set only partially overlaps the request are rejected. Duplicate coverage of a requested body is rejected.
+     * \param deformingBodies List of tide-raising bodies that must be covered (empty = select all compatible models)
+     * \param tideType Type of tidal gravity field variation to select
+     * \return Selected variation models in environment order
+     */
+    std::vector< std::shared_ptr< GravityFieldVariations > > getDirectTidalGravityFieldVariations(
+            const std::vector< std::string >& deformingBodies,
+            const BodyDeformationTypes tideType = basic_solid_body );
+
     //! Function to retrieve the tidal gravity field variations
     /*!
      * Function to retrieve the tidal gravity field variations

--- a/include/tudat/astro/gravitation/gravityFieldVariations.h
+++ b/include/tudat/astro/gravitation/gravityFieldVariations.h
@@ -423,7 +423,7 @@ public:
      * \param tideType Type of tidal gravity field variation to select
      * \return Selected variation models in environment order
      */
-    std::vector< std::shared_ptr< GravityFieldVariations > > getDirectTidalGravityFieldVariations(
+    std::vector< std::shared_ptr< GravityFieldVariations > > getDirectTidalGravityFieldVariationsForDegree(
             const std::vector< std::string >& deformingBodies,
             const int requestedDegree,
             const BodyDeformationTypes tideType = basic_solid_body );

--- a/include/tudat/astro/orbit_determination/acceleration_partials/tidalLoveNumberPartialInterface.h
+++ b/include/tudat/astro/orbit_determination/acceleration_partials/tidalLoveNumberPartialInterface.h
@@ -58,7 +58,8 @@ public:
                                      const std::vector< std::function< Eigen::Vector3d( ) > > deformingBodyStateFunctions,
                                      const std::function< Eigen::Quaterniond( ) > rotationToDeformedBodyFrameFrameFunction,
                                      const std::string& deformedBody ):
-        deformedBodyPositionFunction_( deformedBodyPositionFunction ), deformingBodyStateFunctions_( deformingBodyStateFunctions ),
+        gravityFieldVariations_( gravityFieldVariations ), deformedBodyPositionFunction_( deformedBodyPositionFunction ),
+        deformingBodyStateFunctions_( deformingBodyStateFunctions ),
         rotationToDeformedBodyFrameFrameFunction_( rotationToDeformedBodyFrameFrameFunction ), deformedBody_( deformedBody )
     {
         // Get members from input objects.
@@ -382,6 +383,12 @@ public:
         return deformingBodies_;
     }
 
+    //! Function to retrieve the underlying tidal variation model used by this interface
+    std::shared_ptr< gravitation::SolidBodyTideGravityFieldVariations > getGravityFieldVariations( ) const
+    {
+        return gravityFieldVariations_;
+    }
+
 protected:
     //! Function to compute Love number partials from pre-computed partials and provided scaling values
     /*!
@@ -440,6 +447,9 @@ protected:
 
     //! Reference radius used by tidal deformation model.
     double deformedBodyReferenceRadius_;
+
+    //! Underlying tidal gravity field variation model associated with this interface
+    std::shared_ptr< gravitation::SolidBodyTideGravityFieldVariations > gravityFieldVariations_;
 
     //! Function to retrieve current state of body being tidally deformed
     /*!

--- a/include/tudat/astro/orbit_determination/estimatable_parameters/tidalLoveNumber.h
+++ b/include/tudat/astro/orbit_determination/estimatable_parameters/tidalLoveNumber.h
@@ -11,6 +11,10 @@
 #ifndef TUDAT_TIDALLOVENUMBERPARAMETER_H
 #define TUDAT_TIDALLOVENUMBERPARAMETER_H
 
+#include <algorithm>
+#include <memory>
+#include <vector>
+
 #include "tudat/astro/orbit_determination/estimatable_parameters/estimatableParameter.h"
 #include "tudat/astro/gravitation/basicSolidBodyTideGravityFieldVariations.h"
 
@@ -33,14 +37,74 @@ static const std::vector< std::vector< int > > fullDegreeOrders = { { 0, 1, 2 },
                                                                     { 0, 1, 2, 3, 4, 5 },
                                                                     { 0, 1, 2, 3, 4, 5, 6 } };
 
-//!Pure virtual base class for estimating tidal Love number properties
+//! Pure virtual base class for estimating tidal Love number properties
 template< typename ParameterScalar >
 class TidalLoveNumber : public EstimatableParameter< ParameterScalar >
 {
 public:
-    //! Constructor
+    //! Constructor from a list of compatible tidal variation models
     /*!
-     * Constructor
+     * Constructor from a list of compatible tidal variation models
+     * \param gravityFieldVariationModels Tidal gravity field variation objects of which estimated parameter is a property
+     * \param associatedBody Deformed body
+     * \param degree Degree of Love number that is to be estimated
+     * \param orders List of orders at which Love numbers are to be estimated.
+     * \param sumOrders True of the contributions of the various orders are to be summed (i.e. assumed to be constant for all
+     * orders at given degree), or if they are handled separately
+     * \param loveNumberType Type of Love number property that is to be estimated.
+     * \param useComplexComponents True if the complex Love number is estimated, false if only the real part is considered
+     */
+    TidalLoveNumber(
+            const std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > >& gravityFieldVariationModels,
+            const std::string& associatedBody,
+            const int degree,
+            const std::vector< int > orders,
+            const bool sumOrders,
+            const EstimatebleParametersEnum loveNumberType,
+            const bool useComplexComponents = 0 ):
+        EstimatableParameter< ParameterScalar >( loveNumberType, associatedBody ), degree_( degree ), orders_( orders ),
+        sumOrders_( sumOrders ), gravityFieldVariationModels_( gravityFieldVariationModels ),
+        useComplexComponents_( useComplexComponents )
+    {
+        if( gravityFieldVariationModels_.empty( ) )
+        {
+            throw std::runtime_error( "Error when creating tidal Love number parameter, no gravity field variation models provided." );
+        }
+
+        for( unsigned int i = 0; i < gravityFieldVariationModels_.size( ); i++ )
+        {
+            if( gravityFieldVariationModels_.at( i ) == nullptr )
+            {
+                throw std::runtime_error( "Error when creating tidal Love number parameter, found nullptr variation model." );
+            }
+
+            if( gravityFieldVariationModels_.at( i )->getLoveNumbers( ).count( degree_ ) == 0 )
+            {
+                throw std::runtime_error( "Error when creating tidal Love number parameter of " + associatedBody +
+                                          ", requested degree " + std::to_string( degree_ ) +
+                                          " is unavailable in one of the selected basic solid-body tide models." );
+            }
+        }
+
+        // Keep the first model as a representative single-model reference for backward-compatible accessors.
+        gravityFieldVariationModel_ = gravityFieldVariationModels_.front( );
+
+        for( unsigned int i = 0; i < gravityFieldVariationModels_.size( ); i++ )
+        {
+            const std::vector< std::string >& modelBodies = gravityFieldVariationModels_.at( i )->getDeformingBodies( );
+            for( unsigned int j = 0; j < modelBodies.size( ); j++ )
+            {
+                if( std::find( deformingBodies_.begin( ), deformingBodies_.end( ), modelBodies.at( j ) ) == deformingBodies_.end( ) )
+                {
+                    deformingBodies_.push_back( modelBodies.at( j ) );
+                }
+            }
+        }
+    }
+
+    //! Constructor from a single tidal variation model
+    /*!
+     * Constructor from a single tidal variation model
      * \param gravityFieldVariationModel Tidal gravity field variation object of which estimated paraemeter is a property
      * \param associatedBody Deformed body
      * \param degree Degree of Love number that is to be estimated
@@ -57,8 +121,14 @@ public:
                      const bool sumOrders,
                      const EstimatebleParametersEnum loveNumberType,
                      const bool useComplexComponents = 0 ):
-        EstimatableParameter< ParameterScalar >( loveNumberType, associatedBody ), degree_( degree ), orders_( orders ),
-        sumOrders_( sumOrders ), gravityFieldVariationModel_( gravityFieldVariationModel ), useComplexComponents_( useComplexComponents )
+        TidalLoveNumber( std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > >{
+                                 gravityFieldVariationModel },
+                         associatedBody,
+                         degree,
+                         orders,
+                         sumOrders,
+                         loveNumberType,
+                         useComplexComponents )
     {}
 
     //! Destructor
@@ -97,11 +167,11 @@ public:
     //! Function to retrieve list of bodies causing tidal deformation
     /*!
      * Function to retrieve list of bodies causing tidal deformation
-     * \return :ist of bodies causing tidal deformation
+     * \return List of bodies causing tidal deformation
      */
     std::vector< std::string > getDeformingBodies( )
     {
-        return gravityFieldVariationModel_->getDeformingBodies( );
+        return deformingBodies_;
     }
 
     //! Function to retrieve list of orders at which Love numbers are to be estimated.
@@ -122,6 +192,35 @@ public:
     bool getSumOrders( )
     {
         return sumOrders_;
+    }
+
+    //! Function to retrieve the selected tidal variation models
+    /*!
+     * Function to retrieve the selected tidal variation models
+     * \return Selected tidal variation models owned by this parameter
+     */
+    std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > > getGravityFieldVariationModels( ) const
+    {
+        return gravityFieldVariationModels_;
+    }
+
+    //! Function to check whether a variation model belongs to this parameter
+    /*!
+     * Uses pointer identity against the selected environment models.
+     * \param gravityFieldVariationModel Variation model to test
+     * \return True if the model is one of the models owned by this parameter
+     */
+    bool dependsOnGravityFieldVariation(
+            const std::shared_ptr< gravitation::GravityFieldVariations > gravityFieldVariationModel ) const
+    {
+        for( unsigned int i = 0; i < gravityFieldVariationModels_.size( ); i++ )
+        {
+            if( gravityFieldVariationModels_.at( i ) == gravityFieldVariationModel )
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     //! Function to retrieve parameter description.
@@ -170,8 +269,14 @@ protected:
      */
     bool sumOrders_;
 
-    //! Tidal gravity field variation object of which estimated paraemeter is a property
+    //! Selected tidal gravity field variation models of which estimated parameter is a property
+    std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > > gravityFieldVariationModels_;
+
+    //! Representative single tidal gravity field variation model (first selected model)
     std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > gravityFieldVariationModel_;
+
+    //! Deterministic union of deforming bodies across selected models
+    std::vector< std::string > deformingBodies_;
 
     //! True if the complex Love number is estimated, false if only the real part is considered
     bool useComplexComponents_;
@@ -184,19 +289,20 @@ protected:
 class FullDegreeTidalLoveNumber : public TidalLoveNumber< Eigen::VectorXd >
 {
 public:
-    //! Constructor
+    //! Constructor from multiple compatible tidal variation models
     /*!
-     * Constructor
-     * \param gravityFieldVariationModel Tidal gravity field variation object of which estimated paraemeter is a property
+     * Constructor from multiple compatible tidal variation models
+     * \param gravityFieldVariationModels Tidal gravity field variation objects of which estimated parameter is a property
      * \param associatedBody Deformed body
      * \param degree Degree of Love number that is to be estimateds
      * \param useComplexComponents True if the complex Love number is estimated, false if only the real part is considered
      */
-    FullDegreeTidalLoveNumber( const std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > gravityFieldVariationModel,
-                               const std::string& associatedBody,
-                               const int degree,
-                               const bool useComplexComponents = 0 ):
-        TidalLoveNumber< Eigen::VectorXd >( gravityFieldVariationModel,
+    FullDegreeTidalLoveNumber(
+            const std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > >& gravityFieldVariationModels,
+            const std::string& associatedBody,
+            const int degree,
+            const bool useComplexComponents = 0 ):
+        TidalLoveNumber< Eigen::VectorXd >( gravityFieldVariationModels,
                                             associatedBody,
                                             degree,
                                             fullDegreeOrders.at( degree - 2 ),
@@ -213,6 +319,25 @@ public:
             parameterSize_ = 1;
         }
     }
+
+    //! Constructor from a single tidal variation model
+    /*!
+     * Constructor from a single tidal variation model
+     * \param gravityFieldVariationModel Tidal gravity field variation object of which estimated paraemeter is a property
+     * \param associatedBody Deformed body
+     * \param degree Degree of Love number that is to be estimateds
+     * \param useComplexComponents True if the complex Love number is estimated, false if only the real part is considered
+     */
+    FullDegreeTidalLoveNumber( const std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > gravityFieldVariationModel,
+                               const std::string& associatedBody,
+                               const int degree,
+                               const bool useComplexComponents = 0 ):
+        FullDegreeTidalLoveNumber( std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > >{
+                                           gravityFieldVariationModel },
+                                   associatedBody,
+                                   degree,
+                                   useComplexComponents )
+    {}
 
     //! Get value of Love number k_{n}
     /*!
@@ -366,22 +491,22 @@ private:
 class SingleDegreeVariableTidalLoveNumber : public TidalLoveNumber< Eigen::VectorXd >
 {
 public:
-    //! Constructor
+    //! Constructor from multiple compatible tidal variation models
     /*!
-     * Constructor
-     * \param gravityFieldVariationModel Tidal gravity field variation object of which estimated paraemeter is a property
+     * Constructor from multiple compatible tidal variation models
+     * \param gravityFieldVariationModels Tidal gravity field variation objects of which estimated parameter is a property
      * \param associatedBody Deformed body
      * \param degree Degree of Love number that is to be estimated
      * \param orders List of orders at which Love numbers are to be estimated.
      * \param useComplexComponents True if the complex Love number is estimated, false if only the real part is considered
      */
     SingleDegreeVariableTidalLoveNumber(
-            const std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > gravityFieldVariationModel,
+            const std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > >& gravityFieldVariationModels,
             const std::string& associatedBody,
             const int degree,
             const std::vector< int > orders,
             const bool useComplexComponents = 0 ):
-        TidalLoveNumber< Eigen::VectorXd >( gravityFieldVariationModel,
+        TidalLoveNumber< Eigen::VectorXd >( gravityFieldVariationModels,
                                             associatedBody,
                                             degree,
                                             orders,
@@ -398,6 +523,29 @@ public:
             parameterSize_ = orders_.size( );
         }
     }
+
+    //! Constructor from a single tidal variation model
+    /*!
+     * Constructor from a single tidal variation model
+     * \param gravityFieldVariationModel Tidal gravity field variation object of which estimated paraemeter is a property
+     * \param associatedBody Deformed body
+     * \param degree Degree of Love number that is to be estimated
+     * \param orders List of orders at which Love numbers are to be estimated.
+     * \param useComplexComponents True if the complex Love number is estimated, false if only the real part is considered
+     */
+    SingleDegreeVariableTidalLoveNumber(
+            const std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > gravityFieldVariationModel,
+            const std::string& associatedBody,
+            const int degree,
+            const std::vector< int > orders,
+            const bool useComplexComponents = 0 ):
+        SingleDegreeVariableTidalLoveNumber( std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > >{
+                                                     gravityFieldVariationModel },
+                                             associatedBody,
+                                             degree,
+                                             orders,
+                                             useComplexComponents )
+    {}
 
     //! Get values of Love numbers k_{n,m}
     /*!

--- a/include/tudat/astro/orbit_determination/estimatable_parameters/tidalLoveNumber.h
+++ b/include/tudat/astro/orbit_determination/estimatable_parameters/tidalLoveNumber.h
@@ -63,8 +63,7 @@ public:
             const EstimatebleParametersEnum loveNumberType,
             const bool useComplexComponents = 0 ):
         EstimatableParameter< ParameterScalar >( loveNumberType, associatedBody ), degree_( degree ), orders_( orders ),
-        sumOrders_( sumOrders ), gravityFieldVariationModels_( gravityFieldVariationModels ),
-        useComplexComponents_( useComplexComponents )
+        sumOrders_( sumOrders ), gravityFieldVariationModels_( gravityFieldVariationModels ), useComplexComponents_( useComplexComponents )
     {
         if( gravityFieldVariationModels_.empty( ) )
         {
@@ -80,8 +79,8 @@ public:
 
             if( gravityFieldVariationModels_.at( i )->getLoveNumbers( ).count( degree_ ) == 0 )
             {
-                throw std::runtime_error( "Error when creating tidal Love number parameter of " + associatedBody +
-                                          ", requested degree " + std::to_string( degree_ ) +
+                throw std::runtime_error( "Error when creating tidal Love number parameter of " + associatedBody + ", requested degree " +
+                                          std::to_string( degree_ ) +
                                           " is unavailable in one of the selected basic solid-body tide models." );
             }
         }
@@ -121,14 +120,14 @@ public:
                      const bool sumOrders,
                      const EstimatebleParametersEnum loveNumberType,
                      const bool useComplexComponents = 0 ):
-        TidalLoveNumber( std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > >{
-                                 gravityFieldVariationModel },
-                         associatedBody,
-                         degree,
-                         orders,
-                         sumOrders,
-                         loveNumberType,
-                         useComplexComponents )
+        TidalLoveNumber(
+                std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > >{ gravityFieldVariationModel },
+                associatedBody,
+                degree,
+                orders,
+                sumOrders,
+                loveNumberType,
+                useComplexComponents )
     {}
 
     //! Destructor
@@ -210,8 +209,7 @@ public:
      * \param gravityFieldVariationModel Variation model to test
      * \return True if the model is one of the models owned by this parameter
      */
-    bool dependsOnGravityFieldVariation(
-            const std::shared_ptr< gravitation::GravityFieldVariations > gravityFieldVariationModel ) const
+    bool dependsOnGravityFieldVariation( const std::shared_ptr< gravitation::GravityFieldVariations > gravityFieldVariationModel ) const
     {
         for( unsigned int i = 0; i < gravityFieldVariationModels_.size( ); i++ )
         {
@@ -332,11 +330,11 @@ public:
                                const std::string& associatedBody,
                                const int degree,
                                const bool useComplexComponents = 0 ):
-        FullDegreeTidalLoveNumber( std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > >{
-                                           gravityFieldVariationModel },
-                                   associatedBody,
-                                   degree,
-                                   useComplexComponents )
+        FullDegreeTidalLoveNumber(
+                std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > >{ gravityFieldVariationModel },
+                associatedBody,
+                degree,
+                useComplexComponents )
     {}
 
     //! Get value of Love number k_{n}
@@ -449,8 +447,7 @@ public:
     }
 
     //! Function to check whether a variation model belongs to this parameter (pointer identity)
-    bool dependsOnGravityFieldVariation(
-            const std::shared_ptr< gravitation::GravityFieldVariations > gravityFieldVariationModel ) const
+    bool dependsOnGravityFieldVariation( const std::shared_ptr< gravitation::GravityFieldVariations > gravityFieldVariationModel ) const
     {
         return gravityFieldVariationModel_ == gravityFieldVariationModel;
     }
@@ -552,12 +549,12 @@ public:
             const int degree,
             const std::vector< int > orders,
             const bool useComplexComponents = 0 ):
-        SingleDegreeVariableTidalLoveNumber( std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > >{
-                                                     gravityFieldVariationModel },
-                                             associatedBody,
-                                             degree,
-                                             orders,
-                                             useComplexComponents )
+        SingleDegreeVariableTidalLoveNumber(
+                std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > >{ gravityFieldVariationModel },
+                associatedBody,
+                degree,
+                orders,
+                useComplexComponents )
     {}
 
     //! Get values of Love numbers k_{n,m}

--- a/include/tudat/astro/orbit_determination/estimatable_parameters/tidalLoveNumber.h
+++ b/include/tudat/astro/orbit_determination/estimatable_parameters/tidalLoveNumber.h
@@ -442,6 +442,19 @@ public:
         return gravityFieldVariationModel_->getDeformingBodies( );
     }
 
+    //! Function to retrieve the underlying mode-coupled tidal variation model
+    std::shared_ptr< gravitation::ModeCoupledSolidBodyTideGravityFieldVariations > getGravityFieldVariationModel( ) const
+    {
+        return gravityFieldVariationModel_;
+    }
+
+    //! Function to check whether a variation model belongs to this parameter (pointer identity)
+    bool dependsOnGravityFieldVariation(
+            const std::shared_ptr< gravitation::GravityFieldVariations > gravityFieldVariationModel ) const
+    {
+        return gravityFieldVariationModel_ == gravityFieldVariationModel;
+    }
+
     std::vector< std::pair< int, int > > getParameterForcingDegreeAndOrderIndices( )
     {
         return parameterForcingDegreeAndOrderIndices_;

--- a/include/tudat/simulation/estimation_setup/createEstimatableParametersFactory.h
+++ b/include/tudat/simulation/estimation_setup/createEstimatableParametersFactory.h
@@ -2619,17 +2619,29 @@ std::shared_ptr< estimatable_parameters::EstimatableParameter< Eigen::VectorXd >
                     }
                     else
                     {
-                        // Get associated gravity field variation
-                        std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > gravityFieldVariation =
-                                std::dynamic_pointer_cast< gravitation::BasicSolidBodyTideGravityFieldVariations >(
-                                        currentBody->getGravityFieldVariationSet( )->getDirectTidalGravityFieldVariation(
-                                                tidalLoveNumberSettings->deformingBodies_ ) );
+                        // Get associated gravity field variation models covering the requested deforming bodies
+                        std::vector< std::shared_ptr< gravitation::GravityFieldVariations > > selectedGravityFieldVariations =
+                                currentBody->getGravityFieldVariationSet( )->getDirectTidalGravityFieldVariations(
+                                        tidalLoveNumberSettings->deformingBodies_ );
+                        std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > > gravityFieldVariations;
+                        for( unsigned int i = 0; i < selectedGravityFieldVariations.size( ); i++ )
+                        {
+                            std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > gravityFieldVariation =
+                                    std::dynamic_pointer_cast< gravitation::BasicSolidBodyTideGravityFieldVariations >(
+                                            selectedGravityFieldVariations.at( i ) );
+                            if( gravityFieldVariation == nullptr )
+                            {
+                                throw std::runtime_error(
+                                        "Error, expected BasicSolidBodyTideGravityFieldVariations for tidal love number" );
+                            }
+                            gravityFieldVariations.push_back( gravityFieldVariation );
+                        }
 
                         // Create parameter object
-                        if( gravityFieldVariation != nullptr )
+                        if( gravityFieldVariations.size( ) > 0 )
                         {
                             vectorParameterToEstimate =
-                                    std::make_shared< FullDegreeTidalLoveNumber >( gravityFieldVariation,
+                                    std::make_shared< FullDegreeTidalLoveNumber >( gravityFieldVariations,
                                                                                    currentBodyName,
                                                                                    tidalLoveNumberSettings->degree_,
                                                                                    tidalLoveNumberSettings->useComplexValue_ );
@@ -2670,14 +2682,26 @@ std::shared_ptr< estimatable_parameters::EstimatableParameter< Eigen::VectorXd >
                     }
                     else
                     {
-                        // Get associated gravity field variation
-                        std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > gravityFieldVariation =
-                                std::dynamic_pointer_cast< gravitation::BasicSolidBodyTideGravityFieldVariations >(
-                                        currentBody->getGravityFieldVariationSet( )->getDirectTidalGravityFieldVariation(
-                                                tidalLoveNumberSettings->deformingBodies_ ) );
+                        // Get associated gravity field variation models covering the requested deforming bodies
+                        std::vector< std::shared_ptr< gravitation::GravityFieldVariations > > selectedGravityFieldVariations =
+                                currentBody->getGravityFieldVariationSet( )->getDirectTidalGravityFieldVariations(
+                                        tidalLoveNumberSettings->deformingBodies_ );
+                        std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > > gravityFieldVariations;
+                        for( unsigned int i = 0; i < selectedGravityFieldVariations.size( ); i++ )
+                        {
+                            std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > gravityFieldVariation =
+                                    std::dynamic_pointer_cast< gravitation::BasicSolidBodyTideGravityFieldVariations >(
+                                            selectedGravityFieldVariations.at( i ) );
+                            if( gravityFieldVariation == nullptr )
+                            {
+                                throw std::runtime_error(
+                                        "Error, expected BasicSolidBodyTideGravityFieldVariations for variable tidal love number" );
+                            }
+                            gravityFieldVariations.push_back( gravityFieldVariation );
+                        }
 
                         // Create parameter object
-                        if( gravityFieldVariation != nullptr )
+                        if( gravityFieldVariations.size( ) > 0 )
                         {
                             std::vector< int > orders = tidalLoveNumberSettings->orders_;
                             if( std::find( orders.begin( ), orders.end( ), 0 ) != orders.end( ) &&
@@ -2688,7 +2712,7 @@ std::shared_ptr< estimatable_parameters::EstimatableParameter< Eigen::VectorXd >
                                           << std::endl;
                             }
                             vectorParameterToEstimate =
-                                    std::make_shared< SingleDegreeVariableTidalLoveNumber >( gravityFieldVariation,
+                                    std::make_shared< SingleDegreeVariableTidalLoveNumber >( gravityFieldVariations,
                                                                                              currentBodyName,
                                                                                              tidalLoveNumberSettings->degree_,
                                                                                              tidalLoveNumberSettings->orders_,

--- a/include/tudat/simulation/estimation_setup/createEstimatableParametersFactory.h
+++ b/include/tudat/simulation/estimation_setup/createEstimatableParametersFactory.h
@@ -2621,7 +2621,7 @@ std::shared_ptr< estimatable_parameters::EstimatableParameter< Eigen::VectorXd >
                     {
                         // Get associated gravity field variation models covering the requested deforming bodies
                         std::vector< std::shared_ptr< gravitation::GravityFieldVariations > > selectedGravityFieldVariations =
-                                currentBody->getGravityFieldVariationSet( )->getDirectTidalGravityFieldVariations(
+                                currentBody->getGravityFieldVariationSet( )->getDirectTidalGravityFieldVariationsForDegree(
                                         tidalLoveNumberSettings->deformingBodies_, tidalLoveNumberSettings->degree_ );
                         std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > > gravityFieldVariations;
                         for( unsigned int i = 0; i < selectedGravityFieldVariations.size( ); i++ )
@@ -2684,7 +2684,7 @@ std::shared_ptr< estimatable_parameters::EstimatableParameter< Eigen::VectorXd >
                     {
                         // Get associated gravity field variation models covering the requested deforming bodies
                         std::vector< std::shared_ptr< gravitation::GravityFieldVariations > > selectedGravityFieldVariations =
-                                currentBody->getGravityFieldVariationSet( )->getDirectTidalGravityFieldVariations(
+                                currentBody->getGravityFieldVariationSet( )->getDirectTidalGravityFieldVariationsForDegree(
                                         tidalLoveNumberSettings->deformingBodies_, tidalLoveNumberSettings->degree_ );
                         std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > > gravityFieldVariations;
                         for( unsigned int i = 0; i < selectedGravityFieldVariations.size( ); i++ )

--- a/include/tudat/simulation/estimation_setup/createEstimatableParametersFactory.h
+++ b/include/tudat/simulation/estimation_setup/createEstimatableParametersFactory.h
@@ -2622,7 +2622,7 @@ std::shared_ptr< estimatable_parameters::EstimatableParameter< Eigen::VectorXd >
                         // Get associated gravity field variation models covering the requested deforming bodies
                         std::vector< std::shared_ptr< gravitation::GravityFieldVariations > > selectedGravityFieldVariations =
                                 currentBody->getGravityFieldVariationSet( )->getDirectTidalGravityFieldVariations(
-                                        tidalLoveNumberSettings->deformingBodies_ );
+                                        tidalLoveNumberSettings->deformingBodies_, tidalLoveNumberSettings->degree_ );
                         std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > > gravityFieldVariations;
                         for( unsigned int i = 0; i < selectedGravityFieldVariations.size( ); i++ )
                         {
@@ -2685,7 +2685,7 @@ std::shared_ptr< estimatable_parameters::EstimatableParameter< Eigen::VectorXd >
                         // Get associated gravity field variation models covering the requested deforming bodies
                         std::vector< std::shared_ptr< gravitation::GravityFieldVariations > > selectedGravityFieldVariations =
                                 currentBody->getGravityFieldVariationSet( )->getDirectTidalGravityFieldVariations(
-                                        tidalLoveNumberSettings->deformingBodies_ );
+                                        tidalLoveNumberSettings->deformingBodies_, tidalLoveNumberSettings->degree_ );
                         std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > > gravityFieldVariations;
                         for( unsigned int i = 0; i < selectedGravityFieldVariations.size( ); i++ )
                         {

--- a/include/tudat/simulation/estimation_setup/estimatableParameterSettings.h
+++ b/include/tudat/simulation/estimation_setup/estimatableParameterSettings.h
@@ -817,9 +817,9 @@ public:
 /*!
  *  Class to define settings for estimating a Tidal Love number (k_{n}) at a single degree that is constant for all orders.
  *  Either a real or a complex Love number may be estimated (represented by entries of a VectorXd).
- *  The constructor argument representing the deforming body/bodies must correspond exactly to the deforming bodies in a
- *  BasicSolidBodyTideGravityFieldVariations member object of the deformed body. Alternatively, if only one
- *  BasicSolidBodyTideGravityFieldVariations object is present, the deforming body list may be left empty.
+ *  The constructor argument representing the deforming body/bodies selects the compatible
+ *  BasicSolidBodyTideGravityFieldVariations member objects of the deformed body that together cover the requested bodies.
+ *  An empty deforming-body list selects all compatible basic solid-body tide models.
  */
 class FullDegreeTidalLoveNumberEstimatableParameterSettings : public EstimatableParameterSettings
 {
@@ -876,9 +876,9 @@ public:
  *  Class to define settings for estimating a set of Tidal Love number (k_{n,m}) at a single degree and a set of orders at this
  *  degree. The estimation will provide separate Love numbers for each order
  *  Either a real or a complex Love number may be estimated (represented by entries of a VectorXd).
- *  The constructor argument representing the deforming body/bodies must correspond exactly to the deforming bodies in a
- *  BasicSolidBodyTideGravityFieldVariations member object of the deformed body. Alternatively, if only one
- *  BasicSolidBodyTideGravityFieldVariations object is present, the deforming body list may be left empty.
+ *  The constructor argument representing the deforming body/bodies selects the compatible
+ *  BasicSolidBodyTideGravityFieldVariations member objects of the deformed body that together cover the requested bodies.
+ *  An empty deforming-body list selects all compatible basic solid-body tide models.
  */
 class SingleDegreeVariableTidalLoveNumberEstimatableParameterSettings : public EstimatableParameterSettings
 {

--- a/src/tudat/astro/gravitation/gravityFieldVariations.cpp
+++ b/src/tudat/astro/gravitation/gravityFieldVariations.cpp
@@ -390,10 +390,9 @@ std::vector< std::shared_ptr< GravityFieldVariations > > GravityFieldVariationsS
     auto throwIfBodyHasAmbiguousCoverage = [ & ]( const std::string& bodyName, const int coverageCount ) {
         if( coverageCount > 1 )
         {
-            throw std::runtime_error(
-                    "Error when selecting direct tidal gravity field variations, tide-raising body '" + bodyName +
-                    "' is covered by multiple degree-" + std::to_string( requestedDegree ) +
-                    " tidal models, making the Love-number parameter ambiguous" );
+            throw std::runtime_error( "Error when selecting direct tidal gravity field variations, tide-raising body '" + bodyName +
+                                      "' is covered by multiple degree-" + std::to_string( requestedDegree ) +
+                                      " tidal models, making the Love-number parameter ambiguous" );
         }
     };
 
@@ -429,7 +428,7 @@ std::vector< std::shared_ptr< GravityFieldVariations > > GravityFieldVariationsS
     }
 
     std::map< std::string, int > bodyCoverageCount;
-    for( const std::string& bodyName: requestedBodies )
+    for( const std::string& bodyName : requestedBodies )
     {
         bodyCoverageCount[ bodyName ] = 0;
     }
@@ -489,23 +488,21 @@ std::vector< std::shared_ptr< GravityFieldVariations > > GravityFieldVariationsS
         }
     }
 
-    for( const std::string& bodyName: requestedBodies )
+    for( const std::string& bodyName : requestedBodies )
     {
         if( bodyCoverageCount.at( bodyName ) == 0 )
         {
-            throw std::runtime_error(
-                    "Error when selecting direct tidal gravity field variations, requested tide-raising body '" + bodyName +
-                    "' is not represented by any degree-" + std::to_string( requestedDegree ) +
-                    " tidal model of the requested type" );
+            throw std::runtime_error( "Error when selecting direct tidal gravity field variations, requested tide-raising body '" +
+                                      bodyName + "' is not represented by any degree-" + std::to_string( requestedDegree ) +
+                                      " tidal model of the requested type" );
         }
         throwIfBodyHasAmbiguousCoverage( bodyName, bodyCoverageCount.at( bodyName ) );
     }
 
     if( selectedVariations.empty( ) )
     {
-        throw std::runtime_error(
-                "Error when selecting direct tidal gravity field variations, no degree-" + std::to_string( requestedDegree ) +
-                " models matched the requested deforming-body list" );
+        throw std::runtime_error( "Error when selecting direct tidal gravity field variations, no degree-" +
+                                  std::to_string( requestedDegree ) + " models matched the requested deforming-body list" );
     }
 
     return selectedVariations;

--- a/src/tudat/astro/gravitation/gravityFieldVariations.cpp
+++ b/src/tudat/astro/gravitation/gravityFieldVariations.cpp
@@ -8,6 +8,9 @@
  *    http://tudat.tudelft.nl/LICENSE.
  */
 
+#include <map>
+#include <set>
+
 #include "tudat/basics/utilities.h"
 #include "tudat/astro/gravitation/gravityFieldVariations.h"
 #include "tudat/astro/gravitation/basicSolidBodyTideGravityFieldVariations.h"
@@ -336,6 +339,140 @@ std::shared_ptr< GravityFieldVariations > GravityFieldVariationsSet::getDirectTi
     }
 
     return gravityFieldVariation;
+}
+
+//! Function to retrieve all compatible tidal gravity field variations covering the requested deforming bodies
+std::vector< std::shared_ptr< GravityFieldVariations > > GravityFieldVariationsSet::getDirectTidalGravityFieldVariations(
+        const std::vector< std::string >& namesOfBodiesCausingDeformation,
+        const BodyDeformationTypes tideType )
+{
+    std::vector< std::shared_ptr< GravityFieldVariations > > selectedVariations;
+    std::vector< std::shared_ptr< SolidBodyTideGravityFieldVariations > > modelsOfRequestedType;
+
+    for( unsigned int i = 0; i < variationType_.size( ); i++ )
+    {
+        if( variationType_.at( i ) == tideType )
+        {
+            std::shared_ptr< SolidBodyTideGravityFieldVariations > tidalVariation =
+                    std::dynamic_pointer_cast< SolidBodyTideGravityFieldVariations >( variationObjects_.at( i ) );
+            if( tidalVariation == nullptr )
+            {
+                throw std::runtime_error(
+                        "Error when selecting direct tidal gravity field variations, model of requested type could not be cast to "
+                        "SolidBodyTideGravityFieldVariations" );
+            }
+            modelsOfRequestedType.push_back( tidalVariation );
+        }
+    }
+
+    if( modelsOfRequestedType.empty( ) )
+    {
+        throw std::runtime_error(
+                "Error when selecting direct tidal gravity field variations, no models of the requested tidal type were found" );
+    }
+
+    // Empty list: select every compatible model of the requested type.
+    if( namesOfBodiesCausingDeformation.empty( ) )
+    {
+        for( unsigned int i = 0; i < modelsOfRequestedType.size( ); i++ )
+        {
+            selectedVariations.push_back( modelsOfRequestedType.at( i ) );
+        }
+        return selectedVariations;
+    }
+
+    std::set< std::string > requestedBodies( namesOfBodiesCausingDeformation.begin( ), namesOfBodiesCausingDeformation.end( ) );
+    if( requestedBodies.size( ) != namesOfBodiesCausingDeformation.size( ) )
+    {
+        throw std::runtime_error(
+                "Error when selecting direct tidal gravity field variations, requested deforming body list contains duplicates" );
+    }
+
+    std::map< std::string, int > bodyCoverageCount;
+    for( const std::string& bodyName: requestedBodies )
+    {
+        bodyCoverageCount[ bodyName ] = 0;
+    }
+
+    for( unsigned int i = 0; i < modelsOfRequestedType.size( ); i++ )
+    {
+        const std::vector< std::string >& modelBodies = modelsOfRequestedType.at( i )->getDeformingBodies( );
+        bool modelIntersectsRequest = false;
+        bool modelFullyContainedInRequest = true;
+
+        for( unsigned int j = 0; j < modelBodies.size( ); j++ )
+        {
+            if( requestedBodies.count( modelBodies.at( j ) ) > 0 )
+            {
+                modelIntersectsRequest = true;
+            }
+            else
+            {
+                modelFullyContainedInRequest = false;
+            }
+        }
+
+        if( modelIntersectsRequest && !modelFullyContainedInRequest )
+        {
+            std::string modelBodyList;
+            for( unsigned int j = 0; j < modelBodies.size( ); j++ )
+            {
+                modelBodyList += modelBodies.at( j );
+                if( j + 1 < modelBodies.size( ) )
+                {
+                    modelBodyList += ", ";
+                }
+            }
+            throw std::runtime_error(
+                    "Error when selecting direct tidal gravity field variations, requested deforming bodies partially overlap an "
+                    "indivisible tidal model with deforming bodies [" +
+                    modelBodyList +
+                    "]. Select either the full model body set or only bodies that are represented by dedicated tidal models." );
+        }
+
+        if( modelFullyContainedInRequest && !modelBodies.empty( ) )
+        {
+            bool modelTouchesRequest = false;
+            for( unsigned int j = 0; j < modelBodies.size( ); j++ )
+            {
+                if( requestedBodies.count( modelBodies.at( j ) ) > 0 )
+                {
+                    modelTouchesRequest = true;
+                    bodyCoverageCount[ modelBodies.at( j ) ]++;
+                }
+            }
+
+            if( modelTouchesRequest )
+            {
+                selectedVariations.push_back( modelsOfRequestedType.at( i ) );
+            }
+        }
+    }
+
+    for( const std::string& bodyName: requestedBodies )
+    {
+        if( bodyCoverageCount.at( bodyName ) == 0 )
+        {
+            throw std::runtime_error(
+                    "Error when selecting direct tidal gravity field variations, requested tide-raising body '" + bodyName +
+                    "' is not represented by any compatible tidal model of the requested type" );
+        }
+        if( bodyCoverageCount.at( bodyName ) > 1 )
+        {
+            throw std::runtime_error(
+                    "Error when selecting direct tidal gravity field variations, requested tide-raising body '" + bodyName +
+                    "' is covered by multiple compatible tidal models, making the Love-number parameter ambiguous" );
+        }
+    }
+
+    if( selectedVariations.empty( ) )
+    {
+        throw std::runtime_error(
+                "Error when selecting direct tidal gravity field variations, no compatible tidal models cover the requested deforming "
+                "bodies" );
+    }
+
+    return selectedVariations;
 }
 
 //! Function to retrieve the tidal gravity field variations

--- a/src/tudat/astro/gravitation/gravityFieldVariations.cpp
+++ b/src/tudat/astro/gravitation/gravityFieldVariations.cpp
@@ -344,10 +344,11 @@ std::shared_ptr< GravityFieldVariations > GravityFieldVariationsSet::getDirectTi
 //! Function to retrieve all compatible tidal gravity field variations covering the requested deforming bodies
 std::vector< std::shared_ptr< GravityFieldVariations > > GravityFieldVariationsSet::getDirectTidalGravityFieldVariations(
         const std::vector< std::string >& namesOfBodiesCausingDeformation,
+        const int requestedDegree,
         const BodyDeformationTypes tideType )
 {
     std::vector< std::shared_ptr< GravityFieldVariations > > selectedVariations;
-    std::vector< std::shared_ptr< SolidBodyTideGravityFieldVariations > > modelsOfRequestedType;
+    std::vector< std::shared_ptr< SolidBodyTideGravityFieldVariations > > modelsOfRequestedTypeAndDegree;
 
     for( unsigned int i = 0; i < variationType_.size( ); i++ )
     {
@@ -361,23 +362,62 @@ std::vector< std::shared_ptr< GravityFieldVariations > > GravityFieldVariationsS
                         "Error when selecting direct tidal gravity field variations, model of requested type could not be cast to "
                         "SolidBodyTideGravityFieldVariations" );
             }
-            modelsOfRequestedType.push_back( tidalVariation );
+
+            // Degree filtering happens before body-coverage / ambiguity checks so that independent per-degree models
+            // for the same deforming body remain selectable.
+            std::shared_ptr< BasicSolidBodyTideGravityFieldVariations > basicTidalVariation =
+                    std::dynamic_pointer_cast< BasicSolidBodyTideGravityFieldVariations >( tidalVariation );
+            if( basicTidalVariation == nullptr )
+            {
+                throw std::runtime_error(
+                        "Error when selecting direct tidal gravity field variations, expected BasicSolidBodyTideGravityFieldVariations "
+                        "when filtering by Love-number degree" );
+            }
+            if( basicTidalVariation->getLoveNumbers( ).count( requestedDegree ) > 0 )
+            {
+                modelsOfRequestedTypeAndDegree.push_back( tidalVariation );
+            }
         }
     }
 
-    if( modelsOfRequestedType.empty( ) )
+    if( modelsOfRequestedTypeAndDegree.empty( ) )
     {
         throw std::runtime_error(
-                "Error when selecting direct tidal gravity field variations, no models of the requested tidal type were found" );
+                "Error when selecting direct tidal gravity field variations, no models of the requested tidal type provide degree " +
+                std::to_string( requestedDegree ) );
     }
 
-    // Empty list: select every compatible model of the requested type.
+    auto throwIfBodyHasAmbiguousCoverage = [ & ]( const std::string& bodyName, const int coverageCount ) {
+        if( coverageCount > 1 )
+        {
+            throw std::runtime_error(
+                    "Error when selecting direct tidal gravity field variations, tide-raising body '" + bodyName +
+                    "' is covered by multiple degree-" + std::to_string( requestedDegree ) +
+                    " tidal models, making the Love-number parameter ambiguous" );
+        }
+    };
+
+    // Empty list: select every degree-compatible model, but still reject duplicate body coverage.
     if( namesOfBodiesCausingDeformation.empty( ) )
     {
-        for( unsigned int i = 0; i < modelsOfRequestedType.size( ); i++ )
+        std::map< std::string, int > bodyCoverageCount;
+        for( unsigned int i = 0; i < modelsOfRequestedTypeAndDegree.size( ); i++ )
         {
-            selectedVariations.push_back( modelsOfRequestedType.at( i ) );
+            const std::vector< std::string >& modelBodies = modelsOfRequestedTypeAndDegree.at( i )->getDeformingBodies( );
+            for( unsigned int j = 0; j < modelBodies.size( ); j++ )
+            {
+                bodyCoverageCount[ modelBodies.at( j ) ]++;
+            }
+            selectedVariations.push_back( modelsOfRequestedTypeAndDegree.at( i ) );
         }
+
+        for( std::map< std::string, int >::const_iterator coverageIterator = bodyCoverageCount.begin( );
+             coverageIterator != bodyCoverageCount.end( );
+             coverageIterator++ )
+        {
+            throwIfBodyHasAmbiguousCoverage( coverageIterator->first, coverageIterator->second );
+        }
+
         return selectedVariations;
     }
 
@@ -394,9 +434,9 @@ std::vector< std::shared_ptr< GravityFieldVariations > > GravityFieldVariationsS
         bodyCoverageCount[ bodyName ] = 0;
     }
 
-    for( unsigned int i = 0; i < modelsOfRequestedType.size( ); i++ )
+    for( unsigned int i = 0; i < modelsOfRequestedTypeAndDegree.size( ); i++ )
     {
-        const std::vector< std::string >& modelBodies = modelsOfRequestedType.at( i )->getDeformingBodies( );
+        const std::vector< std::string >& modelBodies = modelsOfRequestedTypeAndDegree.at( i )->getDeformingBodies( );
         bool modelIntersectsRequest = false;
         bool modelFullyContainedInRequest = true;
 
@@ -444,7 +484,7 @@ std::vector< std::shared_ptr< GravityFieldVariations > > GravityFieldVariationsS
 
             if( modelTouchesRequest )
             {
-                selectedVariations.push_back( modelsOfRequestedType.at( i ) );
+                selectedVariations.push_back( modelsOfRequestedTypeAndDegree.at( i ) );
             }
         }
     }
@@ -455,21 +495,17 @@ std::vector< std::shared_ptr< GravityFieldVariations > > GravityFieldVariationsS
         {
             throw std::runtime_error(
                     "Error when selecting direct tidal gravity field variations, requested tide-raising body '" + bodyName +
-                    "' is not represented by any compatible tidal model of the requested type" );
+                    "' is not represented by any degree-" + std::to_string( requestedDegree ) +
+                    " tidal model of the requested type" );
         }
-        if( bodyCoverageCount.at( bodyName ) > 1 )
-        {
-            throw std::runtime_error(
-                    "Error when selecting direct tidal gravity field variations, requested tide-raising body '" + bodyName +
-                    "' is covered by multiple compatible tidal models, making the Love-number parameter ambiguous" );
-        }
+        throwIfBodyHasAmbiguousCoverage( bodyName, bodyCoverageCount.at( bodyName ) );
     }
 
     if( selectedVariations.empty( ) )
     {
         throw std::runtime_error(
-                "Error when selecting direct tidal gravity field variations, no compatible tidal models cover the requested deforming "
-                "bodies" );
+                "Error when selecting direct tidal gravity field variations, no degree-" + std::to_string( requestedDegree ) +
+                " models matched the requested deforming-body list" );
     }
 
     return selectedVariations;

--- a/src/tudat/astro/gravitation/gravityFieldVariations.cpp
+++ b/src/tudat/astro/gravitation/gravityFieldVariations.cpp
@@ -342,7 +342,7 @@ std::shared_ptr< GravityFieldVariations > GravityFieldVariationsSet::getDirectTi
 }
 
 //! Function to retrieve all compatible tidal gravity field variations covering the requested deforming bodies
-std::vector< std::shared_ptr< GravityFieldVariations > > GravityFieldVariationsSet::getDirectTidalGravityFieldVariations(
+std::vector< std::shared_ptr< GravityFieldVariations > > GravityFieldVariationsSet::getDirectTidalGravityFieldVariationsForDegree(
         const std::vector< std::string >& namesOfBodiesCausingDeformation,
         const int requestedDegree,
         const BodyDeformationTypes tideType )

--- a/src/tudat/astro/orbit_determination/acceleration_partials/fullTwoBodySphericalHarmonicGravityPartial.cpp
+++ b/src/tudat/astro/orbit_determination/acceleration_partials/fullTwoBodySphericalHarmonicGravityPartial.cpp
@@ -1303,35 +1303,87 @@ FullTwoBodySphericalHarmonicsGravityPartial::getParameterPartialFunctionDerivedA
             }
 
             std::pair< int, std::pair< int, int > > currentTidalPartialOutput;
+            std::vector< std::function< std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > >( ) > > coefficientPartialFunctions;
+            std::pair< int, int > selectedDegreeAndOrder = std::make_pair( -1, -1 );
             for( unsigned int i = 0; i < tidalLoveNumberPartialInterfaces_.size( ); i++ )
             {
                 currentTidalPartialOutput =
                         tidalLoveNumberPartialInterfaces_.at( i )->setParameterPartialFunction( parameter, maximumDegree, maximumOrder );
-                if( numberOfRows != 0 && currentTidalPartialOutput.first > 0 )
+                if( currentTidalPartialOutput.first > 0 )
                 {
-                    throw std::runtime_error(
-                            "Error when getting full two-body acceleration partial w.r.t. tidal Love number, multiple dependencies "
-                            "found." );
+                    if( numberOfRows == 0 )
+                    {
+                        numberOfRows = currentTidalPartialOutput.first;
+                        selectedDegreeAndOrder = currentTidalPartialOutput.second;
+                    }
+                    else
+                    {
+                        if( numberOfRows != currentTidalPartialOutput.first )
+                        {
+                            throw std::runtime_error(
+                                    "Error when getting full two-body acceleration partial w.r.t. tidal Love number, inconsistent "
+                                    "parameter sizes found." );
+                        }
+                        if( selectedDegreeAndOrder != currentTidalPartialOutput.second )
+                        {
+                            throw std::runtime_error(
+                                    "Error when getting full two-body acceleration partial w.r.t. tidal Love number, inconsistent "
+                                    "degree/order metadata found." );
+                        }
+                    }
+
+                    std::shared_ptr< orbit_determination::TidalLoveNumberPartialInterface > currentInterface =
+                            tidalLoveNumberPartialInterfaces_.at( i );
+                    std::pair< int, int > currentDegreeAndOrder = currentTidalPartialOutput.second;
+                    coefficientPartialFunctions.push_back(
+                            [ currentInterface, parameter, currentDegreeAndOrder ]( ) {
+                                return std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > >(
+                                        currentInterface->getCurrentVectorParameterPartial( parameter, currentDegreeAndOrder ) );
+                            } );
                 }
-                else if( currentTidalPartialOutput.first > 0 )
-                {
-                    tidalLoveNumberPartialInterfaces_.at( i )->updateParameterPartials( );
-                    std::function< std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > >( ) > coefficientPartialFunction =
-                            std::bind( &orbit_determination::TidalLoveNumberPartialInterface::getCurrentVectorParameterPartial,
-                                       tidalLoveNumberPartialInterfaces_.at( i ),
-                                       parameter,
-                                       currentTidalPartialOutput.second );
-                    partialFunction = std::bind( &FullTwoBodySphericalHarmonicsGravityPartial::wrtTidalLoveNumber,
-                                                 this,
-                                                 isBody1Parameter,
-                                                 coefficientPartialFunction,
-                                                 tidalLoveNumber->getDegree( ),
-                                                 tidalLoveNumber->getOrders( ),
-                                                 tidalLoveNumber->getSumOrders( ),
-                                                 parameter->getParameterSize( ),
-                                                 std::placeholders::_1 );
-                    numberOfRows = currentTidalPartialOutput.first;
-                }
+            }
+
+            if( coefficientPartialFunctions.size( ) > 0 )
+            {
+                std::function< std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > >( ) > coefficientPartialFunction =
+                        [ coefficientPartialFunctions ]( ) {
+                            std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > > totalCoefficientPartials(
+                                    coefficientPartialFunctions.front( )( ) );
+                            for( unsigned int functionIndex = 1; functionIndex < coefficientPartialFunctions.size( ); functionIndex++ )
+                            {
+                                const std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > > currentCoefficientPartials(
+                                        coefficientPartialFunctions.at( functionIndex )( ) );
+                                if( currentCoefficientPartials.size( ) != totalCoefficientPartials.size( ) )
+                                {
+                                    throw std::runtime_error(
+                                            "Error when summing full two-body tidal coefficient partials, inconsistent number of orders "
+                                            "found." );
+                                }
+                                for( unsigned int orderIndex = 0; orderIndex < totalCoefficientPartials.size( ); orderIndex++ )
+                                {
+                                    if( currentCoefficientPartials.at( orderIndex ).rows( ) !=
+                                                totalCoefficientPartials.at( orderIndex ).rows( ) ||
+                                        currentCoefficientPartials.at( orderIndex ).cols( ) !=
+                                                totalCoefficientPartials.at( orderIndex ).cols( ) )
+                                    {
+                                        throw std::runtime_error(
+                                                "Error when summing full two-body tidal coefficient partials, inconsistent matrix sizes "
+                                                "found." );
+                                    }
+                                    totalCoefficientPartials.at( orderIndex ) += currentCoefficientPartials.at( orderIndex );
+                                }
+                            }
+                            return totalCoefficientPartials;
+                        };
+                partialFunction = std::bind( &FullTwoBodySphericalHarmonicsGravityPartial::wrtTidalLoveNumber,
+                                             this,
+                                             isBody1Parameter,
+                                             coefficientPartialFunction,
+                                             tidalLoveNumber->getDegree( ),
+                                             tidalLoveNumber->getOrders( ),
+                                             tidalLoveNumber->getSumOrders( ),
+                                             parameter->getParameterSize( ),
+                                             std::placeholders::_1 );
             }
         }
     }

--- a/src/tudat/astro/orbit_determination/acceleration_partials/fullTwoBodySphericalHarmonicGravityPartial.cpp
+++ b/src/tudat/astro/orbit_determination/acceleration_partials/fullTwoBodySphericalHarmonicGravityPartial.cpp
@@ -1335,11 +1335,10 @@ FullTwoBodySphericalHarmonicsGravityPartial::getParameterPartialFunctionDerivedA
                     std::shared_ptr< orbit_determination::TidalLoveNumberPartialInterface > currentInterface =
                             tidalLoveNumberPartialInterfaces_.at( i );
                     std::pair< int, int > currentDegreeAndOrder = currentTidalPartialOutput.second;
-                    coefficientPartialFunctions.push_back(
-                            [ currentInterface, parameter, currentDegreeAndOrder ]( ) {
-                                return std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > >(
-                                        currentInterface->getCurrentVectorParameterPartial( parameter, currentDegreeAndOrder ) );
-                            } );
+                    coefficientPartialFunctions.push_back( [ currentInterface, parameter, currentDegreeAndOrder ]( ) {
+                        return std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > >(
+                                currentInterface->getCurrentVectorParameterPartial( parameter, currentDegreeAndOrder ) );
+                    } );
                 }
             }
 

--- a/src/tudat/astro/orbit_determination/acceleration_partials/sphericalHarmonicAccelerationPartial.cpp
+++ b/src/tudat/astro/orbit_determination/acceleration_partials/sphericalHarmonicAccelerationPartial.cpp
@@ -107,6 +107,8 @@ SphericalHarmonicsGravityPartial::getParameterPartialFunctionDerivedAcceleration
             std::vector< int > orders = tidalLoveNumber->getOrders( );
             int sumOrders = tidalLoveNumber->getSumOrders( );
 
+            std::vector< std::function< std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > >( ) > > coefficientPartialFunctions;
+            std::pair< int, int > selectedDegreeAndOrder = std::make_pair( -1, -1 );
             std::pair< int, std::pair< int, int > > currentTidalPartialOutput;
             for( unsigned int i = 0; i < tidalLoveNumberPartialInterfaces_.size( ); i++ )
             {
@@ -114,33 +116,77 @@ SphericalHarmonicsGravityPartial::getParameterPartialFunctionDerivedAcceleration
                 currentTidalPartialOutput =
                         tidalLoveNumberPartialInterfaces_.at( i )->setParameterPartialFunction( parameter, maximumDegree_, maximumOrder_ );
 
-                // Check consistency
-                if( numberOfRows != 0 && currentTidalPartialOutput.first > 0 )
+                if( currentTidalPartialOutput.first > 0 )
                 {
-                    throw std::runtime_error( "Error when getting double tidal parameter partial, multiple dependencies found " +
-                                              std::to_string( numberOfRows ) + ", " + std::to_string( currentTidalPartialOutput.first ) );
-                }
-                else
-                {
-                    // If tidal dependency esists, set partial function
-                    if( currentTidalPartialOutput.first > 0 )
+                    if( numberOfRows == 0 )
                     {
-                        std::function< std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > >( ) > coefficientPartialFunction =
-                                std::bind( &orbit_determination::TidalLoveNumberPartialInterface::getCurrentDoubleParameterPartial,
-                                           tidalLoveNumberPartialInterfaces_.at( i ),
-                                           parameter,
-                                           currentTidalPartialOutput.second );
-                        partialFunction = std::bind( &SphericalHarmonicsGravityPartial::wrtTidalModelParameter,
-                                                     this,
-                                                     coefficientPartialFunction,
-                                                     degree,
-                                                     orders,
-                                                     sumOrders,
-                                                     parameter->getParameterSize( ),
-                                                     std::placeholders::_1 );
                         numberOfRows = currentTidalPartialOutput.first;
+                        selectedDegreeAndOrder = currentTidalPartialOutput.second;
                     }
+                    else
+                    {
+                        if( numberOfRows != currentTidalPartialOutput.first )
+                        {
+                            throw std::runtime_error(
+                                    "Error when getting double tidal parameter partial, inconsistent parameter sizes found " +
+                                    std::to_string( numberOfRows ) + ", " + std::to_string( currentTidalPartialOutput.first ) );
+                        }
+                        if( selectedDegreeAndOrder != currentTidalPartialOutput.second )
+                        {
+                            throw std::runtime_error(
+                                    "Error when getting double tidal parameter partial, inconsistent degree/order metadata found." );
+                        }
+                    }
+
+                    std::shared_ptr< orbit_determination::TidalLoveNumberPartialInterface > currentInterface =
+                            tidalLoveNumberPartialInterfaces_.at( i );
+                    std::pair< int, int > currentDegreeAndOrder = currentTidalPartialOutput.second;
+                    coefficientPartialFunctions.push_back(
+                            [ currentInterface, parameter, currentDegreeAndOrder ]( ) {
+                                return std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > >(
+                                        currentInterface->getCurrentDoubleParameterPartial( parameter, currentDegreeAndOrder ) );
+                            } );
                 }
+            }
+
+            if( coefficientPartialFunctions.size( ) > 0 )
+            {
+                std::function< std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > >( ) > coefficientPartialFunction =
+                        [ coefficientPartialFunctions ]( ) {
+                            std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > > totalCoefficientPartials(
+                                    coefficientPartialFunctions.front( )( ) );
+                            for( unsigned int functionIndex = 1; functionIndex < coefficientPartialFunctions.size( ); functionIndex++ )
+                            {
+                                const std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > > currentCoefficientPartials(
+                                        coefficientPartialFunctions.at( functionIndex )( ) );
+                                if( currentCoefficientPartials.size( ) != totalCoefficientPartials.size( ) )
+                                {
+                                    throw std::runtime_error(
+                                            "Error when summing double tidal coefficient partials, inconsistent number of orders found." );
+                                }
+                                for( unsigned int orderIndex = 0; orderIndex < totalCoefficientPartials.size( ); orderIndex++ )
+                                {
+                                    if( currentCoefficientPartials.at( orderIndex ).rows( ) !=
+                                                totalCoefficientPartials.at( orderIndex ).rows( ) ||
+                                        currentCoefficientPartials.at( orderIndex ).cols( ) !=
+                                                totalCoefficientPartials.at( orderIndex ).cols( ) )
+                                    {
+                                        throw std::runtime_error(
+                                                "Error when summing double tidal coefficient partials, inconsistent matrix sizes found." );
+                                    }
+                                    totalCoefficientPartials.at( orderIndex ) += currentCoefficientPartials.at( orderIndex );
+                                }
+                            }
+                            return totalCoefficientPartials;
+                        };
+                partialFunction = std::bind( &SphericalHarmonicsGravityPartial::wrtTidalModelParameter,
+                                             this,
+                                             coefficientPartialFunction,
+                                             degree,
+                                             orders,
+                                             sumOrders,
+                                             parameter->getParameterSize( ),
+                                             std::placeholders::_1 );
             }
         }
     }
@@ -203,41 +249,87 @@ SphericalHarmonicsGravityPartial::getParameterPartialFunctionDerivedAcceleration
                 std::vector< int > orders = tidalLoveNumber->getOrders( );
                 int sumOrders = tidalLoveNumber->getSumOrders( );
 
+                std::vector< std::function< std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > >( ) > > coefficientPartialFunctions;
+                std::pair< int, int > selectedDegreeAndOrder = std::make_pair( -1, -1 );
                 std::pair< int, std::pair< int, int > > currentTidalPartialOutput;
                 for( unsigned int i = 0; i < tidalLoveNumberPartialInterfaces_.size( ); i++ )
                 {
                     // Check dependency on current partial object
                     currentTidalPartialOutput = tidalLoveNumberPartialInterfaces_.at( i )->setParameterPartialFunction(
                             parameter, maximumDegree_, maximumOrder_ );
-                    if( numberOfRows != 0 && currentTidalPartialOutput.first > 0 )
+                    if( currentTidalPartialOutput.first > 0 )
                     {
-                        std::cout << i << std::endl;
-                        throw std::runtime_error( "Error when getting vector tidal parameter partial B, inconsistent output" +
-                                                  std::to_string( numberOfRows ) + ", " +
-                                                  std::to_string( currentTidalPartialOutput.first ) );
-                    }
-                    else
-                    {
-                        // If tidal dependency esists, set partial function
-                        if( currentTidalPartialOutput.first > 0 )
+                        if( numberOfRows == 0 )
                         {
-                            std::function< std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > >( ) > coefficientPartialFunction =
-                                    std::bind( &orbit_determination::TidalLoveNumberPartialInterface::getCurrentVectorParameterPartial,
-                                               tidalLoveNumberPartialInterfaces_.at( i ),
-                                               parameter,
-                                               currentTidalPartialOutput.second );
-                            partialFunction = std::bind( &SphericalHarmonicsGravityPartial::wrtTidalModelParameter,
-                                                         this,
-                                                         coefficientPartialFunction,
-                                                         degree,
-                                                         orders,
-                                                         sumOrders,
-                                                         parameter->getParameterSize( ),
-                                                         std::placeholders::_1 );
-
                             numberOfRows = currentTidalPartialOutput.first;
+                            selectedDegreeAndOrder = currentTidalPartialOutput.second;
                         }
+                        else
+                        {
+                            if( numberOfRows != currentTidalPartialOutput.first )
+                            {
+                                throw std::runtime_error(
+                                        "Error when getting vector tidal parameter partial, inconsistent parameter sizes found " +
+                                        std::to_string( numberOfRows ) + ", " + std::to_string( currentTidalPartialOutput.first ) );
+                            }
+                            if( selectedDegreeAndOrder != currentTidalPartialOutput.second )
+                            {
+                                throw std::runtime_error(
+                                        "Error when getting vector tidal parameter partial, inconsistent degree/order metadata found." );
+                            }
+                        }
+
+                        std::shared_ptr< orbit_determination::TidalLoveNumberPartialInterface > currentInterface =
+                                tidalLoveNumberPartialInterfaces_.at( i );
+                        std::pair< int, int > currentDegreeAndOrder = currentTidalPartialOutput.second;
+                        coefficientPartialFunctions.push_back(
+                                [ currentInterface, parameter, currentDegreeAndOrder ]( ) {
+                                    return std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > >(
+                                            currentInterface->getCurrentVectorParameterPartial( parameter, currentDegreeAndOrder ) );
+                                } );
                     }
+                }
+
+                if( coefficientPartialFunctions.size( ) > 0 )
+                {
+                    std::function< std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > >( ) > coefficientPartialFunction =
+                            [ coefficientPartialFunctions ]( ) {
+                                std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > > totalCoefficientPartials(
+                                        coefficientPartialFunctions.front( )( ) );
+                                for( unsigned int functionIndex = 1; functionIndex < coefficientPartialFunctions.size( ); functionIndex++ )
+                                {
+                                    const std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > > currentCoefficientPartials(
+                                            coefficientPartialFunctions.at( functionIndex )( ) );
+                                    if( currentCoefficientPartials.size( ) != totalCoefficientPartials.size( ) )
+                                    {
+                                        throw std::runtime_error(
+                                                "Error when summing vector tidal coefficient partials, inconsistent number of orders "
+                                                "found." );
+                                    }
+                                    for( unsigned int orderIndex = 0; orderIndex < totalCoefficientPartials.size( ); orderIndex++ )
+                                    {
+                                        if( currentCoefficientPartials.at( orderIndex ).rows( ) !=
+                                                    totalCoefficientPartials.at( orderIndex ).rows( ) ||
+                                            currentCoefficientPartials.at( orderIndex ).cols( ) !=
+                                                    totalCoefficientPartials.at( orderIndex ).cols( ) )
+                                        {
+                                            throw std::runtime_error(
+                                                    "Error when summing vector tidal coefficient partials, inconsistent matrix sizes "
+                                                    "found." );
+                                        }
+                                        totalCoefficientPartials.at( orderIndex ) += currentCoefficientPartials.at( orderIndex );
+                                    }
+                                }
+                                return totalCoefficientPartials;
+                            };
+                    partialFunction = std::bind( &SphericalHarmonicsGravityPartial::wrtTidalModelParameter,
+                                                 this,
+                                                 coefficientPartialFunction,
+                                                 degree,
+                                                 orders,
+                                                 sumOrders,
+                                                 parameter->getParameterSize( ),
+                                                 std::placeholders::_1 );
                 }
             }
             else

--- a/src/tudat/astro/orbit_determination/acceleration_partials/sphericalHarmonicAccelerationPartial.cpp
+++ b/src/tudat/astro/orbit_determination/acceleration_partials/sphericalHarmonicAccelerationPartial.cpp
@@ -141,11 +141,10 @@ SphericalHarmonicsGravityPartial::getParameterPartialFunctionDerivedAcceleration
                     std::shared_ptr< orbit_determination::TidalLoveNumberPartialInterface > currentInterface =
                             tidalLoveNumberPartialInterfaces_.at( i );
                     std::pair< int, int > currentDegreeAndOrder = currentTidalPartialOutput.second;
-                    coefficientPartialFunctions.push_back(
-                            [ currentInterface, parameter, currentDegreeAndOrder ]( ) {
-                                return std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > >(
-                                        currentInterface->getCurrentDoubleParameterPartial( parameter, currentDegreeAndOrder ) );
-                            } );
+                    coefficientPartialFunctions.push_back( [ currentInterface, parameter, currentDegreeAndOrder ]( ) {
+                        return std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > >(
+                                currentInterface->getCurrentDoubleParameterPartial( parameter, currentDegreeAndOrder ) );
+                    } );
                 }
             }
 
@@ -282,11 +281,10 @@ SphericalHarmonicsGravityPartial::getParameterPartialFunctionDerivedAcceleration
                         std::shared_ptr< orbit_determination::TidalLoveNumberPartialInterface > currentInterface =
                                 tidalLoveNumberPartialInterfaces_.at( i );
                         std::pair< int, int > currentDegreeAndOrder = currentTidalPartialOutput.second;
-                        coefficientPartialFunctions.push_back(
-                                [ currentInterface, parameter, currentDegreeAndOrder ]( ) {
-                                    return std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > >(
-                                            currentInterface->getCurrentVectorParameterPartial( parameter, currentDegreeAndOrder ) );
-                                } );
+                        coefficientPartialFunctions.push_back( [ currentInterface, parameter, currentDegreeAndOrder ]( ) {
+                            return std::vector< Eigen::Matrix< double, 2, Eigen::Dynamic > >(
+                                    currentInterface->getCurrentVectorParameterPartial( parameter, currentDegreeAndOrder ) );
+                        } );
                     }
                 }
 

--- a/src/tudat/astro/orbit_determination/acceleration_partials/tidalLoveNumberPartialInterface.cpp
+++ b/src/tudat/astro/orbit_determination/acceleration_partials/tidalLoveNumberPartialInterface.cpp
@@ -300,48 +300,41 @@ std::pair< int, std::pair< int, int > > TidalLoveNumberPartialInterface::setPara
                                               maximumUsedDegree,
                                               maximumUsedOrder );
 
-                // Set parameter partial function if relevant terms are found
-                if( maximumUsedDegree > 0 )
+                // Set parameter partial function if this interface's exact variation model belongs to the parameter
+                if( maximumUsedDegree > 0 && coefficientsParameter->dependsOnGravityFieldVariation( gravityFieldVariations_ ) )
                 {
-                    // Check if deforming bodies correspond to bodies in model.
-                    std::vector< int > selectedDeformingBodies =
-                            getSelectedDeformingBodyIds( coefficientsParameter->getDeformingBodies( ) );
-                    if( selectedDeformingBodies.size( ) == coefficientsParameter->getDeformingBodies( ).size( ) &&
-                        coefficientsParameter->getDeformingBodies( ).size( ) == deformingBodies_.size( ) )
+                    // Add partial function if it is not yet set.
+                    if( parameterVectorPartialFunctions_.count(
+                                std::make_pair( parameter, std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ) == 0 )
                     {
-                        // Add partial function if it is not yet set.
-                        if( parameterVectorPartialFunctions_.count(
-                                    std::make_pair( parameter, std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ) == 0 )
-                        {
-                            //                        if( coefficientsParameter->useComplexComponents( ) )
-                            //                        {
-                            //                            // Calculate partials for complex love number
-                            //                            parameterVectorPartialFunctions_[ std::make_pair(
-                            //                                parameter, std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ] =
-                            //                                std::bind( &TidalLoveNumberPartialInterface::
-                            //                                           calculateSphericalHarmonicCoefficientsPartialWrtComplexTidalLoveNumbers,
-                            //                                           this, coefficientsParameter->getDegree( ),
-                            //                                           coefficientsParameter->getOrders( ), selectedDeformingBodies,
-                            //                                           maximumUsedDegree, maximumUsedOrder );
-                            //                        }
-                            //                        else
-                            //                        {
-                            // Calculate partial for real love number
-                            parameterVectorPartialFunctions_[ std::make_pair( parameter,
-                                                                              std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ] =
-                                    std::bind( &TidalLoveNumberPartialInterface::
-                                                       calculateSphericalHarmonicCoefficientsPartialWrtModeCoupledTidalLoveNumbers,
-                                               this,
-                                               coefficientsParameter->getParameterForcingDegreeAndOrderIndices( ),
-                                               coefficientsParameter->getForcingOrdersPerDegree( ),
-                                               selectedDeformingBodies,
-                                               maximumUsedDegree,
-                                               maximumUsedOrder );
-                            //                        }
-                        }
-
-                        numberOfRows = coefficientsParameter->getParameterSize( );
+                        //                        if( coefficientsParameter->useComplexComponents( ) )
+                        //                        {
+                        //                            // Calculate partials for complex love number
+                        //                            parameterVectorPartialFunctions_[ std::make_pair(
+                        //                                parameter, std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ] =
+                        //                                std::bind( &TidalLoveNumberPartialInterface::
+                        //                                           calculateSphericalHarmonicCoefficientsPartialWrtComplexTidalLoveNumbers,
+                        //                                           this, coefficientsParameter->getDegree( ),
+                        //                                           coefficientsParameter->getOrders( ), selectedDeformingBodies,
+                        //                                           maximumUsedDegree, maximumUsedOrder );
+                        //                        }
+                        //                        else
+                        //                        {
+                        // Calculate partial for real love number
+                        parameterVectorPartialFunctions_[ std::make_pair( parameter,
+                                                                          std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ] =
+                                std::bind( &TidalLoveNumberPartialInterface::
+                                                   calculateSphericalHarmonicCoefficientsPartialWrtModeCoupledTidalLoveNumbers,
+                                           this,
+                                           coefficientsParameter->getParameterForcingDegreeAndOrderIndices( ),
+                                           coefficientsParameter->getForcingOrdersPerDegree( ),
+                                           allDeformingBodyIndices_,
+                                           maximumUsedDegree,
+                                           maximumUsedOrder );
+                        //                        }
                     }
+
+                    numberOfRows = coefficientsParameter->getParameterSize( );
                 }
 
                 break;

--- a/src/tudat/astro/orbit_determination/acceleration_partials/tidalLoveNumberPartialInterface.cpp
+++ b/src/tudat/astro/orbit_determination/acceleration_partials/tidalLoveNumberPartialInterface.cpp
@@ -185,50 +185,42 @@ std::pair< int, std::pair< int, int > > TidalLoveNumberPartialInterface::setPara
                 getMaximumUsedDegreeAndOrder(
                         maximumDegree, maximumOrder, coefficientsParameter->getDegree( ), maximumUsedDegree, maximumUsedOrder );
 
-                // Set parameter partial function if relevant terms are found
-                if( maximumUsedDegree > 0 )
+                // Set parameter partial function if this interface's exact variation model belongs to the parameter
+                if( maximumUsedDegree > 0 && coefficientsParameter->dependsOnGravityFieldVariation( gravityFieldVariations_ ) )
                 {
-                    std::vector< int > selectedDeformingBodies =
-                            getSelectedDeformingBodyIds( coefficientsParameter->getDeformingBodies( ) );
-
-                    // Check if deforming bodies correspond to bodies in model.
-                    if( selectedDeformingBodies.size( ) == coefficientsParameter->getDeformingBodies( ).size( ) &&
-                        deformingBodies_.size( ) == coefficientsParameter->getDeformingBodies( ).size( ) )
+                    // Add partial function if it is not yet set.
+                    if( parameterVectorPartialFunctions_.count(
+                                std::make_pair( parameter, std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ) == 0 )
                     {
-                        // Add partial function if it is not yet set.
-                        if( parameterVectorPartialFunctions_.count(
-                                    std::make_pair( parameter, std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ) == 0 )
+                        if( coefficientsParameter->useComplexComponents( ) )
                         {
-                            if( coefficientsParameter->useComplexComponents( ) )
-                            {
-                                // Calculate partials for complex love number
-                                parameterVectorPartialFunctions_[ std::make_pair(
-                                        parameter, std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ] =
-                                        std::bind( &TidalLoveNumberPartialInterface::
-                                                           calculateSphericalHarmonicCoefficientsPartialWrtComplexTidalLoveNumber,
-                                                   this,
-                                                   coefficientsParameter->getDegree( ),
-                                                   selectedDeformingBodies,
-                                                   maximumUsedDegree,
-                                                   maximumUsedOrder );
-                            }
-                            else
-                            {
-                                // Calculate partial for real love number
-                                parameterVectorPartialFunctions_[ std::make_pair(
-                                        parameter, std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ] =
-                                        std::bind( &TidalLoveNumberPartialInterface::
-                                                           calculateSphericalHarmonicCoefficientsPartialWrtRealTidalLoveNumber,
-                                                   this,
-                                                   coefficientsParameter->getDegree( ),
-                                                   selectedDeformingBodies,
-                                                   maximumUsedDegree,
-                                                   maximumUsedOrder );
-                            }
+                            // Calculate partials for complex love number
+                            parameterVectorPartialFunctions_[ std::make_pair(
+                                    parameter, std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ] =
+                                    std::bind( &TidalLoveNumberPartialInterface::
+                                                       calculateSphericalHarmonicCoefficientsPartialWrtComplexTidalLoveNumber,
+                                               this,
+                                               coefficientsParameter->getDegree( ),
+                                               allDeformingBodyIndices_,
+                                               maximumUsedDegree,
+                                               maximumUsedOrder );
                         }
-
-                        numberOfRows = coefficientsParameter->getParameterSize( );
+                        else
+                        {
+                            // Calculate partial for real love number
+                            parameterVectorPartialFunctions_[ std::make_pair(
+                                    parameter, std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ] =
+                                    std::bind( &TidalLoveNumberPartialInterface::
+                                                       calculateSphericalHarmonicCoefficientsPartialWrtRealTidalLoveNumber,
+                                               this,
+                                               coefficientsParameter->getDegree( ),
+                                               allDeformingBodyIndices_,
+                                               maximumUsedDegree,
+                                               maximumUsedOrder );
+                        }
                     }
+
+                    numberOfRows = coefficientsParameter->getParameterSize( );
                 }
 
                 break;
@@ -248,51 +240,44 @@ std::pair< int, std::pair< int, int > > TidalLoveNumberPartialInterface::setPara
                 getMaximumUsedDegreeAndOrder(
                         maximumDegree, maximumOrder, coefficientsParameter->getDegree( ), maximumUsedDegree, maximumUsedOrder );
 
-                // Set parameter partial function if relevant terms are found
-                if( maximumUsedDegree > 0 )
+                // Set parameter partial function if this interface's exact variation model belongs to the parameter
+                if( maximumUsedDegree > 0 && coefficientsParameter->dependsOnGravityFieldVariation( gravityFieldVariations_ ) )
                 {
-                    // Check if deforming bodies correspond to bodies in model.
-                    std::vector< int > selectedDeformingBodies =
-                            getSelectedDeformingBodyIds( coefficientsParameter->getDeformingBodies( ) );
-                    if( selectedDeformingBodies.size( ) == coefficientsParameter->getDeformingBodies( ).size( ) &&
-                        coefficientsParameter->getDeformingBodies( ).size( ) == deformingBodies_.size( ) )
+                    // Add partial function if it is not yet set.
+                    if( parameterVectorPartialFunctions_.count(
+                                std::make_pair( parameter, std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ) == 0 )
                     {
-                        // Add partial function if it is not yet set.
-                        if( parameterVectorPartialFunctions_.count(
-                                    std::make_pair( parameter, std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ) == 0 )
+                        if( coefficientsParameter->useComplexComponents( ) )
                         {
-                            if( coefficientsParameter->useComplexComponents( ) )
-                            {
-                                // Calculate partials for complex love number
-                                parameterVectorPartialFunctions_[ std::make_pair(
-                                        parameter, std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ] =
-                                        std::bind( &TidalLoveNumberPartialInterface::
-                                                           calculateSphericalHarmonicCoefficientsPartialWrtComplexTidalLoveNumbers,
-                                                   this,
-                                                   coefficientsParameter->getDegree( ),
-                                                   coefficientsParameter->getOrders( ),
-                                                   selectedDeformingBodies,
-                                                   maximumUsedDegree,
-                                                   maximumUsedOrder );
-                            }
-                            else
-                            {
-                                // Calculate partial for real love number
-                                parameterVectorPartialFunctions_[ std::make_pair(
-                                        parameter, std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ] =
-                                        std::bind( &TidalLoveNumberPartialInterface::
-                                                           calculateSphericalHarmonicCoefficientsPartialWrtRealTidalLoveNumbers,
-                                                   this,
-                                                   coefficientsParameter->getDegree( ),
-                                                   coefficientsParameter->getOrders( ),
-                                                   selectedDeformingBodies,
-                                                   maximumUsedDegree,
-                                                   maximumUsedOrder );
-                            }
+                            // Calculate partials for complex love number
+                            parameterVectorPartialFunctions_[ std::make_pair(
+                                    parameter, std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ] =
+                                    std::bind( &TidalLoveNumberPartialInterface::
+                                                       calculateSphericalHarmonicCoefficientsPartialWrtComplexTidalLoveNumbers,
+                                               this,
+                                               coefficientsParameter->getDegree( ),
+                                               coefficientsParameter->getOrders( ),
+                                               allDeformingBodyIndices_,
+                                               maximumUsedDegree,
+                                               maximumUsedOrder );
                         }
-
-                        numberOfRows = coefficientsParameter->getParameterSize( );
+                        else
+                        {
+                            // Calculate partial for real love number
+                            parameterVectorPartialFunctions_[ std::make_pair(
+                                    parameter, std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ] =
+                                    std::bind( &TidalLoveNumberPartialInterface::
+                                                       calculateSphericalHarmonicCoefficientsPartialWrtRealTidalLoveNumbers,
+                                               this,
+                                               coefficientsParameter->getDegree( ),
+                                               coefficientsParameter->getOrders( ),
+                                               allDeformingBodyIndices_,
+                                               maximumUsedDegree,
+                                               maximumUsedOrder );
+                        }
                     }
+
+                    numberOfRows = coefficientsParameter->getParameterSize( );
                 }
 
                 break;

--- a/src/tudat/astro/orbit_determination/acceleration_partials/tidalLoveNumberPartialInterface.cpp
+++ b/src/tudat/astro/orbit_determination/acceleration_partials/tidalLoveNumberPartialInterface.cpp
@@ -195,8 +195,8 @@ std::pair< int, std::pair< int, int > > TidalLoveNumberPartialInterface::setPara
                         if( coefficientsParameter->useComplexComponents( ) )
                         {
                             // Calculate partials for complex love number
-                            parameterVectorPartialFunctions_[ std::make_pair(
-                                    parameter, std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ] =
+                            parameterVectorPartialFunctions_[ std::make_pair( parameter,
+                                                                              std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ] =
                                     std::bind( &TidalLoveNumberPartialInterface::
                                                        calculateSphericalHarmonicCoefficientsPartialWrtComplexTidalLoveNumber,
                                                this,
@@ -208,8 +208,8 @@ std::pair< int, std::pair< int, int > > TidalLoveNumberPartialInterface::setPara
                         else
                         {
                             // Calculate partial for real love number
-                            parameterVectorPartialFunctions_[ std::make_pair(
-                                    parameter, std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ] =
+                            parameterVectorPartialFunctions_[ std::make_pair( parameter,
+                                                                              std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ] =
                                     std::bind( &TidalLoveNumberPartialInterface::
                                                        calculateSphericalHarmonicCoefficientsPartialWrtRealTidalLoveNumber,
                                                this,
@@ -250,8 +250,8 @@ std::pair< int, std::pair< int, int > > TidalLoveNumberPartialInterface::setPara
                         if( coefficientsParameter->useComplexComponents( ) )
                         {
                             // Calculate partials for complex love number
-                            parameterVectorPartialFunctions_[ std::make_pair(
-                                    parameter, std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ] =
+                            parameterVectorPartialFunctions_[ std::make_pair( parameter,
+                                                                              std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ] =
                                     std::bind( &TidalLoveNumberPartialInterface::
                                                        calculateSphericalHarmonicCoefficientsPartialWrtComplexTidalLoveNumbers,
                                                this,
@@ -264,8 +264,8 @@ std::pair< int, std::pair< int, int > > TidalLoveNumberPartialInterface::setPara
                         else
                         {
                             // Calculate partial for real love number
-                            parameterVectorPartialFunctions_[ std::make_pair(
-                                    parameter, std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ] =
+                            parameterVectorPartialFunctions_[ std::make_pair( parameter,
+                                                                              std::make_pair( maximumUsedDegree, maximumUsedOrder ) ) ] =
                                     std::bind( &TidalLoveNumberPartialInterface::
                                                        calculateSphericalHarmonicCoefficientsPartialWrtRealTidalLoveNumbers,
                                                this,

--- a/src/tudat/astro/orbit_determination/estimatable_parameters/tidalLoveNumber.cpp
+++ b/src/tudat/astro/orbit_determination/estimatable_parameters/tidalLoveNumber.cpp
@@ -16,109 +16,185 @@ namespace tudat
 namespace estimatable_parameters
 {
 
-//! Get value of Love number k_{n}
-Eigen::VectorXd FullDegreeTidalLoveNumber::getParameterValue( )
+namespace
 {
-    // Retrieve complex Love numbers at required degree
-    std::vector< std::complex< double > > fullLoveNumbers = gravityFieldVariationModel_->getLoveNumbersOfDegree( degree_ );
 
-    // Compute mean value across orders
-    Eigen::VectorXd meanLoveNumber = Eigen::VectorXd::Zero( parameterSize_ );
-    for( int i = 0; i <= degree_; i++ )
+Eigen::VectorXd computeFullDegreeLoveNumberMean(
+        const std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > gravityFieldVariationModel,
+        const int degree,
+        const int parameterSize,
+        const bool useComplexComponents )
+{
+    std::vector< std::complex< double > > fullLoveNumbers = gravityFieldVariationModel->getLoveNumbersOfDegree( degree );
+
+    Eigen::VectorXd meanLoveNumber = Eigen::VectorXd::Zero( parameterSize );
+    for( int i = 0; i <= degree; i++ )
     {
         meanLoveNumber[ 0 ] += fullLoveNumbers[ i ].real( );
-        if( useComplexComponents_ )
+        if( useComplexComponents )
         {
             meanLoveNumber[ 1 ] += fullLoveNumbers[ i ].imag( );
         }
     }
 
-    // Return mean Love number across orders
-    meanLoveNumber = meanLoveNumber / static_cast< double >( degree_ + 1 );
-    return meanLoveNumber;
+    return meanLoveNumber / static_cast< double >( degree + 1 );
 }
 
-//! Reset value of Love number k_{n}
-void FullDegreeTidalLoveNumber::setParameterValue( Eigen::VectorXd parameterValue )
+Eigen::VectorXd computeSingleDegreeVariableLoveNumberValue(
+        const std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > gravityFieldVariationModel,
+        const int degree,
+        const std::vector< int >& orders,
+        const int parameterSize,
+        const bool useComplexComponents )
 {
-    // Retrieve complex Love numbers at required degree
-    std::vector< std::complex< double > > fullLoveNumbers;
-    fullLoveNumbers.resize( degree_ + 1 );
+    std::vector< std::complex< double > > loveNumbers = gravityFieldVariationModel->getLoveNumbersOfDegree( degree );
 
-    // Set complex value of Love numbers
-    double complexPart = 0.0;
-    if( useComplexComponents_ )
+    Eigen::VectorXd loveNumberVector = Eigen::VectorXd::Zero( parameterSize );
+    for( unsigned int i = 0; i < orders.size( ); i++ )
     {
-        complexPart = parameterValue[ 1 ];
-    }
-    else
-    {
-        std::vector< std::complex< double > > currentLoveNumbers = gravityFieldVariationModel_->getLoveNumbersOfDegree( degree_ );
-        double meanComplexNumber = 0.0;
-        for( int i = 0; i <= degree_; i++ )
+        if( useComplexComponents )
         {
-            meanComplexNumber += currentLoveNumbers[ i ].imag( );
-        }
-        meanComplexNumber /= ( degree_ + 1.0 );
-        complexPart = meanComplexNumber;
-    }
-
-    // Modify required values of Love numbers
-    std::complex< double > complexLoveNumber = std::complex< double >( parameterValue[ 0 ], complexPart );
-    for( int i = 0; i <= degree_; i++ )
-    {
-        fullLoveNumbers[ i ] = complexLoveNumber;
-    }
-
-    // Reset Love numbers
-    gravityFieldVariationModel_->resetLoveNumbersOfDegree( fullLoveNumbers, degree_ );
-}
-
-//! Get value of Love number k_{n,m}
-Eigen::VectorXd SingleDegreeVariableTidalLoveNumber::getParameterValue( )
-{
-    // Retrieve complex Love numbers at required degree
-    std::vector< std::complex< double > > loveNumbers = gravityFieldVariationModel_->getLoveNumbersOfDegree( degree_ );
-
-    // Retrieve required values
-    Eigen::VectorXd loveNumberVector = Eigen::VectorXd::Zero( parameterSize_ );
-    for( unsigned int i = 0; i < orders_.size( ); i++ )
-    {
-        if( useComplexComponents_ )
-        {
-            loveNumberVector[ 2 * i ] = loveNumbers[ orders_[ i ] ].real( );
-            loveNumberVector[ 2 * i + 1 ] = loveNumbers[ orders_[ i ] ].imag( );
+            loveNumberVector[ 2 * i ] = loveNumbers[ orders[ i ] ].real( );
+            loveNumberVector[ 2 * i + 1 ] = loveNumbers[ orders[ i ] ].imag( );
         }
         else
         {
-            loveNumberVector[ i ] = loveNumbers[ orders_[ i ] ].real( );
+            loveNumberVector[ i ] = loveNumbers[ orders[ i ] ].real( );
         }
     }
 
     return loveNumberVector;
 }
 
-//! Reset value of Love number k_{n,m}
-void SingleDegreeVariableTidalLoveNumber::setParameterValue( Eigen::VectorXd parameterValue )
-{
-    // Retrieve current complex Love numbers at required degree
-    std::vector< std::complex< double > > fullLoveNumbers = gravityFieldVariationModel_->getLoveNumbersOfDegree( degree_ );
+}  // namespace
 
-    // Modify required values
-    for( unsigned int i = 0; i < orders_.size( ); i++ )
+//! Get value of Love number k_{n}
+Eigen::VectorXd FullDegreeTidalLoveNumber::getParameterValue( )
+{
+    Eigen::VectorXd parameter = computeFullDegreeLoveNumberMean(
+            gravityFieldVariationModels_.front( ), degree_, parameterSize_, useComplexComponents_ );
+
+    for( unsigned int modelIndex = 1; modelIndex < gravityFieldVariationModels_.size( ); modelIndex++ )
     {
-        if( useComplexComponents_ )
+        Eigen::VectorXd currentParameter = computeFullDegreeLoveNumberMean(
+                gravityFieldVariationModels_.at( modelIndex ), degree_, parameterSize_, useComplexComponents_ );
+        if( parameter != currentParameter )
         {
-            fullLoveNumbers[ orders_[ i ] ] = std::complex< double >( parameterValue[ 2 * i ], parameterValue[ 2 * i + 1 ] );
-        }
-        else
-        {
-            fullLoveNumbers[ orders_[ i ] ] = std::complex< double >( parameterValue[ i ], fullLoveNumbers[ orders_[ i ] ].imag( ) );
+            std::cerr << "Warning when retrieving full-degree tidal Love number parameter from multiple models. "
+                         "List entries are incompatible. First entry is: "
+                      << std::endl
+                      << parameter << std::endl
+                      << " Current value is: " << std::endl
+                      << currentParameter << std::endl
+                      << "Difference is: " << parameter - currentParameter << std::endl;
         }
     }
 
-    // Reset values
-    gravityFieldVariationModel_->resetLoveNumbersOfDegree( fullLoveNumbers, degree_ );
+    return parameter;
+}
+
+//! Reset value of Love number k_{n}
+void FullDegreeTidalLoveNumber::setParameterValue( Eigen::VectorXd parameterValue )
+{
+    if( parameterValue.size( ) != parameterSize_ )
+    {
+        throw std::runtime_error( "Error when resetting full-degree tidal Love number parameter, expected size " +
+                                  std::to_string( parameterSize_ ) + ", but received size " +
+                                  std::to_string( parameterValue.size( ) ) + "." );
+    }
+
+    for( unsigned int modelIndex = 0; modelIndex < gravityFieldVariationModels_.size( ); modelIndex++ )
+    {
+        std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > gravityFieldVariationModel =
+                gravityFieldVariationModels_.at( modelIndex );
+
+        std::vector< std::complex< double > > fullLoveNumbers;
+        fullLoveNumbers.resize( degree_ + 1 );
+
+        double complexPart = 0.0;
+        if( useComplexComponents_ )
+        {
+            complexPart = parameterValue[ 1 ];
+        }
+        else
+        {
+            std::vector< std::complex< double > > currentLoveNumbers = gravityFieldVariationModel->getLoveNumbersOfDegree( degree_ );
+            double meanComplexNumber = 0.0;
+            for( int i = 0; i <= degree_; i++ )
+            {
+                meanComplexNumber += currentLoveNumbers[ i ].imag( );
+            }
+            meanComplexNumber /= ( degree_ + 1.0 );
+            complexPart = meanComplexNumber;
+        }
+
+        std::complex< double > complexLoveNumber = std::complex< double >( parameterValue[ 0 ], complexPart );
+        for( int i = 0; i <= degree_; i++ )
+        {
+            fullLoveNumbers[ i ] = complexLoveNumber;
+        }
+
+        gravityFieldVariationModel->resetLoveNumbersOfDegree( fullLoveNumbers, degree_ );
+    }
+}
+
+//! Get value of Love number k_{n,m}
+Eigen::VectorXd SingleDegreeVariableTidalLoveNumber::getParameterValue( )
+{
+    Eigen::VectorXd parameter = computeSingleDegreeVariableLoveNumberValue(
+            gravityFieldVariationModels_.front( ), degree_, orders_, parameterSize_, useComplexComponents_ );
+
+    for( unsigned int modelIndex = 1; modelIndex < gravityFieldVariationModels_.size( ); modelIndex++ )
+    {
+        Eigen::VectorXd currentParameter = computeSingleDegreeVariableLoveNumberValue(
+                gravityFieldVariationModels_.at( modelIndex ), degree_, orders_, parameterSize_, useComplexComponents_ );
+        if( parameter != currentParameter )
+        {
+            std::cerr << "Warning when retrieving single-degree variable tidal Love number parameter from multiple models. "
+                         "List entries are incompatible. First entry is: "
+                      << std::endl
+                      << parameter << std::endl
+                      << " Current value is: " << std::endl
+                      << currentParameter << std::endl
+                      << "Difference is: " << parameter - currentParameter << std::endl;
+        }
+    }
+
+    return parameter;
+}
+
+//! Reset value of Love number k_{n,m}
+void SingleDegreeVariableTidalLoveNumber::setParameterValue( Eigen::VectorXd parameterValue )
+{
+    if( parameterValue.size( ) != parameterSize_ )
+    {
+        throw std::runtime_error( "Error when resetting single-degree variable tidal Love number parameter, expected size " +
+                                  std::to_string( parameterSize_ ) + ", but received size " +
+                                  std::to_string( parameterValue.size( ) ) + "." );
+    }
+
+    for( unsigned int modelIndex = 0; modelIndex < gravityFieldVariationModels_.size( ); modelIndex++ )
+    {
+        std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > gravityFieldVariationModel =
+                gravityFieldVariationModels_.at( modelIndex );
+
+        std::vector< std::complex< double > > fullLoveNumbers = gravityFieldVariationModel->getLoveNumbersOfDegree( degree_ );
+
+        for( unsigned int i = 0; i < orders_.size( ); i++ )
+        {
+            if( useComplexComponents_ )
+            {
+                fullLoveNumbers[ orders_[ i ] ] = std::complex< double >( parameterValue[ 2 * i ], parameterValue[ 2 * i + 1 ] );
+            }
+            else
+            {
+                fullLoveNumbers[ orders_[ i ] ] =
+                        std::complex< double >( parameterValue[ i ], fullLoveNumbers[ orders_[ i ] ].imag( ) );
+            }
+        }
+
+        gravityFieldVariationModel->resetLoveNumbersOfDegree( fullLoveNumbers, degree_ );
+    }
 }
 
 ModeCoupledTidalLoveNumber::ModeCoupledTidalLoveNumber(

--- a/src/tudat/astro/orbit_determination/estimatable_parameters/tidalLoveNumber.cpp
+++ b/src/tudat/astro/orbit_determination/estimatable_parameters/tidalLoveNumber.cpp
@@ -68,17 +68,24 @@ Eigen::VectorXd computeSingleDegreeVariableLoveNumberValue(
 
 }  // namespace
 
+//! Relative tolerance for multi-model Love-number consistency checks.
+/*!
+ *  Matches Eigen::NumTraits< double >::dummy_precision( ) (1e-12). Material mismatches such as
+ *  0.301 vs 0.295 still trigger a warning; negligible floating-point noise does not.
+ */
+constexpr double loveNumberConsistencyTolerance = 1.0E-12;
+
 //! Get value of Love number k_{n}
 Eigen::VectorXd FullDegreeTidalLoveNumber::getParameterValue( )
 {
-    Eigen::VectorXd parameter = computeFullDegreeLoveNumberMean(
-            gravityFieldVariationModels_.front( ), degree_, parameterSize_, useComplexComponents_ );
+    Eigen::VectorXd parameter =
+            computeFullDegreeLoveNumberMean( gravityFieldVariationModels_.front( ), degree_, parameterSize_, useComplexComponents_ );
 
     for( unsigned int modelIndex = 1; modelIndex < gravityFieldVariationModels_.size( ); modelIndex++ )
     {
         Eigen::VectorXd currentParameter = computeFullDegreeLoveNumberMean(
                 gravityFieldVariationModels_.at( modelIndex ), degree_, parameterSize_, useComplexComponents_ );
-        if( parameter != currentParameter )
+        if( !parameter.isApprox( currentParameter, loveNumberConsistencyTolerance ) )
         {
             std::cerr << "Warning when retrieving full-degree tidal Love number parameter from multiple models. "
                          "List entries are incompatible. First entry is: "
@@ -99,8 +106,8 @@ void FullDegreeTidalLoveNumber::setParameterValue( Eigen::VectorXd parameterValu
     if( parameterValue.size( ) != parameterSize_ )
     {
         throw std::runtime_error( "Error when resetting full-degree tidal Love number parameter, expected size " +
-                                  std::to_string( parameterSize_ ) + ", but received size " +
-                                  std::to_string( parameterValue.size( ) ) + "." );
+                                  std::to_string( parameterSize_ ) + ", but received size " + std::to_string( parameterValue.size( ) ) +
+                                  "." );
     }
 
     for( unsigned int modelIndex = 0; modelIndex < gravityFieldVariationModels_.size( ); modelIndex++ )
@@ -111,27 +118,23 @@ void FullDegreeTidalLoveNumber::setParameterValue( Eigen::VectorXd parameterValu
         std::vector< std::complex< double > > fullLoveNumbers;
         fullLoveNumbers.resize( degree_ + 1 );
 
-        double complexPart = 0.0;
         if( useComplexComponents_ )
         {
-            complexPart = parameterValue[ 1 ];
+            const std::complex< double > complexLoveNumber( parameterValue[ 0 ], parameterValue[ 1 ] );
+            for( int i = 0; i <= degree_; i++ )
+            {
+                fullLoveNumbers[ i ] = complexLoveNumber;
+            }
         }
         else
         {
-            std::vector< std::complex< double > > currentLoveNumbers = gravityFieldVariationModel->getLoveNumbersOfDegree( degree_ );
-            double meanComplexNumber = 0.0;
+            // Real-only estimation: update every order's real part, but keep each order's existing
+            // imaginary component independently (do not average across orders).
+            const std::vector< std::complex< double > > currentLoveNumbers = gravityFieldVariationModel->getLoveNumbersOfDegree( degree_ );
             for( int i = 0; i <= degree_; i++ )
             {
-                meanComplexNumber += currentLoveNumbers[ i ].imag( );
+                fullLoveNumbers[ i ] = std::complex< double >( parameterValue[ 0 ], currentLoveNumbers[ i ].imag( ) );
             }
-            meanComplexNumber /= ( degree_ + 1.0 );
-            complexPart = meanComplexNumber;
-        }
-
-        std::complex< double > complexLoveNumber = std::complex< double >( parameterValue[ 0 ], complexPart );
-        for( int i = 0; i <= degree_; i++ )
-        {
-            fullLoveNumbers[ i ] = complexLoveNumber;
         }
 
         gravityFieldVariationModel->resetLoveNumbersOfDegree( fullLoveNumbers, degree_ );
@@ -148,7 +151,7 @@ Eigen::VectorXd SingleDegreeVariableTidalLoveNumber::getParameterValue( )
     {
         Eigen::VectorXd currentParameter = computeSingleDegreeVariableLoveNumberValue(
                 gravityFieldVariationModels_.at( modelIndex ), degree_, orders_, parameterSize_, useComplexComponents_ );
-        if( parameter != currentParameter )
+        if( !parameter.isApprox( currentParameter, loveNumberConsistencyTolerance ) )
         {
             std::cerr << "Warning when retrieving single-degree variable tidal Love number parameter from multiple models. "
                          "List entries are incompatible. First entry is: "
@@ -169,8 +172,8 @@ void SingleDegreeVariableTidalLoveNumber::setParameterValue( Eigen::VectorXd par
     if( parameterValue.size( ) != parameterSize_ )
     {
         throw std::runtime_error( "Error when resetting single-degree variable tidal Love number parameter, expected size " +
-                                  std::to_string( parameterSize_ ) + ", but received size " +
-                                  std::to_string( parameterValue.size( ) ) + "." );
+                                  std::to_string( parameterSize_ ) + ", but received size " + std::to_string( parameterValue.size( ) ) +
+                                  "." );
     }
 
     for( unsigned int modelIndex = 0; modelIndex < gravityFieldVariationModels_.size( ); modelIndex++ )
@@ -188,8 +191,7 @@ void SingleDegreeVariableTidalLoveNumber::setParameterValue( Eigen::VectorXd par
             }
             else
             {
-                fullLoveNumbers[ orders_[ i ] ] =
-                        std::complex< double >( parameterValue[ i ], fullLoveNumbers[ orders_[ i ] ].imag( ) );
+                fullLoveNumbers[ orders_[ i ] ] = std::complex< double >( parameterValue[ i ], fullLoveNumbers[ orders_[ i ] ].imag( ) );
             }
         }
 

--- a/src/tudat/simulation/estimation_setup/createAccelerationPartials.cpp
+++ b/src/tudat/simulation/estimation_setup/createAccelerationPartials.cpp
@@ -55,7 +55,8 @@ std::vector< std::shared_ptr< orbit_determination::TidalLoveNumberPartialInterfa
                     {
                         deformingBodyStateFunctions.push_back( std::bind( &Body::getPosition, bodies.at( deformingBodies.at( i ) ) ) );
                     }
-                    // Create partial object
+                    // Create partial object. Keep one interface per distinct variation model (pointer identity), so that
+                    // independent per-degree models for the same deforming body remain available to Love-number partials.
                     auto newLoveNumberInterface = std::make_shared< orbit_determination::TidalLoveNumberPartialInterface >(
                             variationObjectList.at( i ),
                             deformedBodyPositionFunction,
@@ -66,13 +67,11 @@ std::vector< std::shared_ptr< orbit_determination::TidalLoveNumberPartialInterfa
                     bool addInterface = true;
                     for( unsigned int j = 0; j < loveNumberInterfaces.size( ); j++ )
                     {
-                        if( acceleratingBodyName == loveNumberInterfaces.at( j )->getDeformedBody( ) )
+                        if( newLoveNumberInterface->getGravityFieldVariations( ) ==
+                            loveNumberInterfaces.at( j )->getGravityFieldVariations( ) )
                         {
-                            if( utilities::compareStlVectors< std::string >( newLoveNumberInterface->getDeformingBodies( ),
-                                                                             loveNumberInterfaces.at( j )->getDeformingBodies( ) ) )
-                            {
-                                addInterface = false;
-                            }
+                            addInterface = false;
+                            break;
                         }
                     }
 

--- a/src/tudatpy/dynamics/parameters_setup/expose_parameters_setup.cpp
+++ b/src/tudatpy/dynamics/parameters_setup/expose_parameters_setup.cpp
@@ -1683,7 +1683,11 @@ deformed_body : str
 degree : int
     Degree :math:`l` of the Love number :math:`k_{l}` that is to be estimated
 deforming_bodies : list[str]
-    List of bodies that raise a tide on ``deformed_body`` for which the single Love number defined by this setting is to be used. If the list is left empty, all tide-raising bodies will be used. By using this parameter, the value of :math:`k_{l}` will be identical for the tides raised by each body in this list once parameter values are reset, even if they were different upon environment initialization
+    List of bodies that raise a tide on ``deformed_body`` for which the single Love number defined by this setting is to be used.
+    The bodies may belong to one or more separate ``solid_body_tide`` variation models.
+    If the list is left empty, all compatible basic solid-body tide-raising bodies/models of ``deformed_body`` will be used.
+    By using this parameter, the value of :math:`k_{l}` will be identical for the tides raised by each body in this list once
+    parameter values are reset, even if they were different upon environment initialization
 use_complex_love_number: bool
     Boolean defining whether the estimated Love number is real or imaginary
 

--- a/tests/test_tudat/src/astro/orbit_determination/acceleration_partials/unitTestSphericalHarmonicPartials.cpp
+++ b/tests/test_tudat/src/astro/orbit_determination/acceleration_partials/unitTestSphericalHarmonicPartials.cpp
@@ -21,6 +21,11 @@
 #include "tudat/astro/orbit_determination/acceleration_partials/numericalAccelerationPartial.h"
 #include "tudat/astro/orbit_determination/acceleration_partials/sphericalHarmonicAccelerationPartial.h"
 #include "tudat/astro/orbit_determination/acceleration_partials/sphericalHarmonicPartialFunctions.h"
+#include "tudat/astro/orbit_determination/acceleration_partials/fullTwoBodySphericalHarmonicGravityPartial.h"
+#include "tudat/astro/ephemerides/simpleRotationalEphemeris.h"
+#include "tudat/astro/gravitation/basicSolidBodyTideGravityFieldVariations.h"
+#include "tudat/astro/gravitation/centralGravityModel.h"
+#include "tudat/astro/orbit_determination/observation_partials/rotationMatrixPartial.h"
 #include "tudat/astro/propagators/propagateCovariance.h"
 #include "tudat/simulation/environment_setup/createGroundStations.h"
 #include "tudat/simulation/estimation_setup/createAccelerationPartials.h"
@@ -1380,6 +1385,177 @@ BOOST_AUTO_TEST_CASE( testMultiModelLoveNumberAccelerationPartial )
 
     TUDAT_CHECK_MATRIX_CLOSE_FRACTION( analyticalPartial, numericalPartial, 1.0E-5 );
     BOOST_CHECK( analyticalPartial.norm( ) > 0.0 );
+}
+
+//! Focused regression: full-two-body Love-number partials must sum contributions from multiple tide models.
+BOOST_AUTO_TEST_CASE( testFullTwoBodyMultiModelLoveNumberAccelerationPartial )
+{
+    const double gravitationalParameter = 5.0E5;
+    const double equatorialRadiusOfBody1 = 1300.0;
+    const double equatorialRadiusOfBody2 = 1100.0;
+    const double evaluationTime = 1000.0;
+
+    Eigen::MatrixXd cosineCoefficientsOfBody1Base = Eigen::MatrixXd::Zero( 3, 3 );
+    Eigen::MatrixXd sineCoefficientsOfBody1Base = Eigen::MatrixXd::Zero( 3, 3 );
+    Eigen::MatrixXd cosineCoefficientsOfBody2Base = Eigen::MatrixXd::Zero( 3, 3 );
+    Eigen::MatrixXd sineCoefficientsOfBody2Base = Eigen::MatrixXd::Zero( 3, 3 );
+    cosineCoefficientsOfBody1Base( 0, 0 ) = 1.0;
+    cosineCoefficientsOfBody2Base( 0, 0 ) = 1.0;
+    cosineCoefficientsOfBody1Base( 2, 0 ) = 0.23;
+    cosineCoefficientsOfBody1Base( 2, 1 ) = -0.11;
+    sineCoefficientsOfBody1Base( 2, 1 ) = 0.14;
+    cosineCoefficientsOfBody1Base( 2, 2 ) = 0.09;
+    sineCoefficientsOfBody1Base( 2, 2 ) = -0.06;
+
+    std::shared_ptr< Body > body1 = std::make_shared< Body >( );
+    std::shared_ptr< Body > body2 = std::make_shared< Body >( );
+    std::shared_ptr< Body > body3 = std::make_shared< Body >( );
+
+    std::shared_ptr< SphericalHarmonicsGravityField > body1GravityField = std::make_shared< SphericalHarmonicsGravityField >(
+            gravitationalParameter, equatorialRadiusOfBody1, cosineCoefficientsOfBody1Base, sineCoefficientsOfBody1Base, "IAU_Body1" );
+    std::shared_ptr< SphericalHarmonicsGravityField > body2GravityField = std::make_shared< SphericalHarmonicsGravityField >(
+            gravitationalParameter, equatorialRadiusOfBody2, cosineCoefficientsOfBody2Base, sineCoefficientsOfBody2Base, "IAU_Body2" );
+    std::shared_ptr< GravityFieldModel > body3GravityField = std::make_shared< GravityFieldModel >( 0.35 * gravitationalParameter );
+
+    body1->setGravityFieldModel( body1GravityField );
+    body2->setGravityFieldModel( body2GravityField );
+    body3->setGravityFieldModel( body3GravityField );
+
+    body1->setRotationalEphemeris( std::make_shared< ephemerides::SimpleRotationalEphemeris >(
+            Eigen::Quaterniond::Identity( ), 0.0, evaluationTime, "ECLIPJ2000", "IAU_Body1" ) );
+    body2->setRotationalEphemeris( std::make_shared< ephemerides::SimpleRotationalEphemeris >(
+            Eigen::Quaterniond::Identity( ), 0.0, evaluationTime, "ECLIPJ2000", "IAU_Body2" ) );
+
+    Eigen::Vector6d stateOfBody1 = Eigen::Vector6d::Zero( );
+    Eigen::Vector6d stateOfBody2 = Eigen::Vector6d::Zero( );
+    Eigen::Vector6d stateOfBody3 = Eigen::Vector6d::Zero( );
+    stateOfBody1.segment( 0, 3 ) = ( Eigen::Vector3d( ) << 5100.0, -2200.0, 3600.0 ).finished( );
+    stateOfBody3.segment( 0, 3 ) = ( Eigen::Vector3d( ) << -7800.0, 4100.0, -2600.0 ).finished( );
+    body1->setState( stateOfBody1 );
+    body2->setState( stateOfBody2 );
+    body3->setState( stateOfBody3 );
+    body1->setCurrentRotationToLocalFrameFromEphemeris( evaluationTime );
+    body2->setCurrentRotationToLocalFrameFromEphemeris( evaluationTime );
+
+    auto createSimpleRotationPartialMap = [ ]( const std::shared_ptr< Body >& body ) {
+        std::shared_ptr< ephemerides::SimpleRotationalEphemeris > rotationModel =
+                std::dynamic_pointer_cast< ephemerides::SimpleRotationalEphemeris >( body->getRotationalEphemeris( ) );
+        observation_partials::RotationMatrixPartialNamedList partials;
+        partials[ std::make_pair( constant_rotation_rate, "" ) ] =
+                std::make_shared< observation_partials::RotationMatrixPartialWrtConstantRotationRate >( rotationModel );
+        partials[ std::make_pair( rotation_pole_position, "" ) ] =
+                std::make_shared< observation_partials::RotationMatrixPartialWrtPoleOrientation >( rotationModel );
+        return partials;
+    };
+
+    std::map< int, std::vector< std::complex< double > > > body2LoveNumbers;
+    body2LoveNumbers[ 2 ].push_back( std::complex< double >( 0.21, 0.0 ) );
+    body2LoveNumbers[ 2 ].push_back( std::complex< double >( 0.14, 0.0 ) );
+    body2LoveNumbers[ 2 ].push_back( std::complex< double >( 0.08, 0.0 ) );
+    std::map< int, std::vector< std::complex< double > > > body3LoveNumbers;
+    body3LoveNumbers[ 2 ].push_back( std::complex< double >( 0.19, 0.0 ) );
+    body3LoveNumbers[ 2 ].push_back( std::complex< double >( 0.11, 0.0 ) );
+    body3LoveNumbers[ 2 ].push_back( std::complex< double >( 0.07, 0.0 ) );
+
+    std::shared_ptr< BasicSolidBodyTideGravityFieldVariations > body2Tide =
+            std::make_shared< BasicSolidBodyTideGravityFieldVariations >(
+                    [ & ]( const double ) { return body1->getState( ); },
+                    [ & ]( const double ) { return body1->getCurrentRotationToLocalFrame( ); },
+                    std::vector< std::function< Eigen::Vector6d( const double ) > >{
+                            [ & ]( const double ) { return body2->getState( ); } },
+                    equatorialRadiusOfBody1,
+                    [ & ]( ) { return body1GravityField->getGravitationalParameter( ); },
+                    std::vector< std::function< double( ) > >{ [ & ]( ) { return body2GravityField->getGravitationalParameter( ); } },
+                    body2LoveNumbers,
+                    std::vector< std::string >{ "Body2" } );
+    std::shared_ptr< BasicSolidBodyTideGravityFieldVariations > body3Tide =
+            std::make_shared< BasicSolidBodyTideGravityFieldVariations >(
+                    [ & ]( const double ) { return body1->getState( ); },
+                    [ & ]( const double ) { return body1->getCurrentRotationToLocalFrame( ); },
+                    std::vector< std::function< Eigen::Vector6d( const double ) > >{
+                            [ & ]( const double ) { return body3->getState( ); } },
+                    equatorialRadiusOfBody1,
+                    [ & ]( ) { return body1GravityField->getGravitationalParameter( ); },
+                    std::vector< std::function< double( ) > >{ [ & ]( ) { return body3GravityField->getGravitationalParameter( ); } },
+                    body3LoveNumbers,
+                    std::vector< std::string >{ "Body3" } );
+
+    std::vector< std::shared_ptr< BasicSolidBodyTideGravityFieldVariations > > tideModels;
+    tideModels.push_back( body2Tide );
+    tideModels.push_back( body3Tide );
+    std::shared_ptr< FullDegreeTidalLoveNumber > multiModelLoveNumber =
+            std::make_shared< FullDegreeTidalLoveNumber >( tideModels, "Body1", 2, false );
+
+    std::shared_ptr< orbit_determination::TidalLoveNumberPartialInterface > body2LoveNumberPartialInterface =
+            std::make_shared< orbit_determination::TidalLoveNumberPartialInterface >(
+                    body2Tide,
+                    std::bind( &Body::getPosition, body1 ),
+                    std::vector< std::function< Eigen::Vector3d( ) > >{ std::bind( &Body::getPosition, body2 ) },
+                    std::bind( &Body::getCurrentRotationToLocalFrame, body1 ),
+                    "Body1" );
+    std::shared_ptr< orbit_determination::TidalLoveNumberPartialInterface > body3LoveNumberPartialInterface =
+            std::make_shared< orbit_determination::TidalLoveNumberPartialInterface >(
+                    body3Tide,
+                    std::bind( &Body::getPosition, body1 ),
+                    std::vector< std::function< Eigen::Vector3d( ) > >{ std::bind( &Body::getPosition, body3 ) },
+                    std::bind( &Body::getCurrentRotationToLocalFrame, body1 ),
+                    "Body1" );
+
+    std::shared_ptr< AccelerationSettings > accelerationSettings =
+            std::make_shared< FullTwoBodySphericalHarmonicAccelerationSettings >( 2, 2, 0, 0 );
+    std::shared_ptr< FullTwoBodySphericalHarmonicAcceleration > accelerationModel =
+            std::dynamic_pointer_cast< FullTwoBodySphericalHarmonicAcceleration >(
+                    createAccelerationModel( body1, body2, accelerationSettings, "Body1", "Body2" ) );
+    BOOST_REQUIRE( accelerationModel != nullptr );
+
+    std::shared_ptr< FullTwoBodySphericalHarmonicsGravityPartial > loveNumberAccelerationPartial =
+            std::make_shared< FullTwoBodySphericalHarmonicsGravityPartial >(
+                    "Body1",
+                    "Body2",
+                    accelerationModel,
+                    createSimpleRotationPartialMap( body1 ),
+                    createSimpleRotationPartialMap( body2 ),
+                    std::vector< std::shared_ptr< orbit_determination::TidalLoveNumberPartialInterface > >{
+                            body2LoveNumberPartialInterface, body3LoveNumberPartialInterface } );
+
+    const std::function< void( ) > updateLoveNumberEnvironment = [ & ]( ) {
+        body1->setCurrentRotationToLocalFrameFromEphemeris( evaluationTime );
+        body2->setCurrentRotationToLocalFrameFromEphemeris( evaluationTime );
+        Eigen::MatrixXd cosineCoefficients = cosineCoefficientsOfBody1Base;
+        Eigen::MatrixXd sineCoefficients = sineCoefficientsOfBody1Base;
+        body2Tide->addSphericalHarmonicsCorrections( evaluationTime, sineCoefficients, cosineCoefficients );
+        body3Tide->addSphericalHarmonicsCorrections( evaluationTime, sineCoefficients, cosineCoefficients );
+        body1GravityField->setCosineCoefficients( cosineCoefficients );
+        body1GravityField->setSineCoefficients( sineCoefficients );
+    };
+    auto evaluateLoveNumberAcceleration = [ & ]( ) {
+        body1->setCurrentRotationToLocalFrameFromEphemeris( evaluationTime );
+        body2->setCurrentRotationToLocalFrameFromEphemeris( evaluationTime );
+        accelerationModel->resetCurrentTime( );
+        loveNumberAccelerationPartial->resetCurrentTime( );
+        accelerationModel->updateMembers( evaluationTime );
+        loveNumberAccelerationPartial->update( evaluationTime );
+        return accelerationModel->getAcceleration( );
+    };
+
+    updateLoveNumberEnvironment( );
+    evaluateLoveNumberAcceleration( );
+    const Eigen::MatrixXd analyticalLoveNumberPartial = loveNumberAccelerationPartial->wrtParameter( multiModelLoveNumber );
+    const Eigen::MatrixXd numericalLoveNumberPartial = calculateAccelerationWrtParameterPartials(
+            multiModelLoveNumber,
+            accelerationModel,
+            Eigen::VectorXd::Constant( multiModelLoveNumber->getParameterSize( ), 1.0 ),
+            updateLoveNumberEnvironment,
+            evaluationTime,
+            [ & ]( const double currentTime ) {
+                body1->setCurrentRotationToLocalFrameFromEphemeris( currentTime );
+                body2->setCurrentRotationToLocalFrameFromEphemeris( currentTime );
+            } );
+    updateLoveNumberEnvironment( );
+    evaluateLoveNumberAcceleration( );
+
+    TUDAT_CHECK_MATRIX_CLOSE_FRACTION( analyticalLoveNumberPartial, numericalLoveNumberPartial, 1.0E-8 );
+    BOOST_CHECK( analyticalLoveNumberPartial.norm( ) > 0.0 );
 }
 
 BOOST_AUTO_TEST_SUITE_END( )

--- a/tests/test_tudat/src/astro/orbit_determination/acceleration_partials/unitTestSphericalHarmonicPartials.cpp
+++ b/tests/test_tudat/src/astro/orbit_determination/acceleration_partials/unitTestSphericalHarmonicPartials.cpp
@@ -1558,6 +1558,214 @@ BOOST_AUTO_TEST_CASE( testFullTwoBodyMultiModelLoveNumberAccelerationPartial )
     BOOST_CHECK( analyticalLoveNumberPartial.norm( ) > 0.0 );
 }
 
+//! Same deforming body with separate degree-2 / degree-3 models must keep distinct Love-number interfaces.
+BOOST_AUTO_TEST_CASE( testDegreeSeparatedMoonLoveNumberAccelerationPartials )
+{
+    spice_interface::loadStandardSpiceKernels( );
+
+    const double gravitationalParameter = 3.986004418e14;
+    const double planetaryRadius = 6378137.0;
+
+    Eigen::MatrixXd cosineCoefficients = ( Eigen::MatrixXd( 6, 6 ) << 0.0,
+                                           0.0,
+                                           0.0,
+                                           0.0,
+                                           0.0,
+                                           0.0,
+                                           0.0,
+                                           0.0,
+                                           0.0,
+                                           0.0,
+                                           0.0,
+                                           0.0,
+                                           -4.841651437908150e-4,
+                                           -2.066155090741760e-10,
+                                           2.439383573283130e-6,
+                                           0.0,
+                                           0.0,
+                                           0.0,
+                                           9.571612070934730e-7,
+                                           2.030462010478640e-6,
+                                           9.047878948095281e-7,
+                                           7.213217571215680e-7,
+                                           0.0,
+                                           0.0,
+                                           5.399658666389910e-7,
+                                           -5.361573893888670e-7,
+                                           3.505016239626490e-7,
+                                           9.908567666723210e-7,
+                                           -1.885196330230330e-7,
+                                           0.0,
+                                           6.867029137366810e-8,
+                                           -6.292119230425290e-8,
+                                           6.520780431761640e-7,
+                                           -4.518471523288430e-7,
+                                           -2.953287611756290e-7,
+                                           1.748117954960020e-7 )
+                                                 .finished( );
+
+    Eigen::MatrixXd sineCoefficients = ( Eigen::MatrixXd( 6, 6 ) << 0.0,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         1.384413891379790e-9,
+                                         -1.400273703859340e-6,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         2.482004158568720e-7,
+                                         -6.190054751776180e-7,
+                                         1.414349261929410e-6,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         -4.735673465180860e-7,
+                                         6.624800262758290e-7,
+                                         -2.009567235674520e-7,
+                                         3.088038821491940e-7,
+                                         0.0,
+                                         0.0,
+                                         -9.436980733957690e-8,
+                                         -3.233531925405220e-7,
+                                         -2.149554083060460e-7,
+                                         4.980705501023510e-8,
+                                         -6.693799351801650e-7 )
+                                               .finished( );
+
+    auto runDegreeSeparatedCase = [ & ]( const bool degreeThreeFirst ) {
+        std::shared_ptr< Body > earth = std::make_shared< Body >( );
+        std::shared_ptr< Body > vehicle = std::make_shared< Body >( );
+
+        std::shared_ptr< GravityFieldSettings > earthGravityFieldSettings = std::make_shared< SphericalHarmonicsGravityFieldSettings >(
+                gravitationalParameter, planetaryRadius, cosineCoefficients, sineCoefficients, "IAU_Earth" );
+
+        std::map< int, std::vector< std::complex< double > > > moonDegreeTwoLoveNumbers;
+        moonDegreeTwoLoveNumbers[ 2 ] = std::vector< std::complex< double > >( 3, std::complex< double >( 0.29525, -0.00087 ) );
+        std::map< int, std::vector< std::complex< double > > > moonDegreeThreeLoveNumbers;
+        moonDegreeThreeLoveNumbers[ 3 ] = std::vector< std::complex< double > >( 4, std::complex< double >( 0.093, 0.0 ) );
+
+        std::vector< std::shared_ptr< GravityFieldVariationSettings > > gravityFieldVariationSettings;
+        std::vector< std::string > moonDeformingBodies;
+        moonDeformingBodies.push_back( "Moon" );
+        if( degreeThreeFirst )
+        {
+            gravityFieldVariationSettings.push_back(
+                    std::make_shared< BasicSolidBodyGravityFieldVariationSettings >( moonDeformingBodies, moonDegreeThreeLoveNumbers ) );
+            gravityFieldVariationSettings.push_back(
+                    std::make_shared< BasicSolidBodyGravityFieldVariationSettings >( moonDeformingBodies, moonDegreeTwoLoveNumbers ) );
+        }
+        else
+        {
+            gravityFieldVariationSettings.push_back(
+                    std::make_shared< BasicSolidBodyGravityFieldVariationSettings >( moonDeformingBodies, moonDegreeTwoLoveNumbers ) );
+            gravityFieldVariationSettings.push_back(
+                    std::make_shared< BasicSolidBodyGravityFieldVariationSettings >( moonDeformingBodies, moonDegreeThreeLoveNumbers ) );
+        }
+
+        SystemOfBodies bodies;
+        bodies.addBody( earth, "Earth" );
+        bodies.addBody( vehicle, "Vehicle" );
+        SystemOfBodies moonBodies = createSystemOfBodies( getDefaultBodySettings( std::vector< std::string >{ "Moon" } ) );
+        bodies.addBody( moonBodies.at( "Moon" ), "Moon" );
+
+        std::shared_ptr< ephemerides::SimpleRotationalEphemeris > simpleRotationalEphemeris =
+                std::make_shared< ephemerides::SimpleRotationalEphemeris >(
+                        spice_interface::computeRotationQuaternionBetweenFrames( "ECLIPJ2000", "IAU_Earth", 0.0 ),
+                        2.0 * mathematical_constants::PI / 86400.0,
+                        1.0E7,
+                        "ECLIPJ2000",
+                        "IAU_Earth" );
+        earth->setRotationalEphemeris( simpleRotationalEphemeris );
+
+        std::shared_ptr< tudat::gravitation::TimeDependentSphericalHarmonicsGravityField > earthGravityField =
+                std::dynamic_pointer_cast< gravitation::TimeDependentSphericalHarmonicsGravityField >(
+                        tudat::simulation_setup::createGravityFieldModel(
+                                earthGravityFieldSettings, "Earth", bodies, gravityFieldVariationSettings ) );
+        earth->setGravityFieldModel( earthGravityField );
+        bodies.at( "Earth" )->setGravityFieldVariationSet(
+                createGravityFieldModelVariationsSet( "Earth", bodies, gravityFieldVariationSettings ) );
+        bodies.at( "Earth" )->updateConstantEphemerisDependentMemberQuantities( );
+
+        const double testTime = 1.0E6;
+        earth->setState( Eigen::Vector6d::Zero( ) );
+        earth->setCurrentRotationToLocalFrameFromEphemeris( testTime );
+        bodies.at( "Moon" )->setState(
+                tudat::spice_interface::getBodyCartesianStateAtEpoch( "Moon", "Earth", "ECLIPJ2000", "None", testTime ) );
+
+        Eigen::Vector6d asterixInitialStateInKeplerianElements;
+        asterixInitialStateInKeplerianElements( semiMajorAxisIndex ) = 7500.0E3;
+        asterixInitialStateInKeplerianElements( eccentricityIndex ) = 0.1;
+        asterixInitialStateInKeplerianElements( inclinationIndex ) = unit_conversions::convertDegreesToRadians( 85.3 );
+        asterixInitialStateInKeplerianElements( argumentOfPeriapsisIndex ) = unit_conversions::convertDegreesToRadians( 235.7 );
+        asterixInitialStateInKeplerianElements( longitudeOfAscendingNodeIndex ) = unit_conversions::convertDegreesToRadians( 23.4 );
+        asterixInitialStateInKeplerianElements( trueAnomalyIndex ) = unit_conversions::convertDegreesToRadians( 139.87 );
+        vehicle->setState( orbital_element_conversions::convertKeplerianToCartesianElements(
+                asterixInitialStateInKeplerianElements, gravitationalParameter ) );
+
+        std::shared_ptr< SphericalHarmonicAccelerationSettings > accelerationSettings =
+                std::make_shared< SphericalHarmonicAccelerationSettings >( 5, 5 );
+        std::shared_ptr< SphericalHarmonicsGravitationalAccelerationModel > gravitationalAcceleration =
+                std::dynamic_pointer_cast< SphericalHarmonicsGravitationalAccelerationModel >(
+                        createAccelerationModel( vehicle, earth, accelerationSettings, "Vehicle", "Earth" ) );
+        gravitationalAcceleration->updateMembers( 0.0 );
+        gravitationalAcceleration->getAcceleration( );
+
+        std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNames;
+        parameterNames.push_back(
+                std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 2, "Moon", false ) );
+        parameterNames.push_back(
+                std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 3, "Moon", false ) );
+        std::shared_ptr< estimatable_parameters::EstimatableParameterSet< double > > parameterSet =
+                createParametersToEstimate( parameterNames, bodies );
+
+        std::shared_ptr< SphericalHarmonicsGravityPartial > accelerationPartial =
+                std::dynamic_pointer_cast< SphericalHarmonicsGravityPartial >(
+                        createAnalyticalAccelerationPartial( gravitationalAcceleration,
+                                                             std::make_pair( "Vehicle", vehicle ),
+                                                             std::make_pair( "Earth", earth ),
+                                                             bodies,
+                                                             parameterSet ) );
+        BOOST_REQUIRE( accelerationPartial != nullptr );
+        accelerationPartial->update( testTime );
+
+        std::function< void( ) > sphericalHarmonicFieldUpdate =
+                std::bind( &tudat::gravitation::TimeDependentSphericalHarmonicsGravityField::update, earthGravityField, testTime );
+
+        BOOST_REQUIRE_EQUAL( parameterSet->getVectorParameters( ).size( ), 2 );
+        for( auto parameterIterator = parameterSet->getVectorParameters( ).begin( );
+             parameterIterator != parameterSet->getVectorParameters( ).end( );
+             parameterIterator++ )
+        {
+            std::shared_ptr< estimatable_parameters::EstimatableParameter< Eigen::VectorXd > > loveNumberParameter =
+                    parameterIterator->second;
+            Eigen::MatrixXd analyticalPartial = accelerationPartial->wrtParameter( loveNumberParameter );
+            Eigen::MatrixXd numericalPartial = calculateAccelerationWrtParameterPartials(
+                    loveNumberParameter,
+                    gravitationalAcceleration,
+                    Eigen::VectorXd::Constant( loveNumberParameter->getParameterSize( ), 1.0 ),
+                    sphericalHarmonicFieldUpdate );
+
+            TUDAT_CHECK_MATRIX_CLOSE_FRACTION( analyticalPartial, numericalPartial, 1.0E-5 );
+            BOOST_CHECK( analyticalPartial.norm( ) > 0.0 );
+        }
+    };
+
+    // Degree-3 listed before degree-2 must not drop the degree-2 interface.
+    runDegreeSeparatedCase( true );
+    // Reverse environment order must remain consistent.
+    runDegreeSeparatedCase( false );
+}
+
 BOOST_AUTO_TEST_SUITE_END( )
 
 }  // namespace unit_tests

--- a/tests/test_tudat/src/astro/orbit_determination/acceleration_partials/unitTestSphericalHarmonicPartials.cpp
+++ b/tests/test_tudat/src/astro/orbit_determination/acceleration_partials/unitTestSphericalHarmonicPartials.cpp
@@ -715,6 +715,28 @@ BOOST_AUTO_TEST_CASE( testSphericalHarmonicAccelerationPartial )
                 createGravityFieldModelVariationsSet( "Earth", bodies, gravityFieldVariationSettings ) );
         bodies.at( "Earth" )->updateConstantEphemerisDependentMemberQuantities( );
 
+        // A basic and a mode-coupled tide raised by the same body must retain distinct interfaces.
+        const std::vector< std::shared_ptr< orbit_determination::TidalLoveNumberPartialInterface > > distinctTidalInterfaces =
+                createTidalLoveNumberInterfaces( bodies, "Earth" );
+        BOOST_REQUIRE_EQUAL( distinctTidalInterfaces.size( ), 2 );
+        unsigned int basicInterfaceCount = 0;
+        unsigned int modeCoupledInterfaceCount = 0;
+        for( const auto& tidalInterface : distinctTidalInterfaces )
+        {
+            if( std::dynamic_pointer_cast< BasicSolidBodyTideGravityFieldVariations >( tidalInterface->getGravityFieldVariations( ) ) !=
+                nullptr )
+            {
+                basicInterfaceCount++;
+            }
+            if( std::dynamic_pointer_cast< ModeCoupledSolidBodyTideGravityFieldVariations >(
+                        tidalInterface->getGravityFieldVariations( ) ) != nullptr )
+            {
+                modeCoupledInterfaceCount++;
+            }
+        }
+        BOOST_CHECK_EQUAL( basicInterfaceCount, 1 );
+        BOOST_CHECK_EQUAL( modeCoupledInterfaceCount, 1 );
+
         // Set current state of vehicle and earth.
         double testTime = 1.0E6;
         earth->setState( Eigen::Vector6d::Zero( ) );
@@ -818,6 +840,30 @@ BOOST_AUTO_TEST_CASE( testSphericalHarmonicAccelerationPartial )
 
         std::shared_ptr< estimatable_parameters::EstimatableParameterSet< double > > parameterSet =
                 createParametersToEstimate( parameterNames, bodies );
+
+        std::shared_ptr< EstimatableParameter< Eigen::VectorXd > > modeCoupledParameter;
+        for( const auto& parameterEntry : parameterSet->getVectorParameters( ) )
+        {
+            if( parameterEntry.second->getParameterName( ).first == mode_coupled_tidal_love_numbers )
+            {
+                modeCoupledParameter = parameterEntry.second;
+            }
+        }
+        BOOST_REQUIRE( modeCoupledParameter != nullptr );
+
+        unsigned int modeCoupledDependencyCount = 0;
+        for( const auto& tidalInterface : distinctTidalInterfaces )
+        {
+            const std::pair< int, std::pair< int, int > > partialOutput =
+                    tidalInterface->setParameterPartialFunction( modeCoupledParameter, 5, 5 );
+            if( partialOutput.first > 0 )
+            {
+                modeCoupledDependencyCount++;
+                BOOST_CHECK( std::dynamic_pointer_cast< ModeCoupledSolidBodyTideGravityFieldVariations >(
+                                     tidalInterface->getGravityFieldVariations( ) ) != nullptr );
+            }
+        }
+        BOOST_CHECK_EQUAL( modeCoupledDependencyCount, 1 );
 
         // Check if incompatible tidal parameters correctly throw an error
         {

--- a/tests/test_tudat/src/astro/orbit_determination/acceleration_partials/unitTestSphericalHarmonicPartials.cpp
+++ b/tests/test_tudat/src/astro/orbit_determination/acceleration_partials/unitTestSphericalHarmonicPartials.cpp
@@ -1190,8 +1190,201 @@ BOOST_AUTO_TEST_CASE( testSphericalHarmonicAccelerationPartialWithSynchronousRot
     TUDAT_CHECK_MATRIX_CLOSE_FRACTION( testPartialWrtEarthPosition, partialWrtEarthPosition, 1.0E-6 );
     TUDAT_CHECK_MATRIX_CLOSE_FRACTION( testPartialWrtEarthVelocity, partialWrtEarthVelocity, 1.0E-3 );
 }
+
+//! Mandatory analytical vs numerical partial check for a shared multi-model Love number (Issue #734, Test F).
+BOOST_AUTO_TEST_CASE( testMultiModelLoveNumberAccelerationPartial )
+{
+    spice_interface::loadStandardSpiceKernels( );
+
+    std::shared_ptr< Body > earth = std::make_shared< Body >( );
+    std::shared_ptr< Body > vehicle = std::make_shared< Body >( );
+
+    const double gravitationalParameter = 3.986004418e14;
+    const double planetaryRadius = 6378137.0;
+
+    Eigen::MatrixXd cosineCoefficients = ( Eigen::MatrixXd( 6, 6 ) << 0.0,
+                                           0.0,
+                                           0.0,
+                                           0.0,
+                                           0.0,
+                                           0.0,
+                                           0.0,
+                                           0.0,
+                                           0.0,
+                                           0.0,
+                                           0.0,
+                                           0.0,
+                                           -4.841651437908150e-4,
+                                           -2.066155090741760e-10,
+                                           2.439383573283130e-6,
+                                           0.0,
+                                           0.0,
+                                           0.0,
+                                           9.571612070934730e-7,
+                                           2.030462010478640e-6,
+                                           9.047878948095281e-7,
+                                           7.213217571215680e-7,
+                                           0.0,
+                                           0.0,
+                                           5.399658666389910e-7,
+                                           -5.361573893888670e-7,
+                                           3.505016239626490e-7,
+                                           9.908567666723210e-7,
+                                           -1.885196330230330e-7,
+                                           0.0,
+                                           6.867029137366810e-8,
+                                           -6.292119230425290e-8,
+                                           6.520780431761640e-7,
+                                           -4.518471523288430e-7,
+                                           -2.953287611756290e-7,
+                                           1.748117954960020e-7 )
+                                                 .finished( );
+
+    Eigen::MatrixXd sineCoefficients = ( Eigen::MatrixXd( 6, 6 ) << 0.0,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         1.384413891379790e-9,
+                                         -1.400273703859340e-6,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         2.482004158568720e-7,
+                                         -6.190054751776180e-7,
+                                         1.414349261929410e-6,
+                                         0.0,
+                                         0.0,
+                                         0.0,
+                                         -4.735673465180860e-7,
+                                         6.624800262758290e-7,
+                                         -2.009567235674520e-7,
+                                         3.088038821491940e-7,
+                                         0.0,
+                                         0.0,
+                                         -9.436980733957690e-8,
+                                         -3.233531925405220e-7,
+                                         -2.149554083060460e-7,
+                                         4.980705501023510e-8,
+                                         -6.693799351801650e-7 )
+                                               .finished( );
+
+    std::shared_ptr< GravityFieldSettings > earthGravityFieldSettings = std::make_shared< SphericalHarmonicsGravityFieldSettings >(
+            gravitationalParameter, planetaryRadius, cosineCoefficients, sineCoefficients, "IAU_Earth" );
+
+    std::map< int, std::vector< std::complex< double > > > sharedLoveNumbers;
+    sharedLoveNumbers[ 2 ] = std::vector< std::complex< double > >( 3, std::complex< double >( 0.29525, -0.00087 ) );
+    sharedLoveNumbers[ 3 ] = std::vector< std::complex< double > >( 4, std::complex< double >( 0.093, 0.0 ) );
+
+    std::vector< std::shared_ptr< GravityFieldVariationSettings > > gravityFieldVariationSettings;
+    std::vector< std::string > moonDeformingBodies;
+    moonDeformingBodies.push_back( "Moon" );
+    std::vector< std::string > sunDeformingBodies;
+    sunDeformingBodies.push_back( "Sun" );
+    gravityFieldVariationSettings.push_back(
+            std::make_shared< BasicSolidBodyGravityFieldVariationSettings >( moonDeformingBodies, sharedLoveNumbers ) );
+    gravityFieldVariationSettings.push_back(
+            std::make_shared< BasicSolidBodyGravityFieldVariationSettings >( sunDeformingBodies, sharedLoveNumbers ) );
+
+    SystemOfBodies bodies;
+    bodies.addBody( earth, "Earth" );
+    bodies.addBody( vehicle, "Vehicle" );
+    SystemOfBodies moonAndSunBodies;
+    {
+        std::vector< std::string > moonAndSunNames;
+        moonAndSunNames.push_back( "Moon" );
+        moonAndSunNames.push_back( "Sun" );
+        moonAndSunBodies = createSystemOfBodies( getDefaultBodySettings( moonAndSunNames ) );
+    }
+    bodies.addBody( moonAndSunBodies.at( "Moon" ), "Moon" );
+    bodies.addBody( moonAndSunBodies.at( "Sun" ), "Sun" );
+
+    std::shared_ptr< ephemerides::SimpleRotationalEphemeris > simpleRotationalEphemeris =
+            std::make_shared< ephemerides::SimpleRotationalEphemeris >(
+                    spice_interface::computeRotationQuaternionBetweenFrames( "ECLIPJ2000", "IAU_Earth", 0.0 ),
+                    2.0 * mathematical_constants::PI / 86400.0,
+                    1.0E7,
+                    "ECLIPJ2000",
+                    "IAU_Earth" );
+    earth->setRotationalEphemeris( simpleRotationalEphemeris );
+
+    std::shared_ptr< tudat::gravitation::TimeDependentSphericalHarmonicsGravityField > earthGravityField =
+            std::dynamic_pointer_cast< gravitation::TimeDependentSphericalHarmonicsGravityField >(
+                    tudat::simulation_setup::createGravityFieldModel(
+                            earthGravityFieldSettings, "Earth", bodies, gravityFieldVariationSettings ) );
+    earth->setGravityFieldModel( earthGravityField );
+    bodies.at( "Earth" )->setGravityFieldVariationSet(
+            createGravityFieldModelVariationsSet( "Earth", bodies, gravityFieldVariationSettings ) );
+    bodies.at( "Earth" )->updateConstantEphemerisDependentMemberQuantities( );
+
+    double testTime = 1.0E6;
+    earth->setState( Eigen::Vector6d::Zero( ) );
+    earth->setCurrentRotationToLocalFrameFromEphemeris( testTime );
+    bodies.at( "Moon" )->setState(
+            tudat::spice_interface::getBodyCartesianStateAtEpoch( "Moon", "Earth", "ECLIPJ2000", "None", testTime ) );
+    bodies.at( "Sun" )->setState(
+            tudat::spice_interface::getBodyCartesianStateAtEpoch( "Sun", "Earth", "ECLIPJ2000", "None", testTime ) );
+
+    Eigen::Vector6d asterixInitialStateInKeplerianElements;
+    asterixInitialStateInKeplerianElements( semiMajorAxisIndex ) = 7500.0E3;
+    asterixInitialStateInKeplerianElements( eccentricityIndex ) = 0.1;
+    asterixInitialStateInKeplerianElements( inclinationIndex ) = unit_conversions::convertDegreesToRadians( 85.3 );
+    asterixInitialStateInKeplerianElements( argumentOfPeriapsisIndex ) = unit_conversions::convertDegreesToRadians( 235.7 );
+    asterixInitialStateInKeplerianElements( longitudeOfAscendingNodeIndex ) = unit_conversions::convertDegreesToRadians( 23.4 );
+    asterixInitialStateInKeplerianElements( trueAnomalyIndex ) = unit_conversions::convertDegreesToRadians( 139.87 );
+    vehicle->setState( orbital_element_conversions::convertKeplerianToCartesianElements( asterixInitialStateInKeplerianElements,
+                                                                                         gravitationalParameter ) );
+
+    std::shared_ptr< SphericalHarmonicAccelerationSettings > accelerationSettings =
+            std::make_shared< SphericalHarmonicAccelerationSettings >( 5, 5 );
+    std::shared_ptr< SphericalHarmonicsGravitationalAccelerationModel > gravitationalAcceleration =
+            std::dynamic_pointer_cast< SphericalHarmonicsGravitationalAccelerationModel >(
+                    createAccelerationModel( vehicle, earth, accelerationSettings, "Vehicle", "Earth" ) );
+    gravitationalAcceleration->updateMembers( 0.0 );
+    gravitationalAcceleration->getAcceleration( );
+
+    std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNames;
+    std::vector< std::string > deformingBodiesMoonSun;
+    deformingBodiesMoonSun.push_back( "Moon" );
+    deformingBodiesMoonSun.push_back( "Sun" );
+    parameterNames.push_back( std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >(
+            "Earth", 2, deformingBodiesMoonSun, false ) );
+    std::shared_ptr< estimatable_parameters::EstimatableParameterSet< double > > parameterSet =
+            createParametersToEstimate( parameterNames, bodies );
+
+    std::shared_ptr< SphericalHarmonicsGravityPartial > accelerationPartial = std::dynamic_pointer_cast< SphericalHarmonicsGravityPartial >(
+            createAnalyticalAccelerationPartial( gravitationalAcceleration,
+                                                 std::make_pair( "Vehicle", vehicle ),
+                                                 std::make_pair( "Earth", earth ),
+                                                 bodies,
+                                                 parameterSet ) );
+    accelerationPartial->update( testTime );
+
+    std::shared_ptr< estimatable_parameters::EstimatableParameter< Eigen::VectorXd > > loveNumberParameter =
+            parameterSet->getVectorParameters( ).begin( )->second;
+    std::function< void( ) > sphericalHarmonicFieldUpdate =
+            std::bind( &tudat::gravitation::TimeDependentSphericalHarmonicsGravityField::update, earthGravityField, testTime );
+
+    Eigen::MatrixXd analyticalPartial = accelerationPartial->wrtParameter( loveNumberParameter );
+    Eigen::MatrixXd numericalPartial = calculateAccelerationWrtParameterPartials(
+            loveNumberParameter, gravitationalAcceleration, Eigen::VectorXd::Constant( 1, 1.0 ), sphericalHarmonicFieldUpdate );
+
+    TUDAT_CHECK_MATRIX_CLOSE_FRACTION( analyticalPartial, numericalPartial, 1.0E-5 );
+    BOOST_CHECK( analyticalPartial.norm( ) > 0.0 );
+}
+
 BOOST_AUTO_TEST_SUITE_END( )
 
 }  // namespace unit_tests
 
 }  // namespace tudat
+

--- a/tests/test_tudat/src/astro/orbit_determination/acceleration_partials/unitTestSphericalHarmonicPartials.cpp
+++ b/tests/test_tudat/src/astro/orbit_determination/acceleration_partials/unitTestSphericalHarmonicPartials.cpp
@@ -1336,8 +1336,7 @@ BOOST_AUTO_TEST_CASE( testMultiModelLoveNumberAccelerationPartial )
     earth->setCurrentRotationToLocalFrameFromEphemeris( testTime );
     bodies.at( "Moon" )->setState(
             tudat::spice_interface::getBodyCartesianStateAtEpoch( "Moon", "Earth", "ECLIPJ2000", "None", testTime ) );
-    bodies.at( "Sun" )->setState(
-            tudat::spice_interface::getBodyCartesianStateAtEpoch( "Sun", "Earth", "ECLIPJ2000", "None", testTime ) );
+    bodies.at( "Sun" )->setState( tudat::spice_interface::getBodyCartesianStateAtEpoch( "Sun", "Earth", "ECLIPJ2000", "None", testTime ) );
 
     Eigen::Vector6d asterixInitialStateInKeplerianElements;
     asterixInitialStateInKeplerianElements( semiMajorAxisIndex ) = 7500.0E3;
@@ -1361,8 +1360,8 @@ BOOST_AUTO_TEST_CASE( testMultiModelLoveNumberAccelerationPartial )
     std::vector< std::string > deformingBodiesMoonSun;
     deformingBodiesMoonSun.push_back( "Moon" );
     deformingBodiesMoonSun.push_back( "Sun" );
-    parameterNames.push_back( std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >(
-            "Earth", 2, deformingBodiesMoonSun, false ) );
+    parameterNames.push_back(
+            std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 2, deformingBodiesMoonSun, false ) );
     std::shared_ptr< estimatable_parameters::EstimatableParameterSet< double > > parameterSet =
             createParametersToEstimate( parameterNames, bodies );
 
@@ -1437,7 +1436,7 @@ BOOST_AUTO_TEST_CASE( testFullTwoBodyMultiModelLoveNumberAccelerationPartial )
     body1->setCurrentRotationToLocalFrameFromEphemeris( evaluationTime );
     body2->setCurrentRotationToLocalFrameFromEphemeris( evaluationTime );
 
-    auto createSimpleRotationPartialMap = [ ]( const std::shared_ptr< Body >& body ) {
+    auto createSimpleRotationPartialMap = []( const std::shared_ptr< Body >& body ) {
         std::shared_ptr< ephemerides::SimpleRotationalEphemeris > rotationModel =
                 std::dynamic_pointer_cast< ephemerides::SimpleRotationalEphemeris >( body->getRotationalEphemeris( ) );
         observation_partials::RotationMatrixPartialNamedList partials;
@@ -1457,28 +1456,24 @@ BOOST_AUTO_TEST_CASE( testFullTwoBodyMultiModelLoveNumberAccelerationPartial )
     body3LoveNumbers[ 2 ].push_back( std::complex< double >( 0.11, 0.0 ) );
     body3LoveNumbers[ 2 ].push_back( std::complex< double >( 0.07, 0.0 ) );
 
-    std::shared_ptr< BasicSolidBodyTideGravityFieldVariations > body2Tide =
-            std::make_shared< BasicSolidBodyTideGravityFieldVariations >(
-                    [ & ]( const double ) { return body1->getState( ); },
-                    [ & ]( const double ) { return body1->getCurrentRotationToLocalFrame( ); },
-                    std::vector< std::function< Eigen::Vector6d( const double ) > >{
-                            [ & ]( const double ) { return body2->getState( ); } },
-                    equatorialRadiusOfBody1,
-                    [ & ]( ) { return body1GravityField->getGravitationalParameter( ); },
-                    std::vector< std::function< double( ) > >{ [ & ]( ) { return body2GravityField->getGravitationalParameter( ); } },
-                    body2LoveNumbers,
-                    std::vector< std::string >{ "Body2" } );
-    std::shared_ptr< BasicSolidBodyTideGravityFieldVariations > body3Tide =
-            std::make_shared< BasicSolidBodyTideGravityFieldVariations >(
-                    [ & ]( const double ) { return body1->getState( ); },
-                    [ & ]( const double ) { return body1->getCurrentRotationToLocalFrame( ); },
-                    std::vector< std::function< Eigen::Vector6d( const double ) > >{
-                            [ & ]( const double ) { return body3->getState( ); } },
-                    equatorialRadiusOfBody1,
-                    [ & ]( ) { return body1GravityField->getGravitationalParameter( ); },
-                    std::vector< std::function< double( ) > >{ [ & ]( ) { return body3GravityField->getGravitationalParameter( ); } },
-                    body3LoveNumbers,
-                    std::vector< std::string >{ "Body3" } );
+    std::shared_ptr< BasicSolidBodyTideGravityFieldVariations > body2Tide = std::make_shared< BasicSolidBodyTideGravityFieldVariations >(
+            [ & ]( const double ) { return body1->getState( ); },
+            [ & ]( const double ) { return body1->getCurrentRotationToLocalFrame( ); },
+            std::vector< std::function< Eigen::Vector6d( const double ) > >{ [ & ]( const double ) { return body2->getState( ); } },
+            equatorialRadiusOfBody1,
+            [ & ]( ) { return body1GravityField->getGravitationalParameter( ); },
+            std::vector< std::function< double( ) > >{ [ & ]( ) { return body2GravityField->getGravitationalParameter( ); } },
+            body2LoveNumbers,
+            std::vector< std::string >{ "Body2" } );
+    std::shared_ptr< BasicSolidBodyTideGravityFieldVariations > body3Tide = std::make_shared< BasicSolidBodyTideGravityFieldVariations >(
+            [ & ]( const double ) { return body1->getState( ); },
+            [ & ]( const double ) { return body1->getCurrentRotationToLocalFrame( ); },
+            std::vector< std::function< Eigen::Vector6d( const double ) > >{ [ & ]( const double ) { return body3->getState( ); } },
+            equatorialRadiusOfBody1,
+            [ & ]( ) { return body1GravityField->getGravitationalParameter( ); },
+            std::vector< std::function< double( ) > >{ [ & ]( ) { return body3GravityField->getGravitationalParameter( ); } },
+            body3LoveNumbers,
+            std::vector< std::string >{ "Body3" } );
 
     std::vector< std::shared_ptr< BasicSolidBodyTideGravityFieldVariations > > tideModels;
     tideModels.push_back( body2Tide );
@@ -1541,16 +1536,16 @@ BOOST_AUTO_TEST_CASE( testFullTwoBodyMultiModelLoveNumberAccelerationPartial )
     updateLoveNumberEnvironment( );
     evaluateLoveNumberAcceleration( );
     const Eigen::MatrixXd analyticalLoveNumberPartial = loveNumberAccelerationPartial->wrtParameter( multiModelLoveNumber );
-    const Eigen::MatrixXd numericalLoveNumberPartial = calculateAccelerationWrtParameterPartials(
-            multiModelLoveNumber,
-            accelerationModel,
-            Eigen::VectorXd::Constant( multiModelLoveNumber->getParameterSize( ), 1.0 ),
-            updateLoveNumberEnvironment,
-            evaluationTime,
-            [ & ]( const double currentTime ) {
-                body1->setCurrentRotationToLocalFrameFromEphemeris( currentTime );
-                body2->setCurrentRotationToLocalFrameFromEphemeris( currentTime );
-            } );
+    const Eigen::MatrixXd numericalLoveNumberPartial =
+            calculateAccelerationWrtParameterPartials( multiModelLoveNumber,
+                                                       accelerationModel,
+                                                       Eigen::VectorXd::Constant( multiModelLoveNumber->getParameterSize( ), 1.0 ),
+                                                       updateLoveNumberEnvironment,
+                                                       evaluationTime,
+                                                       [ & ]( const double currentTime ) {
+                                                           body1->setCurrentRotationToLocalFrameFromEphemeris( currentTime );
+                                                           body2->setCurrentRotationToLocalFrameFromEphemeris( currentTime );
+                                                       } );
     updateLoveNumberEnvironment( );
     evaluateLoveNumberAcceleration( );
 
@@ -1709,8 +1704,8 @@ BOOST_AUTO_TEST_CASE( testDegreeSeparatedMoonLoveNumberAccelerationPartials )
         asterixInitialStateInKeplerianElements( argumentOfPeriapsisIndex ) = unit_conversions::convertDegreesToRadians( 235.7 );
         asterixInitialStateInKeplerianElements( longitudeOfAscendingNodeIndex ) = unit_conversions::convertDegreesToRadians( 23.4 );
         asterixInitialStateInKeplerianElements( trueAnomalyIndex ) = unit_conversions::convertDegreesToRadians( 139.87 );
-        vehicle->setState( orbital_element_conversions::convertKeplerianToCartesianElements(
-                asterixInitialStateInKeplerianElements, gravitationalParameter ) );
+        vehicle->setState( orbital_element_conversions::convertKeplerianToCartesianElements( asterixInitialStateInKeplerianElements,
+                                                                                             gravitationalParameter ) );
 
         std::shared_ptr< SphericalHarmonicAccelerationSettings > accelerationSettings =
                 std::make_shared< SphericalHarmonicAccelerationSettings >( 5, 5 );
@@ -1721,10 +1716,8 @@ BOOST_AUTO_TEST_CASE( testDegreeSeparatedMoonLoveNumberAccelerationPartials )
         gravitationalAcceleration->getAcceleration( );
 
         std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNames;
-        parameterNames.push_back(
-                std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 2, "Moon", false ) );
-        parameterNames.push_back(
-                std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 3, "Moon", false ) );
+        parameterNames.push_back( std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 2, "Moon", false ) );
+        parameterNames.push_back( std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 3, "Moon", false ) );
         std::shared_ptr< estimatable_parameters::EstimatableParameterSet< double > > parameterSet =
                 createParametersToEstimate( parameterNames, bodies );
 
@@ -1741,19 +1734,18 @@ BOOST_AUTO_TEST_CASE( testDegreeSeparatedMoonLoveNumberAccelerationPartials )
         std::function< void( ) > sphericalHarmonicFieldUpdate =
                 std::bind( &tudat::gravitation::TimeDependentSphericalHarmonicsGravityField::update, earthGravityField, testTime );
 
-        BOOST_REQUIRE_EQUAL( parameterSet->getVectorParameters( ).size( ), 2 );
-        for( auto parameterIterator = parameterSet->getVectorParameters( ).begin( );
-             parameterIterator != parameterSet->getVectorParameters( ).end( );
-             parameterIterator++ )
+        const auto vectorParameters = parameterSet->getVectorParameters( );
+        BOOST_REQUIRE_EQUAL( vectorParameters.size( ), 2 );
+        for( auto parameterIterator = vectorParameters.begin( ); parameterIterator != vectorParameters.end( ); parameterIterator++ )
         {
             std::shared_ptr< estimatable_parameters::EstimatableParameter< Eigen::VectorXd > > loveNumberParameter =
                     parameterIterator->second;
             Eigen::MatrixXd analyticalPartial = accelerationPartial->wrtParameter( loveNumberParameter );
-            Eigen::MatrixXd numericalPartial = calculateAccelerationWrtParameterPartials(
-                    loveNumberParameter,
-                    gravitationalAcceleration,
-                    Eigen::VectorXd::Constant( loveNumberParameter->getParameterSize( ), 1.0 ),
-                    sphericalHarmonicFieldUpdate );
+            Eigen::MatrixXd numericalPartial =
+                    calculateAccelerationWrtParameterPartials( loveNumberParameter,
+                                                               gravitationalAcceleration,
+                                                               Eigen::VectorXd::Constant( loveNumberParameter->getParameterSize( ), 1.0 ),
+                                                               sphericalHarmonicFieldUpdate );
 
             TUDAT_CHECK_MATRIX_CLOSE_FRACTION( analyticalPartial, numericalPartial, 1.0E-5 );
             BOOST_CHECK( analyticalPartial.norm( ) > 0.0 );
@@ -1771,4 +1763,3 @@ BOOST_AUTO_TEST_SUITE_END( )
 }  // namespace unit_tests
 
 }  // namespace tudat
-

--- a/tests/test_tudat/src/astro/orbit_determination/unitTestTidalPropertyEstimation.cpp
+++ b/tests/test_tudat/src/astro/orbit_determination/unitTestTidalPropertyEstimation.cpp
@@ -12,9 +12,11 @@
 #define BOOST_TEST_MAIN
 
 #include <string>
+#include <algorithm>
 #include "tudat/simulation/environment_setup/createBodiesFactory.h"
 #include "tudat/simulation/environment_setup/defaultBodies.h"
 #include "tudat/simulation/environment_setup/createGravityField.h"
+#include "tudat/simulation/environment_setup/createGravityFieldVariations.h"
 #include <thread>
 
 #include <limits>
@@ -22,6 +24,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "tudat/basics/testMacros.h"
+#include "tudat/basics/utilities.h"
 #include "tudat/simulation/estimation_setup/createEstimatableParametersFactory.h"
 #include "tudat/astro/propagators/propagateCovariance.h"
 #include "tudat/simulation/environment_setup/createGroundStations.h"
@@ -30,6 +33,8 @@
 #include "tudat/simulation/estimation_setup/podProcessing.h"
 #include "tudat/simulation/estimation_setup/simulateObservations.h"
 #include "tudat/astro/orbit_determination/estimatable_parameters/directTidalTimeLag.h"
+#include "tudat/astro/orbit_determination/estimatable_parameters/tidalLoveNumber.h"
+#include "tudat/astro/gravitation/basicSolidBodyTideGravityFieldVariations.h"
 
 namespace tudat
 {
@@ -549,6 +554,306 @@ BOOST_AUTO_TEST_CASE( test_LoveNumberEstimationFromOrbiterData )
     }
 
     std::cout << "Parameter error" << ( estimationError ).transpose( ) << std::endl;
+}
+
+//! Helper to create separate Moon/Sun basic solid-body tide models with optional distinct Love numbers.
+std::vector< std::shared_ptr< GravityFieldVariationSettings > > getSeparateMoonSunEarthTideSettings(
+        const std::complex< double > moonDegreeTwoLoveNumber,
+        const std::complex< double > sunDegreeTwoLoveNumber )
+{
+    std::vector< std::shared_ptr< GravityFieldVariationSettings > > gravityFieldVariations;
+
+    std::map< int, std::vector< std::complex< double > > > moonLoveNumbers;
+    moonLoveNumbers[ 2 ] = std::vector< std::complex< double > >( 3, moonDegreeTwoLoveNumber );
+    moonLoveNumbers[ 3 ] = std::vector< std::complex< double > >( 4, std::complex< double >( 0.093, 0.0 ) );
+    gravityFieldVariations.push_back( std::make_shared< BasicSolidBodyGravityFieldVariationSettings >(
+            std::vector< std::string >{ "Moon" }, moonLoveNumbers ) );
+
+    std::map< int, std::vector< std::complex< double > > > sunLoveNumbers;
+    sunLoveNumbers[ 2 ] = std::vector< std::complex< double > >( 3, sunDegreeTwoLoveNumber );
+    sunLoveNumbers[ 3 ] = std::vector< std::complex< double > >( 4, std::complex< double >( 0.093, 0.0 ) );
+    gravityFieldVariations.push_back( std::make_shared< BasicSolidBodyGravityFieldVariationSettings >(
+            std::vector< std::string >{ "Sun" }, sunLoveNumbers ) );
+
+    return gravityFieldVariations;
+}
+
+//! Unit test for multi-model full-degree Love-number parameter selection and reset semantics (Issue #734).
+BOOST_AUTO_TEST_CASE( test_MultiModelFullDegreeLoveNumberParameterSetup )
+{
+    spice_interface::loadStandardSpiceKernels( );
+
+    std::vector< std::string > bodyNames;
+    bodyNames.push_back( "Earth" );
+    bodyNames.push_back( "Sun" );
+    bodyNames.push_back( "Moon" );
+    BodyListSettings bodySettings = getDefaultBodySettings( bodyNames, "Earth", "ECLIPJ2000" );
+    bodySettings.at( "Earth" )->gravityFieldVariationSettings = getSeparateMoonSunEarthTideSettings(
+            std::complex< double >( 0.301, -0.001 ), std::complex< double >( 0.295, -0.002 ) );
+    SystemOfBodies bodies = createSystemOfBodies( bodySettings );
+
+    auto getBasicTideModels =
+            [ &bodies ]( ) -> std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > > {
+        return utilities::dynamicCastSVectorToTVector< gravitation::GravityFieldVariations,
+                                                       gravitation::BasicSolidBodyTideGravityFieldVariations >(
+                bodies.at( "Earth" )->getGravityFieldVariationSet( )->getDirectTidalGravityFieldVariations( ) );
+    };
+
+    // Test A / G: explicit multi-model creation, both body-list orders, and combined-model compatibility.
+    {
+        std::vector< std::string > deformingBodiesMoonSun;
+        deformingBodiesMoonSun.push_back( "Moon" );
+        deformingBodiesMoonSun.push_back( "Sun" );
+        std::vector< std::string > deformingBodiesSunMoon;
+        deformingBodiesSunMoon.push_back( "Sun" );
+        deformingBodiesSunMoon.push_back( "Moon" );
+
+        std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNamesMoonSun;
+        parameterNamesMoonSun.push_back( std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >(
+                "Earth", 2, deformingBodiesMoonSun, false ) );
+        std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNamesSunMoon;
+        parameterNamesSunMoon.push_back( std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >(
+                "Earth", 2, deformingBodiesSunMoon, false ) );
+
+        std::shared_ptr< EstimatableParameterSet< double > > parameterSetMoonSun =
+                createParametersToEstimate< double, double >( parameterNamesMoonSun, bodies );
+        std::shared_ptr< EstimatableParameterSet< double > > parameterSetSunMoon =
+                createParametersToEstimate< double, double >( parameterNamesSunMoon, bodies );
+
+        std::shared_ptr< FullDegreeTidalLoveNumber > loveNumberMoonSun = std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >(
+                parameterSetMoonSun->getVectorParameters( ).begin( )->second );
+        std::shared_ptr< FullDegreeTidalLoveNumber > loveNumberSunMoon = std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >(
+                parameterSetSunMoon->getVectorParameters( ).begin( )->second );
+        BOOST_REQUIRE( loveNumberMoonSun != nullptr );
+        BOOST_REQUIRE( loveNumberSunMoon != nullptr );
+        BOOST_CHECK_EQUAL( loveNumberMoonSun->getParameterSize( ), 1 );
+        BOOST_CHECK_EQUAL( loveNumberMoonSun->getGravityFieldVariationModels( ).size( ), 2 );
+        BOOST_CHECK_EQUAL( loveNumberSunMoon->getGravityFieldVariationModels( ).size( ), 2 );
+        BOOST_CHECK_EQUAL( loveNumberMoonSun->getDeformingBodies( ).size( ), 2 );
+        BOOST_CHECK( std::find( loveNumberMoonSun->getDeformingBodies( ).begin( ),
+                                loveNumberMoonSun->getDeformingBodies( ).end( ),
+                                "Moon" ) != loveNumberMoonSun->getDeformingBodies( ).end( ) );
+        BOOST_CHECK( std::find( loveNumberMoonSun->getDeformingBodies( ).begin( ),
+                                loveNumberMoonSun->getDeformingBodies( ).end( ),
+                                "Sun" ) != loveNumberMoonSun->getDeformingBodies( ).end( ) );
+        BOOST_CHECK( loveNumberMoonSun->getGravityFieldVariationModels( ) == loveNumberSunMoon->getGravityFieldVariationModels( ) );
+    }
+
+    // Existing combined model with both deforming bodies remains valid.
+    {
+        BodyListSettings combinedBodySettings = getDefaultBodySettings( bodyNames, "Earth", "ECLIPJ2000" );
+        std::map< int, std::vector< std::complex< double > > > combinedLoveNumbers;
+        combinedLoveNumbers[ 2 ] = std::vector< std::complex< double > >( 3, std::complex< double >( 0.3, -0.001 ) );
+        std::vector< std::string > combinedDeformingBodies;
+        combinedDeformingBodies.push_back( "Moon" );
+        combinedDeformingBodies.push_back( "Sun" );
+        std::vector< std::shared_ptr< GravityFieldVariationSettings > > combinedVariations;
+        combinedVariations.push_back(
+                std::make_shared< BasicSolidBodyGravityFieldVariationSettings >( combinedDeformingBodies, combinedLoveNumbers ) );
+        combinedBodySettings.at( "Earth" )->gravityFieldVariationSettings = combinedVariations;
+        SystemOfBodies combinedBodies = createSystemOfBodies( combinedBodySettings );
+
+        std::vector< std::shared_ptr< EstimatableParameterSettings > > combinedParameterNames;
+        combinedParameterNames.push_back( std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >(
+                "Earth", 2, combinedDeformingBodies, false ) );
+        bool combinedCreationSucceeded = true;
+        try
+        {
+            createParametersToEstimate< double, double >( combinedParameterNames, combinedBodies );
+        }
+        catch( const std::runtime_error& )
+        {
+            combinedCreationSucceeded = false;
+        }
+        BOOST_CHECK( combinedCreationSucceeded );
+    }
+
+    // Test B: synchronized reset preserves per-model imaginary parts for real-only estimation.
+    {
+        std::vector< std::string > deformingBodiesMoonSun;
+        deformingBodiesMoonSun.push_back( "Moon" );
+        deformingBodiesMoonSun.push_back( "Sun" );
+        std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNames;
+        parameterNames.push_back( std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >(
+                "Earth", 2, deformingBodiesMoonSun, false ) );
+        std::shared_ptr< EstimatableParameterSet< double > > parameterSet =
+                createParametersToEstimate< double, double >( parameterNames, bodies );
+        std::shared_ptr< FullDegreeTidalLoveNumber > loveNumberParameter = std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >(
+                parameterSet->getVectorParameters( ).begin( )->second );
+        BOOST_REQUIRE( loveNumberParameter != nullptr );
+
+        std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > > tideModels = getBasicTideModels( );
+        BOOST_REQUIRE_EQUAL( tideModels.size( ), 2 );
+        const double moonImagBefore = tideModels.at( 0 )->getLoveNumbersOfDegree( 2 ).at( 0 ).imag( );
+        const double sunImagBefore = tideModels.at( 1 )->getLoveNumbersOfDegree( 2 ).at( 0 ).imag( );
+
+        Eigen::VectorXd resetValue = Eigen::VectorXd::Zero( 1 );
+        resetValue( 0 ) = 0.33;
+        loveNumberParameter->setParameterValue( resetValue );
+
+        for( int order = 0; order <= 2; order++ )
+        {
+            BOOST_CHECK_CLOSE_FRACTION( tideModels.at( 0 )->getLoveNumbersOfDegree( 2 ).at( order ).real( ), 0.33, 1.0E-14 );
+            BOOST_CHECK_CLOSE_FRACTION( tideModels.at( 1 )->getLoveNumbersOfDegree( 2 ).at( order ).real( ), 0.33, 1.0E-14 );
+            BOOST_CHECK_CLOSE_FRACTION( tideModels.at( 0 )->getLoveNumbersOfDegree( 2 ).at( order ).imag( ), moonImagBefore, 1.0E-14 );
+            BOOST_CHECK_CLOSE_FRACTION( tideModels.at( 1 )->getLoveNumbersOfDegree( 2 ).at( order ).imag( ), sunImagBefore, 1.0E-14 );
+        }
+    }
+
+    // Complex shared reset updates both components in every selected model.
+    {
+        bodySettings.at( "Earth" )->gravityFieldVariationSettings = getSeparateMoonSunEarthTideSettings(
+                std::complex< double >( 0.301, -0.001 ), std::complex< double >( 0.295, -0.002 ) );
+        bodies = createSystemOfBodies( bodySettings );
+
+        std::vector< std::string > deformingBodiesMoonSun;
+        deformingBodiesMoonSun.push_back( "Moon" );
+        deformingBodiesMoonSun.push_back( "Sun" );
+        std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNames;
+        parameterNames.push_back( std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >(
+                "Earth", 2, deformingBodiesMoonSun, true ) );
+        std::shared_ptr< EstimatableParameterSet< double > > parameterSet =
+                createParametersToEstimate< double, double >( parameterNames, bodies );
+        std::shared_ptr< FullDegreeTidalLoveNumber > loveNumberParameter = std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >(
+                parameterSet->getVectorParameters( ).begin( )->second );
+        BOOST_REQUIRE( loveNumberParameter != nullptr );
+
+        Eigen::VectorXd resetValue = Eigen::VectorXd::Zero( 2 );
+        resetValue( 0 ) = 0.28;
+        resetValue( 1 ) = -0.004;
+        loveNumberParameter->setParameterValue( resetValue );
+
+        std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > > tideModels = getBasicTideModels( );
+        for( unsigned int modelIndex = 0; modelIndex < tideModels.size( ); modelIndex++ )
+        {
+            for( int order = 0; order <= 2; order++ )
+            {
+                BOOST_CHECK_CLOSE_FRACTION( tideModels.at( modelIndex )->getLoveNumbersOfDegree( 2 ).at( order ).real( ), 0.28, 1.0E-14 );
+                BOOST_CHECK_CLOSE_FRACTION( tideModels.at( modelIndex )->getLoveNumbersOfDegree( 2 ).at( order ).imag( ), -0.004, 1.0E-14 );
+            }
+        }
+    }
+
+    // Test C: empty deforming-body list selects all compatible basic tide models.
+    {
+        bodySettings.at( "Earth" )->gravityFieldVariationSettings = getSeparateMoonSunEarthTideSettings(
+                std::complex< double >( 0.301, -0.001 ), std::complex< double >( 0.295, -0.002 ) );
+        bodies = createSystemOfBodies( bodySettings );
+
+        std::vector< std::string > emptyDeformingBodies;
+        std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNames;
+        parameterNames.push_back( std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >(
+                "Earth", 2, emptyDeformingBodies, false ) );
+        std::shared_ptr< EstimatableParameterSet< double > > parameterSet =
+                createParametersToEstimate< double, double >( parameterNames, bodies );
+        std::shared_ptr< FullDegreeTidalLoveNumber > loveNumberParameter = std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >(
+                parameterSet->getVectorParameters( ).begin( )->second );
+        BOOST_REQUIRE( loveNumberParameter != nullptr );
+        BOOST_CHECK_EQUAL( loveNumberParameter->getGravityFieldVariationModels( ).size( ), 2 );
+
+        Eigen::VectorXd resetValue = Eigen::VectorXd::Zero( 1 );
+        resetValue( 0 ) = 0.27;
+        loveNumberParameter->setParameterValue( resetValue );
+        std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > > tideModels = getBasicTideModels( );
+        for( unsigned int modelIndex = 0; modelIndex < tideModels.size( ); modelIndex++ )
+        {
+            for( int order = 0; order <= 2; order++ )
+            {
+                BOOST_CHECK_CLOSE_FRACTION( tideModels.at( modelIndex )->getLoveNumbersOfDegree( 2 ).at( order ).real( ), 0.27, 1.0E-14 );
+            }
+        }
+    }
+
+    // Test D: subset selection only updates the requested model.
+    {
+        bodySettings.at( "Earth" )->gravityFieldVariationSettings = getSeparateMoonSunEarthTideSettings(
+                std::complex< double >( 0.301, -0.001 ), std::complex< double >( 0.295, -0.002 ) );
+        bodies = createSystemOfBodies( bodySettings );
+
+        std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNames;
+        parameterNames.push_back(
+                std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 2, "Moon", false ) );
+        std::shared_ptr< EstimatableParameterSet< double > > parameterSet =
+                createParametersToEstimate< double, double >( parameterNames, bodies );
+        std::shared_ptr< FullDegreeTidalLoveNumber > loveNumberParameter = std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >(
+                parameterSet->getVectorParameters( ).begin( )->second );
+        BOOST_REQUIRE( loveNumberParameter != nullptr );
+
+        std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > > tideModels = getBasicTideModels( );
+        const double sunRealBefore = tideModels.at( 1 )->getLoveNumbersOfDegree( 2 ).at( 0 ).real( );
+        Eigen::VectorXd resetValue = Eigen::VectorXd::Zero( 1 );
+        resetValue( 0 ) = 0.35;
+        loveNumberParameter->setParameterValue( resetValue );
+
+        for( int order = 0; order <= 2; order++ )
+        {
+            BOOST_CHECK_CLOSE_FRACTION( tideModels.at( 0 )->getLoveNumbersOfDegree( 2 ).at( order ).real( ), 0.35, 1.0E-14 );
+            BOOST_CHECK_CLOSE_FRACTION( tideModels.at( 1 )->getLoveNumbersOfDegree( 2 ).at( order ).real( ), sunRealBefore, 1.0E-14 );
+        }
+    }
+
+    // Test E: invalid selections throw actionable errors.
+    {
+        bodySettings.at( "Earth" )->gravityFieldVariationSettings = getSeparateMoonSunEarthTideSettings(
+                std::complex< double >( 0.301, -0.001 ), std::complex< double >( 0.295, -0.002 ) );
+        bodies = createSystemOfBodies( bodySettings );
+
+        bool missingBodyCaught = false;
+        try
+        {
+            std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNames;
+            parameterNames.push_back(
+                    std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 2, "Mars", false ) );
+            createParametersToEstimate< double, double >( parameterNames, bodies );
+        }
+        catch( const std::runtime_error& error )
+        {
+            missingBodyCaught = true;
+            BOOST_CHECK( std::string( error.what( ) ).find( "Mars" ) != std::string::npos );
+        }
+        BOOST_CHECK( missingBodyCaught );
+
+        bool unavailableDegreeCaught = false;
+        try
+        {
+            std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNames;
+            parameterNames.push_back(
+                    std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 4, "Moon", false ) );
+            createParametersToEstimate< double, double >( parameterNames, bodies );
+        }
+        catch( const std::runtime_error& )
+        {
+            unavailableDegreeCaught = true;
+        }
+        BOOST_CHECK( unavailableDegreeCaught );
+
+        BodyListSettings combinedBodySettings = getDefaultBodySettings( bodyNames, "Earth", "ECLIPJ2000" );
+        std::map< int, std::vector< std::complex< double > > > combinedLoveNumbers;
+        combinedLoveNumbers[ 2 ] = std::vector< std::complex< double > >( 3, std::complex< double >( 0.3, 0.0 ) );
+        std::vector< std::string > combinedDeformingBodies;
+        combinedDeformingBodies.push_back( "Moon" );
+        combinedDeformingBodies.push_back( "Sun" );
+        std::vector< std::shared_ptr< GravityFieldVariationSettings > > combinedVariations;
+        combinedVariations.push_back(
+                std::make_shared< BasicSolidBodyGravityFieldVariationSettings >( combinedDeformingBodies, combinedLoveNumbers ) );
+        combinedBodySettings.at( "Earth" )->gravityFieldVariationSettings = combinedVariations;
+        SystemOfBodies combinedBodies = createSystemOfBodies( combinedBodySettings );
+
+        bool partialOverlapCaught = false;
+        try
+        {
+            std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNames;
+            parameterNames.push_back(
+                    std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 2, "Moon", false ) );
+            createParametersToEstimate< double, double >( parameterNames, combinedBodies );
+        }
+        catch( const std::runtime_error& error )
+        {
+            partialOverlapCaught = true;
+            BOOST_CHECK( std::string( error.what( ) ).find( "partially overlap" ) != std::string::npos );
+        }
+        BOOST_CHECK( partialOverlapCaught );
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END( )

--- a/tests/test_tudat/src/astro/orbit_determination/unitTestTidalPropertyEstimation.cpp
+++ b/tests/test_tudat/src/astro/orbit_determination/unitTestTidalPropertyEstimation.cpp
@@ -629,13 +629,10 @@ BOOST_AUTO_TEST_CASE( test_MultiModelFullDegreeLoveNumberParameterSetup )
         BOOST_CHECK_EQUAL( loveNumberMoonSun->getParameterSize( ), 1 );
         BOOST_CHECK_EQUAL( loveNumberMoonSun->getGravityFieldVariationModels( ).size( ), 2 );
         BOOST_CHECK_EQUAL( loveNumberSunMoon->getGravityFieldVariationModels( ).size( ), 2 );
-        BOOST_CHECK_EQUAL( loveNumberMoonSun->getDeformingBodies( ).size( ), 2 );
-        BOOST_CHECK( std::find( loveNumberMoonSun->getDeformingBodies( ).begin( ),
-                                loveNumberMoonSun->getDeformingBodies( ).end( ),
-                                "Moon" ) != loveNumberMoonSun->getDeformingBodies( ).end( ) );
-        BOOST_CHECK( std::find( loveNumberMoonSun->getDeformingBodies( ).begin( ),
-                                loveNumberMoonSun->getDeformingBodies( ).end( ),
-                                "Sun" ) != loveNumberMoonSun->getDeformingBodies( ).end( ) );
+        const std::vector< std::string > selectedBodies = loveNumberMoonSun->getDeformingBodies( );
+        BOOST_CHECK_EQUAL( selectedBodies.size( ), 2 );
+        BOOST_CHECK( std::find( selectedBodies.begin( ), selectedBodies.end( ), "Moon" ) != selectedBodies.end( ) );
+        BOOST_CHECK( std::find( selectedBodies.begin( ), selectedBodies.end( ), "Sun" ) != selectedBodies.end( ) );
         BOOST_CHECK( loveNumberMoonSun->getGravityFieldVariationModels( ) == loveNumberSunMoon->getGravityFieldVariationModels( ) );
     }
 
@@ -853,6 +850,157 @@ BOOST_AUTO_TEST_CASE( test_MultiModelFullDegreeLoveNumberParameterSetup )
             BOOST_CHECK( std::string( error.what( ) ).find( "partially overlap" ) != std::string::npos );
         }
         BOOST_CHECK( partialOverlapCaught );
+    }
+
+    // Degree-aware selection: independent Moon degree-2 / degree-3 models remain selectable.
+    {
+        BodyListSettings degreeSeparatedBodySettings = getDefaultBodySettings( bodyNames, "Earth", "ECLIPJ2000" );
+        std::vector< std::shared_ptr< GravityFieldVariationSettings > > degreeSeparatedVariations;
+
+        std::map< int, std::vector< std::complex< double > > > moonDegreeTwoLoveNumbers;
+        moonDegreeTwoLoveNumbers[ 2 ] = std::vector< std::complex< double > >( 3, std::complex< double >( 0.301, -0.001 ) );
+        degreeSeparatedVariations.push_back( std::make_shared< BasicSolidBodyGravityFieldVariationSettings >(
+                std::vector< std::string >{ "Moon" }, moonDegreeTwoLoveNumbers ) );
+
+        std::map< int, std::vector< std::complex< double > > > moonDegreeThreeLoveNumbers;
+        moonDegreeThreeLoveNumbers[ 3 ] = std::vector< std::complex< double > >( 4, std::complex< double >( 0.093, 0.0 ) );
+        degreeSeparatedVariations.push_back( std::make_shared< BasicSolidBodyGravityFieldVariationSettings >(
+                std::vector< std::string >{ "Moon" }, moonDegreeThreeLoveNumbers ) );
+
+        std::map< int, std::vector< std::complex< double > > > sunDegreeTwoLoveNumbers;
+        sunDegreeTwoLoveNumbers[ 2 ] = std::vector< std::complex< double > >( 3, std::complex< double >( 0.295, -0.002 ) );
+        degreeSeparatedVariations.push_back( std::make_shared< BasicSolidBodyGravityFieldVariationSettings >(
+                std::vector< std::string >{ "Sun" }, sunDegreeTwoLoveNumbers ) );
+
+        degreeSeparatedBodySettings.at( "Earth" )->gravityFieldVariationSettings = degreeSeparatedVariations;
+        SystemOfBodies degreeSeparatedBodies = createSystemOfBodies( degreeSeparatedBodySettings );
+
+        std::vector< std::shared_ptr< EstimatableParameterSettings > > degreeTwoMoonParameters;
+        degreeTwoMoonParameters.push_back(
+                std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 2, "Moon", false ) );
+        std::shared_ptr< EstimatableParameterSet< double > > degreeTwoMoonParameterSet =
+                createParametersToEstimate< double, double >( degreeTwoMoonParameters, degreeSeparatedBodies );
+        std::shared_ptr< FullDegreeTidalLoveNumber > degreeTwoMoonLoveNumber =
+                std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >(
+                        degreeTwoMoonParameterSet->getVectorParameters( ).begin( )->second );
+        BOOST_REQUIRE( degreeTwoMoonLoveNumber != nullptr );
+        BOOST_CHECK_EQUAL( degreeTwoMoonLoveNumber->getGravityFieldVariationModels( ).size( ), 1 );
+        BOOST_CHECK_EQUAL( degreeTwoMoonLoveNumber->getDeformingBodies( ).size( ), 1 );
+        BOOST_CHECK_EQUAL( degreeTwoMoonLoveNumber->getDeformingBodies( ).at( 0 ), "Moon" );
+
+        std::vector< std::string > emptyDeformingBodies;
+        std::vector< std::shared_ptr< EstimatableParameterSettings > > degreeTwoEmptyParameters;
+        degreeTwoEmptyParameters.push_back( std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >(
+                "Earth", 2, emptyDeformingBodies, false ) );
+        std::shared_ptr< EstimatableParameterSet< double > > degreeTwoEmptyParameterSet =
+                createParametersToEstimate< double, double >( degreeTwoEmptyParameters, degreeSeparatedBodies );
+        std::shared_ptr< FullDegreeTidalLoveNumber > degreeTwoEmptyLoveNumber =
+                std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >(
+                        degreeTwoEmptyParameterSet->getVectorParameters( ).begin( )->second );
+        BOOST_REQUIRE( degreeTwoEmptyLoveNumber != nullptr );
+        BOOST_CHECK_EQUAL( degreeTwoEmptyLoveNumber->getGravityFieldVariationModels( ).size( ), 2 );
+
+        std::vector< std::shared_ptr< EstimatableParameterSettings > > degreeThreeMoonParameters;
+        degreeThreeMoonParameters.push_back(
+                std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 3, "Moon", false ) );
+        std::shared_ptr< EstimatableParameterSet< double > > degreeThreeMoonParameterSet =
+                createParametersToEstimate< double, double >( degreeThreeMoonParameters, degreeSeparatedBodies );
+        std::shared_ptr< FullDegreeTidalLoveNumber > degreeThreeMoonLoveNumber =
+                std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >(
+                        degreeThreeMoonParameterSet->getVectorParameters( ).begin( )->second );
+        BOOST_REQUIRE( degreeThreeMoonLoveNumber != nullptr );
+        BOOST_CHECK_EQUAL( degreeThreeMoonLoveNumber->getGravityFieldVariationModels( ).size( ), 1 );
+    }
+
+    // Empty list must reject duplicate body coverage for the same requested degree.
+    {
+        BodyListSettings ambiguousBodySettings = getDefaultBodySettings( bodyNames, "Earth", "ECLIPJ2000" );
+        std::vector< std::shared_ptr< GravityFieldVariationSettings > > ambiguousVariations;
+        std::map< int, std::vector< std::complex< double > > > firstMoonLoveNumbers;
+        firstMoonLoveNumbers[ 2 ] = std::vector< std::complex< double > >( 3, std::complex< double >( 0.301, 0.0 ) );
+        ambiguousVariations.push_back( std::make_shared< BasicSolidBodyGravityFieldVariationSettings >(
+                std::vector< std::string >{ "Moon" }, firstMoonLoveNumbers ) );
+        std::map< int, std::vector< std::complex< double > > > secondMoonLoveNumbers;
+        secondMoonLoveNumbers[ 2 ] = std::vector< std::complex< double > >( 3, std::complex< double >( 0.295, 0.0 ) );
+        ambiguousVariations.push_back( std::make_shared< BasicSolidBodyGravityFieldVariationSettings >(
+                std::vector< std::string >{ "Moon" }, secondMoonLoveNumbers ) );
+        ambiguousBodySettings.at( "Earth" )->gravityFieldVariationSettings = ambiguousVariations;
+        SystemOfBodies ambiguousBodies = createSystemOfBodies( ambiguousBodySettings );
+
+        bool emptyListAmbiguityCaught = false;
+        try
+        {
+            std::vector< std::string > emptyDeformingBodies;
+            std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNames;
+            parameterNames.push_back( std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >(
+                    "Earth", 2, emptyDeformingBodies, false ) );
+            createParametersToEstimate< double, double >( parameterNames, ambiguousBodies );
+        }
+        catch( const std::runtime_error& error )
+        {
+            emptyListAmbiguityCaught = true;
+            BOOST_CHECK( std::string( error.what( ) ).find( "Moon" ) != std::string::npos );
+            BOOST_CHECK( std::string( error.what( ) ).find( "ambiguous" ) != std::string::npos );
+        }
+        BOOST_CHECK( emptyListAmbiguityCaught );
+
+        bool explicitListAmbiguityCaught = false;
+        try
+        {
+            std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNames;
+            parameterNames.push_back(
+                    std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 2, "Moon", false ) );
+            createParametersToEstimate< double, double >( parameterNames, ambiguousBodies );
+        }
+        catch( const std::runtime_error& error )
+        {
+            explicitListAmbiguityCaught = true;
+            BOOST_CHECK( std::string( error.what( ) ).find( "Moon" ) != std::string::npos );
+            BOOST_CHECK( std::string( error.what( ) ).find( "ambiguous" ) != std::string::npos );
+        }
+        BOOST_CHECK( explicitListAmbiguityCaught );
+    }
+
+    // Order-varying Love numbers also synchronize across multiple selected models.
+    {
+        bodySettings.at( "Earth" )->gravityFieldVariationSettings = getSeparateMoonSunEarthTideSettings(
+                std::complex< double >( 0.301, -0.001 ), std::complex< double >( 0.295, -0.002 ) );
+        bodies = createSystemOfBodies( bodySettings );
+
+        std::vector< std::string > deformingBodiesMoonSun;
+        deformingBodiesMoonSun.push_back( "Moon" );
+        deformingBodiesMoonSun.push_back( "Sun" );
+        std::vector< int > estimatedOrders;
+        estimatedOrders.push_back( 1 );
+        std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNames;
+        parameterNames.push_back( std::make_shared< SingleDegreeVariableTidalLoveNumberEstimatableParameterSettings >(
+                "Earth", 2, estimatedOrders, deformingBodiesMoonSun, false ) );
+        std::shared_ptr< EstimatableParameterSet< double > > parameterSet =
+                createParametersToEstimate< double, double >( parameterNames, bodies );
+        std::shared_ptr< SingleDegreeVariableTidalLoveNumber > loveNumberParameter =
+                std::dynamic_pointer_cast< SingleDegreeVariableTidalLoveNumber >(
+                        parameterSet->getVectorParameters( ).begin( )->second );
+        BOOST_REQUIRE( loveNumberParameter != nullptr );
+        BOOST_CHECK_EQUAL( loveNumberParameter->getGravityFieldVariationModels( ).size( ), 2 );
+        BOOST_CHECK_EQUAL( loveNumberParameter->getParameterSize( ), 1 );
+
+        std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > > tideModels = getBasicTideModels( );
+        BOOST_REQUIRE_EQUAL( tideModels.size( ), 2 );
+        const double moonOrderZeroBefore = tideModels.at( 0 )->getLoveNumbersOfDegree( 2 ).at( 0 ).real( );
+        const double moonOrderTwoBefore = tideModels.at( 0 )->getLoveNumbersOfDegree( 2 ).at( 2 ).real( );
+        const double sunOrderZeroBefore = tideModels.at( 1 )->getLoveNumbersOfDegree( 2 ).at( 0 ).real( );
+        const double sunOrderTwoBefore = tideModels.at( 1 )->getLoveNumbersOfDegree( 2 ).at( 2 ).real( );
+
+        Eigen::VectorXd resetValue = Eigen::VectorXd::Zero( 1 );
+        resetValue( 0 ) = 0.42;
+        loveNumberParameter->setParameterValue( resetValue );
+
+        BOOST_CHECK_CLOSE_FRACTION( tideModels.at( 0 )->getLoveNumbersOfDegree( 2 ).at( 1 ).real( ), 0.42, 1.0E-14 );
+        BOOST_CHECK_CLOSE_FRACTION( tideModels.at( 1 )->getLoveNumbersOfDegree( 2 ).at( 1 ).real( ), 0.42, 1.0E-14 );
+        BOOST_CHECK_CLOSE_FRACTION( tideModels.at( 0 )->getLoveNumbersOfDegree( 2 ).at( 0 ).real( ), moonOrderZeroBefore, 1.0E-14 );
+        BOOST_CHECK_CLOSE_FRACTION( tideModels.at( 0 )->getLoveNumbersOfDegree( 2 ).at( 2 ).real( ), moonOrderTwoBefore, 1.0E-14 );
+        BOOST_CHECK_CLOSE_FRACTION( tideModels.at( 1 )->getLoveNumbersOfDegree( 2 ).at( 0 ).real( ), sunOrderZeroBefore, 1.0E-14 );
+        BOOST_CHECK_CLOSE_FRACTION( tideModels.at( 1 )->getLoveNumbersOfDegree( 2 ).at( 2 ).real( ), sunOrderTwoBefore, 1.0E-14 );
     }
 }
 

--- a/tests/test_tudat/src/astro/orbit_determination/unitTestTidalPropertyEstimation.cpp
+++ b/tests/test_tudat/src/astro/orbit_determination/unitTestTidalPropertyEstimation.cpp
@@ -566,14 +566,14 @@ std::vector< std::shared_ptr< GravityFieldVariationSettings > > getSeparateMoonS
     std::map< int, std::vector< std::complex< double > > > moonLoveNumbers;
     moonLoveNumbers[ 2 ] = std::vector< std::complex< double > >( 3, moonDegreeTwoLoveNumber );
     moonLoveNumbers[ 3 ] = std::vector< std::complex< double > >( 4, std::complex< double >( 0.093, 0.0 ) );
-    gravityFieldVariations.push_back( std::make_shared< BasicSolidBodyGravityFieldVariationSettings >(
-            std::vector< std::string >{ "Moon" }, moonLoveNumbers ) );
+    gravityFieldVariations.push_back(
+            std::make_shared< BasicSolidBodyGravityFieldVariationSettings >( std::vector< std::string >{ "Moon" }, moonLoveNumbers ) );
 
     std::map< int, std::vector< std::complex< double > > > sunLoveNumbers;
     sunLoveNumbers[ 2 ] = std::vector< std::complex< double > >( 3, sunDegreeTwoLoveNumber );
     sunLoveNumbers[ 3 ] = std::vector< std::complex< double > >( 4, std::complex< double >( 0.093, 0.0 ) );
-    gravityFieldVariations.push_back( std::make_shared< BasicSolidBodyGravityFieldVariationSettings >(
-            std::vector< std::string >{ "Sun" }, sunLoveNumbers ) );
+    gravityFieldVariations.push_back(
+            std::make_shared< BasicSolidBodyGravityFieldVariationSettings >( std::vector< std::string >{ "Sun" }, sunLoveNumbers ) );
 
     return gravityFieldVariations;
 }
@@ -588,12 +588,11 @@ BOOST_AUTO_TEST_CASE( test_MultiModelFullDegreeLoveNumberParameterSetup )
     bodyNames.push_back( "Sun" );
     bodyNames.push_back( "Moon" );
     BodyListSettings bodySettings = getDefaultBodySettings( bodyNames, "Earth", "ECLIPJ2000" );
-    bodySettings.at( "Earth" )->gravityFieldVariationSettings = getSeparateMoonSunEarthTideSettings(
-            std::complex< double >( 0.301, -0.001 ), std::complex< double >( 0.295, -0.002 ) );
+    bodySettings.at( "Earth" )->gravityFieldVariationSettings =
+            getSeparateMoonSunEarthTideSettings( std::complex< double >( 0.301, -0.001 ), std::complex< double >( 0.295, -0.002 ) );
     SystemOfBodies bodies = createSystemOfBodies( bodySettings );
 
-    auto getBasicTideModels =
-            [ &bodies ]( ) -> std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > > {
+    auto getBasicTideModels = [ &bodies ]( ) -> std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > > {
         return utilities::dynamicCastSVectorToTVector< gravitation::GravityFieldVariations,
                                                        gravitation::BasicSolidBodyTideGravityFieldVariations >(
                 bodies.at( "Earth" )->getGravityFieldVariationSet( )->getDirectTidalGravityFieldVariations( ) );
@@ -609,21 +608,21 @@ BOOST_AUTO_TEST_CASE( test_MultiModelFullDegreeLoveNumberParameterSetup )
         deformingBodiesSunMoon.push_back( "Moon" );
 
         std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNamesMoonSun;
-        parameterNamesMoonSun.push_back( std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >(
-                "Earth", 2, deformingBodiesMoonSun, false ) );
+        parameterNamesMoonSun.push_back(
+                std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 2, deformingBodiesMoonSun, false ) );
         std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNamesSunMoon;
-        parameterNamesSunMoon.push_back( std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >(
-                "Earth", 2, deformingBodiesSunMoon, false ) );
+        parameterNamesSunMoon.push_back(
+                std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 2, deformingBodiesSunMoon, false ) );
 
         std::shared_ptr< EstimatableParameterSet< double > > parameterSetMoonSun =
                 createParametersToEstimate< double, double >( parameterNamesMoonSun, bodies );
         std::shared_ptr< EstimatableParameterSet< double > > parameterSetSunMoon =
                 createParametersToEstimate< double, double >( parameterNamesSunMoon, bodies );
 
-        std::shared_ptr< FullDegreeTidalLoveNumber > loveNumberMoonSun = std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >(
-                parameterSetMoonSun->getVectorParameters( ).begin( )->second );
-        std::shared_ptr< FullDegreeTidalLoveNumber > loveNumberSunMoon = std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >(
-                parameterSetSunMoon->getVectorParameters( ).begin( )->second );
+        std::shared_ptr< FullDegreeTidalLoveNumber > loveNumberMoonSun =
+                std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >( parameterSetMoonSun->getVectorParameters( ).begin( )->second );
+        std::shared_ptr< FullDegreeTidalLoveNumber > loveNumberSunMoon =
+                std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >( parameterSetSunMoon->getVectorParameters( ).begin( )->second );
         BOOST_REQUIRE( loveNumberMoonSun != nullptr );
         BOOST_REQUIRE( loveNumberSunMoon != nullptr );
         BOOST_CHECK_EQUAL( loveNumberMoonSun->getParameterSize( ), 1 );
@@ -651,8 +650,8 @@ BOOST_AUTO_TEST_CASE( test_MultiModelFullDegreeLoveNumberParameterSetup )
         SystemOfBodies combinedBodies = createSystemOfBodies( combinedBodySettings );
 
         std::vector< std::shared_ptr< EstimatableParameterSettings > > combinedParameterNames;
-        combinedParameterNames.push_back( std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >(
-                "Earth", 2, combinedDeformingBodies, false ) );
+        combinedParameterNames.push_back(
+                std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 2, combinedDeformingBodies, false ) );
         bool combinedCreationSucceeded = true;
         try
         {
@@ -665,24 +664,44 @@ BOOST_AUTO_TEST_CASE( test_MultiModelFullDegreeLoveNumberParameterSetup )
         BOOST_CHECK( combinedCreationSucceeded );
     }
 
-    // Test B: synchronized reset preserves per-model imaginary parts for real-only estimation.
+    // Test B: real-only reset updates the shared real part and preserves each order's imaginary part.
     {
+        std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > > tideModels = getBasicTideModels( );
+        BOOST_REQUIRE_EQUAL( tideModels.size( ), 2 );
+
+        // Deliberately distinct per-order imaginary parts so a mean-imag rewrite would fail.
+        std::vector< std::complex< double > > moonDegreeTwoLoveNumbers = { std::complex< double >( 0.301, -0.001 ),
+                                                                           std::complex< double >( 0.301, -0.003 ),
+                                                                           std::complex< double >( 0.301, -0.005 ) };
+        std::vector< std::complex< double > > sunDegreeTwoLoveNumbers = { std::complex< double >( 0.295, -0.002 ),
+                                                                          std::complex< double >( 0.295, -0.004 ),
+                                                                          std::complex< double >( 0.295, -0.006 ) };
+        tideModels.at( 0 )->resetLoveNumbersOfDegree( moonDegreeTwoLoveNumbers, 2 );
+        tideModels.at( 1 )->resetLoveNumbersOfDegree( sunDegreeTwoLoveNumbers, 2 );
+
         std::vector< std::string > deformingBodiesMoonSun;
         deformingBodiesMoonSun.push_back( "Moon" );
         deformingBodiesMoonSun.push_back( "Sun" );
         std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNames;
-        parameterNames.push_back( std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >(
-                "Earth", 2, deformingBodiesMoonSun, false ) );
+        parameterNames.push_back(
+                std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 2, deformingBodiesMoonSun, false ) );
         std::shared_ptr< EstimatableParameterSet< double > > parameterSet =
                 createParametersToEstimate< double, double >( parameterNames, bodies );
-        std::shared_ptr< FullDegreeTidalLoveNumber > loveNumberParameter = std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >(
-                parameterSet->getVectorParameters( ).begin( )->second );
+        std::shared_ptr< FullDegreeTidalLoveNumber > loveNumberParameter =
+                std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >( parameterSet->getVectorParameters( ).begin( )->second );
         BOOST_REQUIRE( loveNumberParameter != nullptr );
+        BOOST_CHECK_EQUAL( loveNumberParameter->getParameterSize( ), 1 );
 
-        std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > > tideModels = getBasicTideModels( );
-        BOOST_REQUIRE_EQUAL( tideModels.size( ), 2 );
-        const double moonImagBefore = tideModels.at( 0 )->getLoveNumbersOfDegree( 2 ).at( 0 ).imag( );
-        const double sunImagBefore = tideModels.at( 1 )->getLoveNumbersOfDegree( 2 ).at( 0 ).imag( );
+        bool wrongSizeRejected = false;
+        try
+        {
+            loveNumberParameter->setParameterValue( Eigen::VectorXd::Zero( 2 ) );
+        }
+        catch( const std::runtime_error& )
+        {
+            wrongSizeRejected = true;
+        }
+        BOOST_CHECK( wrongSizeRejected );
 
         Eigen::VectorXd resetValue = Eigen::VectorXd::Zero( 1 );
         resetValue( 0 ) = 0.33;
@@ -692,27 +711,33 @@ BOOST_AUTO_TEST_CASE( test_MultiModelFullDegreeLoveNumberParameterSetup )
         {
             BOOST_CHECK_CLOSE_FRACTION( tideModels.at( 0 )->getLoveNumbersOfDegree( 2 ).at( order ).real( ), 0.33, 1.0E-14 );
             BOOST_CHECK_CLOSE_FRACTION( tideModels.at( 1 )->getLoveNumbersOfDegree( 2 ).at( order ).real( ), 0.33, 1.0E-14 );
-            BOOST_CHECK_CLOSE_FRACTION( tideModels.at( 0 )->getLoveNumbersOfDegree( 2 ).at( order ).imag( ), moonImagBefore, 1.0E-14 );
-            BOOST_CHECK_CLOSE_FRACTION( tideModels.at( 1 )->getLoveNumbersOfDegree( 2 ).at( order ).imag( ), sunImagBefore, 1.0E-14 );
+            BOOST_CHECK_CLOSE_FRACTION( tideModels.at( 0 )->getLoveNumbersOfDegree( 2 ).at( order ).imag( ),
+                                        moonDegreeTwoLoveNumbers.at( order ).imag( ),
+                                        1.0E-14 );
+            BOOST_CHECK_CLOSE_FRACTION( tideModels.at( 1 )->getLoveNumbersOfDegree( 2 ).at( order ).imag( ),
+                                        sunDegreeTwoLoveNumbers.at( order ).imag( ),
+                                        1.0E-14 );
         }
+        BOOST_CHECK( moonDegreeTwoLoveNumbers.at( 0 ).imag( ) != sunDegreeTwoLoveNumbers.at( 0 ).imag( ) );
+        BOOST_CHECK( moonDegreeTwoLoveNumbers.at( 0 ).imag( ) != moonDegreeTwoLoveNumbers.at( 1 ).imag( ) );
     }
 
     // Complex shared reset updates both components in every selected model.
     {
-        bodySettings.at( "Earth" )->gravityFieldVariationSettings = getSeparateMoonSunEarthTideSettings(
-                std::complex< double >( 0.301, -0.001 ), std::complex< double >( 0.295, -0.002 ) );
+        bodySettings.at( "Earth" )->gravityFieldVariationSettings =
+                getSeparateMoonSunEarthTideSettings( std::complex< double >( 0.301, -0.001 ), std::complex< double >( 0.295, -0.002 ) );
         bodies = createSystemOfBodies( bodySettings );
 
         std::vector< std::string > deformingBodiesMoonSun;
         deformingBodiesMoonSun.push_back( "Moon" );
         deformingBodiesMoonSun.push_back( "Sun" );
         std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNames;
-        parameterNames.push_back( std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >(
-                "Earth", 2, deformingBodiesMoonSun, true ) );
+        parameterNames.push_back(
+                std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 2, deformingBodiesMoonSun, true ) );
         std::shared_ptr< EstimatableParameterSet< double > > parameterSet =
                 createParametersToEstimate< double, double >( parameterNames, bodies );
-        std::shared_ptr< FullDegreeTidalLoveNumber > loveNumberParameter = std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >(
-                parameterSet->getVectorParameters( ).begin( )->second );
+        std::shared_ptr< FullDegreeTidalLoveNumber > loveNumberParameter =
+                std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >( parameterSet->getVectorParameters( ).begin( )->second );
         BOOST_REQUIRE( loveNumberParameter != nullptr );
 
         Eigen::VectorXd resetValue = Eigen::VectorXd::Zero( 2 );
@@ -733,18 +758,18 @@ BOOST_AUTO_TEST_CASE( test_MultiModelFullDegreeLoveNumberParameterSetup )
 
     // Test C: empty deforming-body list selects all compatible basic tide models.
     {
-        bodySettings.at( "Earth" )->gravityFieldVariationSettings = getSeparateMoonSunEarthTideSettings(
-                std::complex< double >( 0.301, -0.001 ), std::complex< double >( 0.295, -0.002 ) );
+        bodySettings.at( "Earth" )->gravityFieldVariationSettings =
+                getSeparateMoonSunEarthTideSettings( std::complex< double >( 0.301, -0.001 ), std::complex< double >( 0.295, -0.002 ) );
         bodies = createSystemOfBodies( bodySettings );
 
         std::vector< std::string > emptyDeformingBodies;
         std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNames;
-        parameterNames.push_back( std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >(
-                "Earth", 2, emptyDeformingBodies, false ) );
+        parameterNames.push_back(
+                std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 2, emptyDeformingBodies, false ) );
         std::shared_ptr< EstimatableParameterSet< double > > parameterSet =
                 createParametersToEstimate< double, double >( parameterNames, bodies );
-        std::shared_ptr< FullDegreeTidalLoveNumber > loveNumberParameter = std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >(
-                parameterSet->getVectorParameters( ).begin( )->second );
+        std::shared_ptr< FullDegreeTidalLoveNumber > loveNumberParameter =
+                std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >( parameterSet->getVectorParameters( ).begin( )->second );
         BOOST_REQUIRE( loveNumberParameter != nullptr );
         BOOST_CHECK_EQUAL( loveNumberParameter->getGravityFieldVariationModels( ).size( ), 2 );
 
@@ -763,17 +788,16 @@ BOOST_AUTO_TEST_CASE( test_MultiModelFullDegreeLoveNumberParameterSetup )
 
     // Test D: subset selection only updates the requested model.
     {
-        bodySettings.at( "Earth" )->gravityFieldVariationSettings = getSeparateMoonSunEarthTideSettings(
-                std::complex< double >( 0.301, -0.001 ), std::complex< double >( 0.295, -0.002 ) );
+        bodySettings.at( "Earth" )->gravityFieldVariationSettings =
+                getSeparateMoonSunEarthTideSettings( std::complex< double >( 0.301, -0.001 ), std::complex< double >( 0.295, -0.002 ) );
         bodies = createSystemOfBodies( bodySettings );
 
         std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNames;
-        parameterNames.push_back(
-                std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 2, "Moon", false ) );
+        parameterNames.push_back( std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 2, "Moon", false ) );
         std::shared_ptr< EstimatableParameterSet< double > > parameterSet =
                 createParametersToEstimate< double, double >( parameterNames, bodies );
-        std::shared_ptr< FullDegreeTidalLoveNumber > loveNumberParameter = std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >(
-                parameterSet->getVectorParameters( ).begin( )->second );
+        std::shared_ptr< FullDegreeTidalLoveNumber > loveNumberParameter =
+                std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >( parameterSet->getVectorParameters( ).begin( )->second );
         BOOST_REQUIRE( loveNumberParameter != nullptr );
 
         std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > > tideModels = getBasicTideModels( );
@@ -791,8 +815,8 @@ BOOST_AUTO_TEST_CASE( test_MultiModelFullDegreeLoveNumberParameterSetup )
 
     // Test E: invalid selections throw actionable errors.
     {
-        bodySettings.at( "Earth" )->gravityFieldVariationSettings = getSeparateMoonSunEarthTideSettings(
-                std::complex< double >( 0.301, -0.001 ), std::complex< double >( 0.295, -0.002 ) );
+        bodySettings.at( "Earth" )->gravityFieldVariationSettings =
+                getSeparateMoonSunEarthTideSettings( std::complex< double >( 0.301, -0.001 ), std::complex< double >( 0.295, -0.002 ) );
         bodies = createSystemOfBodies( bodySettings );
 
         bool missingBodyCaught = false;
@@ -880,9 +904,8 @@ BOOST_AUTO_TEST_CASE( test_MultiModelFullDegreeLoveNumberParameterSetup )
                 std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 2, "Moon", false ) );
         std::shared_ptr< EstimatableParameterSet< double > > degreeTwoMoonParameterSet =
                 createParametersToEstimate< double, double >( degreeTwoMoonParameters, degreeSeparatedBodies );
-        std::shared_ptr< FullDegreeTidalLoveNumber > degreeTwoMoonLoveNumber =
-                std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >(
-                        degreeTwoMoonParameterSet->getVectorParameters( ).begin( )->second );
+        std::shared_ptr< FullDegreeTidalLoveNumber > degreeTwoMoonLoveNumber = std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >(
+                degreeTwoMoonParameterSet->getVectorParameters( ).begin( )->second );
         BOOST_REQUIRE( degreeTwoMoonLoveNumber != nullptr );
         BOOST_CHECK_EQUAL( degreeTwoMoonLoveNumber->getGravityFieldVariationModels( ).size( ), 1 );
         BOOST_CHECK_EQUAL( degreeTwoMoonLoveNumber->getDeformingBodies( ).size( ), 1 );
@@ -890,13 +913,12 @@ BOOST_AUTO_TEST_CASE( test_MultiModelFullDegreeLoveNumberParameterSetup )
 
         std::vector< std::string > emptyDeformingBodies;
         std::vector< std::shared_ptr< EstimatableParameterSettings > > degreeTwoEmptyParameters;
-        degreeTwoEmptyParameters.push_back( std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >(
-                "Earth", 2, emptyDeformingBodies, false ) );
+        degreeTwoEmptyParameters.push_back(
+                std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 2, emptyDeformingBodies, false ) );
         std::shared_ptr< EstimatableParameterSet< double > > degreeTwoEmptyParameterSet =
                 createParametersToEstimate< double, double >( degreeTwoEmptyParameters, degreeSeparatedBodies );
-        std::shared_ptr< FullDegreeTidalLoveNumber > degreeTwoEmptyLoveNumber =
-                std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >(
-                        degreeTwoEmptyParameterSet->getVectorParameters( ).begin( )->second );
+        std::shared_ptr< FullDegreeTidalLoveNumber > degreeTwoEmptyLoveNumber = std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >(
+                degreeTwoEmptyParameterSet->getVectorParameters( ).begin( )->second );
         BOOST_REQUIRE( degreeTwoEmptyLoveNumber != nullptr );
         BOOST_CHECK_EQUAL( degreeTwoEmptyLoveNumber->getGravityFieldVariationModels( ).size( ), 2 );
 
@@ -905,9 +927,8 @@ BOOST_AUTO_TEST_CASE( test_MultiModelFullDegreeLoveNumberParameterSetup )
                 std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 3, "Moon", false ) );
         std::shared_ptr< EstimatableParameterSet< double > > degreeThreeMoonParameterSet =
                 createParametersToEstimate< double, double >( degreeThreeMoonParameters, degreeSeparatedBodies );
-        std::shared_ptr< FullDegreeTidalLoveNumber > degreeThreeMoonLoveNumber =
-                std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >(
-                        degreeThreeMoonParameterSet->getVectorParameters( ).begin( )->second );
+        std::shared_ptr< FullDegreeTidalLoveNumber > degreeThreeMoonLoveNumber = std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >(
+                degreeThreeMoonParameterSet->getVectorParameters( ).begin( )->second );
         BOOST_REQUIRE( degreeThreeMoonLoveNumber != nullptr );
         BOOST_CHECK_EQUAL( degreeThreeMoonLoveNumber->getGravityFieldVariationModels( ).size( ), 1 );
     }
@@ -932,8 +953,8 @@ BOOST_AUTO_TEST_CASE( test_MultiModelFullDegreeLoveNumberParameterSetup )
         {
             std::vector< std::string > emptyDeformingBodies;
             std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNames;
-            parameterNames.push_back( std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >(
-                    "Earth", 2, emptyDeformingBodies, false ) );
+            parameterNames.push_back(
+                    std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 2, emptyDeformingBodies, false ) );
             createParametersToEstimate< double, double >( parameterNames, ambiguousBodies );
         }
         catch( const std::runtime_error& error )
@@ -963,8 +984,8 @@ BOOST_AUTO_TEST_CASE( test_MultiModelFullDegreeLoveNumberParameterSetup )
 
     // Order-varying Love numbers also synchronize across multiple selected models.
     {
-        bodySettings.at( "Earth" )->gravityFieldVariationSettings = getSeparateMoonSunEarthTideSettings(
-                std::complex< double >( 0.301, -0.001 ), std::complex< double >( 0.295, -0.002 ) );
+        bodySettings.at( "Earth" )->gravityFieldVariationSettings =
+                getSeparateMoonSunEarthTideSettings( std::complex< double >( 0.301, -0.001 ), std::complex< double >( 0.295, -0.002 ) );
         bodies = createSystemOfBodies( bodySettings );
 
         std::vector< std::string > deformingBodiesMoonSun;
@@ -978,8 +999,7 @@ BOOST_AUTO_TEST_CASE( test_MultiModelFullDegreeLoveNumberParameterSetup )
         std::shared_ptr< EstimatableParameterSet< double > > parameterSet =
                 createParametersToEstimate< double, double >( parameterNames, bodies );
         std::shared_ptr< SingleDegreeVariableTidalLoveNumber > loveNumberParameter =
-                std::dynamic_pointer_cast< SingleDegreeVariableTidalLoveNumber >(
-                        parameterSet->getVectorParameters( ).begin( )->second );
+                std::dynamic_pointer_cast< SingleDegreeVariableTidalLoveNumber >( parameterSet->getVectorParameters( ).begin( )->second );
         BOOST_REQUIRE( loveNumberParameter != nullptr );
         BOOST_CHECK_EQUAL( loveNumberParameter->getGravityFieldVariationModels( ).size( ), 2 );
         BOOST_CHECK_EQUAL( loveNumberParameter->getParameterSize( ), 1 );

--- a/tests/test_tudat/src/astro/orbit_determination/unitTestTidalPropertyEstimation.cpp
+++ b/tests/test_tudat/src/astro/orbit_determination/unitTestTidalPropertyEstimation.cpp
@@ -486,12 +486,26 @@ BOOST_AUTO_TEST_CASE( test_LoveNumberEstimationFromOrbiterData )
             "Earth", 2, std::vector< int >{ 2 }, "Sun", true ) );
     parameterNames.push_back( std::make_shared< SingleDegreeVariableTidalLoveNumberEstimatableParameterSettings >(
             "Earth", 2, std::vector< int >{ 0, 1 }, "Moon", false ) );
-    parameterNames.push_back( std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >( "Earth", 3, "Moon", true ) );
+    parameterNames.push_back( std::make_shared< FullDegreeTidalLoveNumberEstimatableParameterSettings >(
+            "Earth", 3, std::vector< std::string >{ "Moon", "Sun" }, true ) );
 
     // Create parameters
     std::shared_ptr< estimatable_parameters::EstimatableParameterSet< double > > parametersToEstimate =
             createParametersToEstimate< double, double >( parameterNames, bodies );
     printEstimatableParameterEntries( parametersToEstimate );
+
+    bool sharedMultiModelLoveNumberFound = false;
+    for( const auto& parameterEntry : parametersToEstimate->getVectorParameters( ) )
+    {
+        std::shared_ptr< FullDegreeTidalLoveNumber > fullDegreeLoveNumber =
+                std::dynamic_pointer_cast< FullDegreeTidalLoveNumber >( parameterEntry.second );
+        if( fullDegreeLoveNumber != nullptr && fullDegreeLoveNumber->getDegree( ) == 3 )
+        {
+            sharedMultiModelLoveNumberFound = true;
+            BOOST_CHECK_EQUAL( fullDegreeLoveNumber->getGravityFieldVariationModels( ).size( ), 2 );
+        }
+    }
+    BOOST_CHECK( sharedMultiModelLoveNumberFound );
 
     // Define observation settings
     std::vector< std::shared_ptr< ObservationModelSettings > > observationSettingsList;
@@ -517,6 +531,16 @@ BOOST_AUTO_TEST_CASE( test_LoveNumberEstimationFromOrbiterData )
     // Simulate observations
     std::shared_ptr< ObservationCollection<> > observationsAndTimes = simulateObservations< double, double >(
             measurementSimulationInput, orbitDeterminationManager.getObservationSimulators( ), bodies );
+
+    // Exercise the complete shared multi-model covariance path before perturbing the estimation parameters.
+    std::shared_ptr< CovarianceAnalysisInput< double, double > > covarianceInput =
+            std::make_shared< CovarianceAnalysisInput< double, double > >( observationsAndTimes );
+    std::shared_ptr< CovarianceAnalysisOutput< double > > covarianceOutput = orbitDeterminationManager.computeCovariance( covarianceInput );
+    BOOST_REQUIRE( covarianceOutput != nullptr );
+    const Eigen::MatrixXd covarianceMatrix = covarianceOutput->getUnnormalizedCovarianceMatrix( );
+    BOOST_CHECK_EQUAL( covarianceMatrix.rows( ), parametersToEstimate->getParameterSetSize( ) );
+    BOOST_CHECK_EQUAL( covarianceMatrix.cols( ), parametersToEstimate->getParameterSetSize( ) );
+    BOOST_CHECK( covarianceMatrix.allFinite( ) );
 
     // Perturb parameter estimate
     Eigen::VectorXd initialParameterEstimate = parametersToEstimate->template getFullParameterValues< double >( );
@@ -1021,6 +1045,44 @@ BOOST_AUTO_TEST_CASE( test_MultiModelFullDegreeLoveNumberParameterSetup )
         BOOST_CHECK_CLOSE_FRACTION( tideModels.at( 0 )->getLoveNumbersOfDegree( 2 ).at( 2 ).real( ), moonOrderTwoBefore, 1.0E-14 );
         BOOST_CHECK_CLOSE_FRACTION( tideModels.at( 1 )->getLoveNumbersOfDegree( 2 ).at( 0 ).real( ), sunOrderZeroBefore, 1.0E-14 );
         BOOST_CHECK_CLOSE_FRACTION( tideModels.at( 1 )->getLoveNumbersOfDegree( 2 ).at( 2 ).real( ), sunOrderTwoBefore, 1.0E-14 );
+    }
+
+    // Complex order-varying resets update both components at the selected orders in every selected model.
+    {
+        bodySettings.at( "Earth" )->gravityFieldVariationSettings =
+                getSeparateMoonSunEarthTideSettings( std::complex< double >( 0.301, -0.001 ), std::complex< double >( 0.295, -0.002 ) );
+        bodies = createSystemOfBodies( bodySettings );
+
+        const std::vector< std::string > deformingBodiesMoonSun = { "Moon", "Sun" };
+        const std::vector< int > estimatedOrders = { 0, 2 };
+        std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterNames;
+        parameterNames.push_back( std::make_shared< SingleDegreeVariableTidalLoveNumberEstimatableParameterSettings >(
+                "Earth", 2, estimatedOrders, deformingBodiesMoonSun, true ) );
+        std::shared_ptr< EstimatableParameterSet< double > > parameterSet =
+                createParametersToEstimate< double, double >( parameterNames, bodies );
+        std::shared_ptr< SingleDegreeVariableTidalLoveNumber > loveNumberParameter =
+                std::dynamic_pointer_cast< SingleDegreeVariableTidalLoveNumber >( parameterSet->getVectorParameters( ).begin( )->second );
+        BOOST_REQUIRE( loveNumberParameter != nullptr );
+        BOOST_CHECK_EQUAL( loveNumberParameter->getGravityFieldVariationModels( ).size( ), 2 );
+        BOOST_CHECK_EQUAL( loveNumberParameter->getParameterSize( ), 4 );
+
+        std::vector< std::shared_ptr< gravitation::BasicSolidBodyTideGravityFieldVariations > > tideModels = getBasicTideModels( );
+        BOOST_REQUIRE_EQUAL( tideModels.size( ), 2 );
+        const std::complex< double > moonOrderOneBefore = tideModels.at( 0 )->getLoveNumbersOfDegree( 2 ).at( 1 );
+        const std::complex< double > sunOrderOneBefore = tideModels.at( 1 )->getLoveNumbersOfDegree( 2 ).at( 1 );
+
+        Eigen::VectorXd resetValue( 4 );
+        resetValue << 0.41, -0.011, 0.43, -0.013;
+        loveNumberParameter->setParameterValue( resetValue );
+
+        for( unsigned int modelIndex = 0; modelIndex < tideModels.size( ); modelIndex++ )
+        {
+            const std::vector< std::complex< double > > resetLoveNumbers = tideModels.at( modelIndex )->getLoveNumbersOfDegree( 2 );
+            BOOST_CHECK_SMALL( std::abs( resetLoveNumbers.at( 0 ) - std::complex< double >( 0.41, -0.011 ) ), 1.0E-14 );
+            BOOST_CHECK_SMALL( std::abs( resetLoveNumbers.at( 2 ) - std::complex< double >( 0.43, -0.013 ) ), 1.0E-14 );
+        }
+        BOOST_CHECK_SMALL( std::abs( tideModels.at( 0 )->getLoveNumbersOfDegree( 2 ).at( 1 ) - moonOrderOneBefore ), 1.0E-14 );
+        BOOST_CHECK_SMALL( std::abs( tideModels.at( 1 )->getLoveNumbersOfDegree( 2 ).at( 1 ) - sunOrderOneBefore ), 1.0E-14 );
     }
 }
 

--- a/tests/test_tudatpy/test_multi_body_love_number.py
+++ b/tests/test_tudatpy/test_multi_body_love_number.py
@@ -1,0 +1,90 @@
+"""Regression coverage for multi-body order-invariant k Love number setup (Issue #734).
+
+Uses the locally built kernel bindings so the test exercises the C++ parameter path
+without depending on optional pure-Python ephemeris wrappers.
+"""
+
+import numpy as np
+
+from tudatpy.kernel.dynamics import environment_setup, parameters_setup, propagation_setup
+from tudatpy.kernel.dynamics.parameters_setup import EstimatableParameterTypes
+from tudatpy.kernel.estimation import estimation_analysis
+from tudatpy.kernel.interface import spice
+
+
+def _create_multi_body_tide_environment():
+    spice.load_standard_kernels()
+
+    bodies_to_create = ["Earth", "Moon", "Sun"]
+    body_settings = environment_setup.get_default_body_settings(bodies_to_create, "Earth", "J2000")
+    body_settings.get("Earth").gravity_field_variation_settings = [
+        environment_setup.gravity_field_variation.solid_body_tide("Moon", 0.301, 2),
+        environment_setup.gravity_field_variation.solid_body_tide("Sun", 0.295, 2),
+    ]
+    bodies = environment_setup.create_system_of_bodies(body_settings)
+
+    bodies.create_empty_body("Delfi")
+    acceleration_settings = {
+        "Delfi": {"Earth": [propagation_setup.acceleration.spherical_harmonic_gravity(2, 2)]}
+    }
+    acceleration_models = propagation_setup.create_acceleration_models(
+        bodies, acceleration_settings, ["Delfi"], ["Earth"]
+    )
+
+    initial_state = np.array([7.0e6, 0.0, 0.0, 0.0, 7.5e3, 0.0])
+    termination = propagation_setup.propagator.time_termination(3600.0)
+    integrator = propagation_setup.integrator.runge_kutta_fixed_step(
+        100.0, propagation_setup.integrator.CoefficientSets.rkf_78
+    )
+    propagator_settings = propagation_setup.propagator.translational(
+        ["Earth"],
+        acceleration_models,
+        ["Delfi"],
+        initial_state,
+        0.0,
+        integrator,
+        termination,
+    )
+    return bodies, propagator_settings
+
+
+def _assert_love_number_parameter_present(parameter_set):
+    identifiers = parameter_set.get_parameter_identifiers()
+    love_number_identifiers = [
+        identifier
+        for identifier in identifiers
+        if identifier[0] == EstimatableParameterTypes.full_degree_tidal_love_number_type
+    ]
+    assert len(love_number_identifiers) == 1
+    assert love_number_identifiers[0][1][0] == "Earth"
+
+
+def _exercise_love_number_setup(deforming_bodies):
+    bodies, propagator_settings = _create_multi_body_tide_environment()
+
+    parameter_settings = parameters_setup.initial_states(propagator_settings, bodies)
+    parameter_settings.append(
+        parameters_setup.order_invariant_k_love_number("Earth", 2, deforming_bodies, False)
+    )
+    parameter_set = parameters_setup.create_parameter_set(parameter_settings, bodies)
+
+    assert parameter_set.parameter_set_size > 6
+    _assert_love_number_parameter_present(parameter_set)
+
+    estimator = estimation_analysis.Estimator(
+        bodies,
+        parameter_set,
+        [],
+        propagator_settings,
+        integrate_on_creation=False,
+    )
+    assert estimator is not None
+    assert estimator.variational_solver is not None
+
+
+def test_multi_body_love_number_explicit_deforming_bodies():
+    _exercise_love_number_setup(["Moon", "Sun"])
+
+
+def test_multi_body_love_number_empty_deforming_bodies():
+    _exercise_love_number_setup([])


### PR DESCRIPTION
Fixes #734.

This fixes how Love-number parameters are set up when a shared degree-wise Love number is used across tide-raising bodies that are modeled separately, like Moon- and Sun-induced tides on Earth.

Model selection now first filters by Love-number degree, then checks which deforming bodies are covered. You can pass an explicit list of bodies that may span multiple compatible models, or leave it empty to pick all models with the right degree. Cases like missing bodies, partial overlaps, duplicate coverage, or ambiguous matches now throw clear errors.

Love-number parameters keep track of the selected models and update all of them together. For real-valued parameters, each order in each model keeps its existing imaginary part. Tidal partial interfaces are linked to parameters based on the underlying variation model, and spherical-harmonic acceleration partials sum contributions from all selected models.

The interface factory now treats models as distinct even if they use the same deforming body. This lets degree-2 and degree-3 tide models coexist without making analytical partials depend on model order. Mode-coupled Love-number parameters use the same model-identity matching to avoid accidentally linking to the wrong basic tide model.

Tests cover:

- separate Moon and Sun tide models;
- explicit and empty deforming-body lists;
- subset, combined-model, missing-body, partial-overlap, and ambiguous-coverage cases;
- degree-aware model selection;
- real and complex shared parameter resets;
- order-varying Love-number resets;
- standard and full two-body spherical-harmonic partials compared against finite differences;
- same-body degree-2 and degree-3 models in different environment orders.

Validation performed:

- `test_orbit_determination_TidalPropertyEstimation`
- `test_acceleration_partials_SphericalHarmonicPartials`
- committed Python regression: `tests/test_tudatpy/test_multi_body_love_number.py`
  - command: `python -m pytest tests/test_tudatpy/test_multi_body_love_number.py -v`
  - covers explicit `deforming_bodies=["Moon", "Sun"]` and empty `deforming_bodies=[]`, parameter-set creation, Estimator construction, and variational-equation solver setup