### PR TITLE
check for body shape model before creating occultation model

### DIFF
--- a/src/tudat/simulation/environment_setup/createOccultationModel.cpp
+++ b/src/tudat/simulation/environment_setup/createOccultationModel.cpp
@@ -33,8 +33,14 @@ std::shared_ptr< tudat::electromagnetism::OccultationModel > createOccultationMo
         case 1: {
             auto occultingBodyName = occultingBodies.front( );
             auto occultingBody = bodies.at( occultingBodyName );
+            auto occultingBodyShapeModel = occultingBody->getShapeModel( );
+            if( occultingBodyShapeModel == nullptr )
+            {
+                throw std::runtime_error( "Error when creating occultation model, occulting body " + occultingBodyName +
+                                          " has no shape model." );
+            }
             occultationModel = std::make_shared< SingleOccultingBodyOccultationModel >(
-                    occultingBodyName, std::bind( &Body::getPosition, occultingBody ), occultingBody->getShapeModel( ) );
+                    occultingBodyName, std::bind( &Body::getPosition, occultingBody ), occultingBodyShapeModel );
             break;
         }
         default: {
@@ -43,8 +49,14 @@ std::shared_ptr< tudat::electromagnetism::OccultationModel > createOccultationMo
             for( const auto& occultingBodyName : occultingBodies )
             {
                 auto occultingBody = bodies.at( occultingBodyName );
+                auto occultingBodyShapeModel = occultingBody->getShapeModel( );
+                if( occultingBodyShapeModel == nullptr )
+                {
+                    throw std::runtime_error( "Error when creating occultation model, occulting body " + occultingBodyName +
+                                              " has no shape model." );
+                }
                 occultingBodyPositionFunctions.emplace_back( std::bind( &Body::getPosition, occultingBody ) );
-                occultingBodyShapeModels.push_back( occultingBody->getShapeModel( ) );
+                occultingBodyShapeModels.push_back( occultingBodyShapeModel );
             }
             occultationModel = std::make_shared< SimpleMultipleOccultingBodyOccultationModel >(
                     occultingBodies, occultingBodyPositionFunctions, occultingBodyShapeModels );
@@ -57,5 +69,3 @@ std::shared_ptr< tudat::electromagnetism::OccultationModel > createOccultationMo
 
 }  // namespace simulation_setup
 }  // namespace tudat
-
-#include "tudat/simulation/environment_setup/createOccultationModel.h"


### PR DESCRIPTION
Fixes #902

Check if the body shape model is defined before creating the occultation model, if not, throw an exception.

Reproduced using the following script, adapted from the perturbed satellite orbit example:


```python


# Load standard modules
import numpy as np
from matplotlib import pyplot as plt
from tudatpy.astro.time_representation import DateTime
from tudatpy.interface import spice
from tudatpy.dynamics import (
    environment_setup,
    propagation_setup,
    simulator,
)
from tudatpy.util import result2array

# Load spice kernels
spice.load_standard_kernels()

# Define string names for bodies to be created from default.
bodies_to_create = ["Sun", "Earth", "Moon", "Mars", "Venus"]

# Use "Earth"/"J2000" as global frame origin and orientation.
global_frame_origin = "Earth"
global_frame_orientation = "J2000"

# Create default body settings
body_settings = environment_setup.get_default_body_settings(
    bodies_to_create, global_frame_origin, global_frame_orientation
)

# no shape model for occulter defined
body_settings.add_empty_settings("Occulter")
body_settings.get("Occulter").ephemeris_settings = environment_setup.ephemeris.constant(
    np.array([1e7, 0, 0, 0, 0, 0]),
    frame_origin=global_frame_origin,
    frame_orientation=global_frame_orientation,
)


# Create empty body settings for the satellite
body_settings.add_empty_settings("Delfi-C3")

# Create radiation pressure settings
reference_area_radiation = (
    4 * 0.3 * 0.1 + 2 * 0.1 * 0.1
) / 4  # Average projection area of a 3U CubeSat
radiation_pressure_coefficient = 1.2
occulting_bodies_dict = dict()
occulting_bodies_dict["Sun"] = ["Earth", "Occulter"]
vehicle_target_settings = (
    environment_setup.radiation_pressure.cannonball_radiation_target(
        reference_area_radiation, radiation_pressure_coefficient, occulting_bodies_dict
    )
)

# Add the radiation pressure interface to the body settings
body_settings.get(
    "Delfi-C3"
).radiation_pressure_target_settings = vehicle_target_settings


bodies = environment_setup.create_system_of_bodies(body_settings)
bodies.get("Delfi-C3").mass = 2.2  # kg

# Define bodies that are propagated
bodies_to_propagate = ["Delfi-C3"]

# Define central bodies of propagation
central_bodies = ["Earth"]

# Define accelerations acting on Delfi-C3 by Sun and Earth.
accelerations_settings_delfi_c3 = dict(
    Sun=[
        propagation_setup.acceleration.radiation_pressure(),
        propagation_setup.acceleration.point_mass_gravity(),
    ],
    Earth=[
        propagation_setup.acceleration.spherical_harmonic_gravity(5, 5),
    ],
    Moon=[propagation_setup.acceleration.point_mass_gravity()],
    Mars=[propagation_setup.acceleration.point_mass_gravity()],
    Venus=[propagation_setup.acceleration.point_mass_gravity()],
)

# Create global accelerations settings dictionary.
acceleration_settings = {"Delfi-C3": accelerations_settings_delfi_c3}

# Create acceleration models.
acceleration_models = propagation_setup.create_acceleration_models(
    bodies, acceleration_settings, bodies_to_propagate, central_bodies
)

```