### PR TITLE
DSN N-Way range partials

### DIFF
--- a/cmake/tudat/TudatLinkLibraries.cmake
+++ b/cmake/tudat/TudatLinkLibraries.cmake
@@ -51,6 +51,7 @@ endif ()
 
 list(APPEND Tudat_PROPAGATION_LIBRARIES
         Tudat::tudat_propagation_setup
+        Tudat::tudat_estimatable_parameters
         Tudat::tudat_shape_based_methods
         Tudat::tudat_low_thrust_trajectories
         Tudat::tudat_environment_setup

--- a/include/tudat/astro/observation_models/dsnNWayRangeObservationModel.h
+++ b/include/tudat/astro/observation_models/dsnNWayRangeObservationModel.h
@@ -31,6 +31,31 @@ namespace tudat
 namespace observation_models
 {
 
+/*! Get the factor to convert a transmitter frequency integral to DSN n-way range observables in range units.
+ *
+ * Get the factor C_b by which the integral of the transmitted frequency over the round-trip light time is
+ * multiplied to obtain the DSN n-way (sequential) range observable in range units (Moyer (2003), section
+ * 13.5.2). The factor depends on the uplink frequency band.
+ *
+ * @param uplinkBand Frequency band of the uplink signal.
+ * @return Conversion factor from transmitter frequency integral (cycles) to range units.
+ */
+inline double getDsnRangeUnitConversionFactor( const FrequencyBands uplinkBand )
+{
+    switch( uplinkBand )
+    {
+        case s_band:
+            return 0.5;
+        case x_band:
+            return 221.0 / ( 749.0 * 2.0 );
+        case ka_band:
+            return 221.0 / ( 3599.0 * 2.0 );
+        default:
+            throw std::runtime_error( "Error when computing DSN range unit conversion factor: unsupported uplink frequency band " +
+                                      getFrequencyBandString( uplinkBand ) );
+    }
+}
+
 template< typename ObservationScalarType = double, typename TimeType = Time >
 class DsnNWayRangeObservationModel : public ObservationModel< 1, ObservationScalarType, TimeType >
 {
@@ -154,23 +179,7 @@ public:
         FrequencyBands downlinkBand = frequencyBands.at( 1 );
 
         // Define the conversion factor based on the value of the uplink frequency band
-        double conversionFactor;
-        if( uplinkBand == 0 )  // S-band
-        {
-            conversionFactor = 0.5;
-        }
-        else if( uplinkBand == 1 )  // X-band
-        {
-            conversionFactor = 221.0 / ( 749.0 * 2.0 );
-        }
-        else if( uplinkBand == 2 )  // Ka-band
-        {
-            conversionFactor = 221 / ( 3599 * 2.0 );
-        }
-        else
-        {
-            throw std::runtime_error( "Unsupported uplink frequency band" );
-        }
+        double conversionFactor = getDsnRangeUnitConversionFactor( uplinkBand );
 
         // Set approximate up- and down-link frequencies.
         double currentTurnAroundRatio = static_cast< ObservationScalarType >( turnaroundRatio_( uplinkBand, downlinkBand ) );

--- a/include/tudat/astro/orbit_determination/observation_partials/dsnNWayRangePartial.h
+++ b/include/tudat/astro/orbit_determination/observation_partials/dsnNWayRangePartial.h
@@ -1,0 +1,118 @@
+/*    Copyright (c) 2010-2023, Delft University of Technology
+ *    All rigths reserved
+ *
+ *    This file is part of the Tudat. Redistribution and use in source and
+ *    binary forms, with or without modification, are permitted exclusively
+ *    under the terms of the Modified BSD license. You should have received
+ *    a copy of the license with this file. If not, please or visit:
+ *    http://tudat.tudelft.nl/LICENSE.
+ *
+ *    References:
+ *          T. Moyer (2003), Formulation for Observed and Computed Values of Deep Space Network Data
+ * Types for Navigation, DEEP SPACE COMMUNICATIONS AND NAVIGATION SERIES, JPL/NASA
+ */
+
+#ifndef TUDAT_DSNNWAYRANGEPARTIAL_H
+#define TUDAT_DSNNWAYRANGEPARTIAL_H
+
+#include <functional>
+#include <memory>
+
+#include <Eigen/Core>
+
+#include "tudat/astro/earth_orientation/terrestrialTimeScaleConverter.h"
+#include "tudat/astro/observation_models/observationAncillarySettings.h"
+#include "tudat/astro/observation_models/observationFrequencies.h"
+#include "tudat/astro/orbit_determination/observation_partials/nWayRangePartial.h"
+
+namespace tudat
+{
+
+namespace observation_partials
+{
+
+/*! Calculate the factor scaling n-way range partials to DSN n-way range partials.
+ *
+ * Calculate the factor by which partials of the n-way range observable (in meters) are scaled to obtain
+ * partials of the DSN n-way (sequential) range observable (in range units), for a reception-time-referenced
+ * observation. Following from Moyer (2003), eq. 13-128, the scaling factor is
+ *
+ *      C_b * f_T( t_1 ) / c,
+ *
+ * with C_b the uplink-band-dependent range unit conversion factor, f_T the frequency transmitted by the
+ * transmitting ground station, t_1 the transmission time (converted to UTC for the frequency lookup) and c the
+ * speed of light.
+ *
+ * @param transmittedFrequencyFunction Function returning the frequency transmitted by the transmitting ground
+ *      station as a function of frequency bands (unused for the transmitted frequency) and time (UTC).
+ * @param timeScaleConverter Time scale converter, used to convert the transmission time from TDB to UTC.
+ * @param linkEndTimes List of times (TDB) at each link end during observation, as returned by the DSN n-way
+ *      range observation model (first entry is the transmission time).
+ * @param ancillarySettings Observation ancillary simulation settings, from which the frequency bands are retrieved.
+ * @return Scaling factor from n-way range partials (meters) to DSN n-way range partials (range units).
+ */
+double getDsnNWayRangeScalingFactor(
+        const std::function< double( std::vector< observation_models::FrequencyBands >, double ) > transmittedFrequencyFunction,
+        const std::shared_ptr< earth_orientation::TerrestrialTimeScaleConverter > timeScaleConverter,
+        const std::vector< double >& linkEndTimes,
+        const std::shared_ptr< observation_models::ObservationAncillarySimulationSettings > ancillarySettings );
+
+//! Class to compute the partial derivatives of a DSN n-way (sequential) range observation.
+/*!
+ *  Class to compute the partial derivatives of a DSN n-way (sequential) range observation. The partials are
+ *  computed as the partials of the corresponding n-way range observable (defined on the same link ends and
+ *  light time calculator), scaled by the factor converting a range change in meters to a change of the
+ *  observable in range units (see getDsnNWayRangeScalingFactor).
+ */
+class DsnNWayRangePartial : public ObservationPartial< 1 >
+{
+public:
+    //! Constructor
+    /*!
+     * Constructor
+     * \param nWayRangePartial Partial object for the n-way range observable defined on the same link ends.
+     * \param scalingFactorFunction Function computing the factor scaling n-way range partials (in meters) to DSN
+     *      n-way range partials (in range units), as a function of the link end times and ancillary settings.
+     */
+    DsnNWayRangePartial(
+            const std::shared_ptr< NWayRangePartial > nWayRangePartial,
+            const std::function< double( const std::vector< double >&,
+                                         const std::shared_ptr< observation_models::ObservationAncillarySimulationSettings > ) >
+                    scalingFactorFunction );
+
+    //! Destructor
+    ~DsnNWayRangePartial( ) = default;
+
+    //! Function to calculate the observation partial(s) at required time and state
+    /*!
+     *  Function to calculate the observation partial(s) at required time and state. State and time
+     *  are typically obtained from evaluation of observation model.
+     *  \param states Link end states. Index maps to link end for a given ObsevableType through getLinkEndIndex function.
+     *  \param times Link end time.
+     *  \param linkEndOfFixedTime Link end that is kept fixed when computing the observable.
+     *  \param ancillarySettings Observation ancillary simulation settings.
+     *  \param currentObservation Value of the observation for which the partial is to be computed.
+     *  \return Vector of pairs containing partial values and associated times.
+     */
+    std::vector< std::pair< Eigen::Matrix< double, 1, Eigen::Dynamic >, double > > calculatePartial(
+            const std::vector< Eigen::Vector6d >& states,
+            const std::vector< double >& times,
+            const observation_models::LinkEndType linkEndOfFixedTime = observation_models::receiver,
+            const std::shared_ptr< observation_models::ObservationAncillarySimulationSettings > ancillarySettings = nullptr,
+            const Eigen::Vector1d& currentObservation = Eigen::Vector1d::Constant( TUDAT_NAN ) ) override;
+
+protected:
+    //! Partial object for the n-way range observable defined on the same link ends.
+    std::shared_ptr< NWayRangePartial > nWayRangePartial_;
+
+    //! Function computing the factor scaling n-way range partials to DSN n-way range partials.
+    const std::function< double( const std::vector< double >&,
+                                 const std::shared_ptr< observation_models::ObservationAncillarySimulationSettings > ) >
+            scalingFactorFunction_;
+};
+
+}  // namespace observation_partials
+
+}  // namespace tudat
+
+#endif  // TUDAT_DSNNWAYRANGEPARTIAL_H

--- a/include/tudat/simulation/estimation_setup/createNWayRangePartials.h
+++ b/include/tudat/simulation/estimation_setup/createNWayRangePartials.h
@@ -16,11 +16,14 @@
 #include <memory>
 #include <vector>
 
+#include "tudat/astro/observation_models/dsnNWayRangeObservationModel.h"
 #include "tudat/astro/observation_models/linkTypeDefs.h"
 #include "tudat/astro/observation_models/observableTypes.h"
+#include "tudat/astro/orbit_determination/observation_partials/dsnNWayRangePartial.h"
 #include "tudat/astro/orbit_determination/observation_partials/nWayRangePartial.h"
 #include "tudat/math/interpolators/interpolator.h"
 #include "tudat/simulation/estimation_setup/createDirectObservationPartials.h"
+#include "tudat/simulation/estimation_setup/createLightTimeCorrection.h"
 #include "tudat/simulation/estimation_setup/createObservationBiasPartial.h"
 
 namespace tudat
@@ -178,6 +181,102 @@ std::pair< SingleLinkObservationPartialList, std::shared_ptr< PositionPartialSca
     }
 
     return std::make_pair( nWayRangePartialList, nWayRangeScaler );
+}
+
+//! Function to generate DSN n-way range partials and associated scaler for single link ends.
+/*!
+ *  Function to generate DSN n-way (sequential) range partials and associated scaler for all parameters that are
+ *  to be estimated, for a single link ends set. The partials are created as the partials of an equivalent n-way
+ *  range observable (defined on the same link ends and light time calculator), scaled by the factor converting a
+ *  range change in meters to a change of the observable in range units (Moyer (2003), eq. 13-128).
+ *  \param observationModel DSN n-way range observation model for which partials are to be created.
+ *  \param bodies List of all bodies, for creating the partials.
+ *  \param parametersToEstimate Set of parameters that are to be estimated.
+ *  \return Set of observation partials with associated indices in complete vector of parameters that are
+ *  estimated, and NWayRangeScaling object, used for scaling the position partial members of the partials.
+ */
+template< typename ParameterType, typename TimeType >
+std::pair< SingleLinkObservationPartialList, std::shared_ptr< PositionPartialScaling > > createDsnNWayRangePartials(
+        const std::shared_ptr< observation_models::ObservationModel< 1, ParameterType, TimeType > > observationModel,
+        const simulation_setup::SystemOfBodies& bodies,
+        const std::shared_ptr< estimatable_parameters::EstimatableParameterSet< ParameterType > > parametersToEstimate )
+{
+    using namespace observation_models;
+
+    auto dsnNWayRangeObservationModel =
+            std::dynamic_pointer_cast< observation_models::DsnNWayRangeObservationModel< ParameterType, TimeType > >( observationModel );
+    if( dsnNWayRangeObservationModel == nullptr )
+    {
+        throw std::runtime_error(
+                "Error when creating DSN n-way range partials; input observation model is not DSN "
+                "n-way range" );
+    }
+
+    observation_models::LinkEnds linkEnds = dsnNWayRangeObservationModel->getLinkEnds( );
+
+    // Create partials of equivalent n-way range observable, defined on the same light time calculator. Partials
+    // w.r.t. link properties (e.g. observation biases) are suppressed here (they are created at the level of the
+    // DSN n-way range observable, without frequency scaling).
+    auto equivalentNWayRangeModel = std::make_shared< observation_models::NWayRangeObservationModel< ParameterType, TimeType > >(
+            linkEnds, dsnNWayRangeObservationModel->getLightTimeCalculator( ) );
+    std::pair< SingleLinkObservationPartialList, std::shared_ptr< PositionPartialScaling > > nWayRangePartials =
+            createNWayRangePartials< ParameterType, TimeType >( equivalentNWayRangeModel, bodies, parametersToEstimate, true );
+
+    // Create function returning the transmitted frequency of the transmitting ground station (passing the first
+    // retransmitter as receiving link end ensures that no transponder turnaround ratios are applied).
+    const std::function< double( std::vector< FrequencyBands >, double ) > transmittedFrequencyFunction =
+            createLinkFrequencyFunction( bodies, linkEnds, observation_models::transmitter, observation_models::retransmitter );
+    const std::shared_ptr< earth_orientation::TerrestrialTimeScaleConverter > timeScaleConverter =
+            dsnNWayRangeObservationModel->getTimeScaleConverter( );
+
+    const std::function< double( const std::vector< double >&,
+                                 const std::shared_ptr< observation_models::ObservationAncillarySimulationSettings > ) >
+            scalingFactorFunction =
+                    [ transmittedFrequencyFunction, timeScaleConverter ](
+                            const std::vector< double >& linkEndTimes,
+                            const std::shared_ptr< observation_models::ObservationAncillarySimulationSettings > ancillarySettings ) {
+                        return getDsnNWayRangeScalingFactor(
+                                transmittedFrequencyFunction, timeScaleConverter, linkEndTimes, ancillarySettings );
+                    };
+
+    // Scale n-way range partials (in meters) to DSN n-way range partials (in range units)
+    SingleLinkObservationPartialList dsnNWayRangePartialList;
+    for( auto const& [ partialKey, partialValue ] : nWayRangePartials.first )
+    {
+        auto const& nWayRangePartial = std::dynamic_pointer_cast< NWayRangePartial >( partialValue );
+        if( nWayRangePartial == nullptr )
+        {
+            throw std::runtime_error(
+                    "Error when creating DSN n-way range partials; constituent n-way range partial "
+                    "is of incompatible type" );
+        }
+        dsnNWayRangePartialList[ partialKey ] = std::make_shared< DsnNWayRangePartial >( nWayRangePartial, scalingFactorFunction );
+    }
+
+    // Create partials w.r.t. link properties (e.g. observation biases) of the DSN n-way range observable; these
+    // are not scaled by the frequency factor.
+    std::map< int, std::shared_ptr< estimatable_parameters::EstimatableParameter< Eigen::VectorXd > > > vectorParametersToEstimate =
+            parametersToEstimate->getVectorParameters( );
+    for( auto const& [ parameterIndex, parameter ] : vectorParametersToEstimate )
+    {
+        std::shared_ptr< ObservationPartial< 1 > > currentDsnNWayRangePartial;
+        if( isParameterObservationLinkProperty( parameter->getParameterName( ).first ) &&
+            !isParameterObservationLinkTimeProperty( parameter->getParameterName( ).first ) )
+        {
+            currentDsnNWayRangePartial =
+                    createObservationPartialWrtLinkProperty< 1 >( linkEnds, observation_models::dsn_n_way_range, parameter, bodies );
+        }
+
+        // Check if partial is non-nullptr
+        if( currentDsnNWayRangePartial != nullptr )
+        {
+            // Add partial to the list.
+            std::pair< int, int > currentPair = std::make_pair( parameterIndex, parameter->getParameterSize( ) );
+            dsnNWayRangePartialList[ currentPair ] = currentDsnNWayRangePartial;
+        }
+    }
+
+    return std::make_pair( dsnNWayRangePartialList, nWayRangePartials.second );
 }
 
 }  // namespace observation_partials

--- a/include/tudat/simulation/estimation_setup/createObservationPartials.h
+++ b/include/tudat/simulation/estimation_setup/createObservationPartials.h
@@ -233,6 +233,20 @@ public:
                 observationPartials = createDifferencedObservablePartials< ObservationScalarType, TimeType, 1 >(
                         observationModel, bodies, parametersToEstimate );
                 break;
+            case observation_models::dsn_n_way_range:
+                if( isPartialForDifferencedObservable )
+                {
+                    throw std::runtime_error(
+                            "Error when requesting partial creation for DSN n-way range; differenced partial not supported" );
+                }
+                if( isPartialForConcatenatedObservable )
+                {
+                    throw std::runtime_error(
+                            "Error when requesting partial creation for DSN n-way range; concatenated partial not supported" );
+                }
+                observationPartials =
+                        createDsnNWayRangePartials< ObservationScalarType, TimeType >( observationModel, bodies, parametersToEstimate );
+                break;
             default:
                 std::string errorMessage = "Error when making observation partial set, could not recognize observable " +
                         std::to_string( observationModel->getObservableType( ) ) + " of size 1 ";

--- a/src/tudat/astro/orbit_determination/observation_partials/CMakeLists.txt
+++ b/src/tudat/astro/orbit_determination/observation_partials/CMakeLists.txt
@@ -18,6 +18,7 @@ set(observation_partials_SOURCES
   "oneWayRangePartial.cpp"
   "twoWayDopplerPartial.cpp"
   "nWayRangePartial.cpp"
+  "dsnNWayRangePartial.cpp"
   "oneWayDopplerPartial.cpp"
   "relativeAngularPositionPartial.cpp"
   "observationPartial.cpp"

--- a/src/tudat/astro/orbit_determination/observation_partials/dsnNWayRangePartial.cpp
+++ b/src/tudat/astro/orbit_determination/observation_partials/dsnNWayRangePartial.cpp
@@ -1,0 +1,121 @@
+/*    Copyright (c) 2010-2023, Delft University of Technology
+ *    All rigths reserved
+ *
+ *    This file is part of the Tudat. Redistribution and use in source and
+ *    binary forms, with or without modification, are permitted exclusively
+ *    under the terms of the Modified BSD license. You should have received
+ *    a copy of the license with this file. If not, please or visit:
+ *    http://tudat.tudelft.nl/LICENSE.
+ *
+ *    References:
+ *          T. Moyer (2003), Formulation for Observed and Computed Values of Deep Space Network Data
+ * Types for Navigation, DEEP SPACE COMMUNICATIONS AND NAVIGATION SERIES, JPL/NASA
+ */
+
+#include <functional>
+#include <memory>
+
+#include <Eigen/Core>
+
+#include "tudat/astro/basic_astro/physicalConstants.h"
+#include "tudat/astro/earth_orientation/terrestrialTimeScaleConverter.h"
+#include "tudat/astro/observation_models/dsnNWayRangeObservationModel.h"
+#include "tudat/astro/observation_models/observationAncillarySettings.h"
+#include "tudat/astro/observation_models/observationFrequencies.h"
+#include "tudat/astro/orbit_determination/observation_partials/dsnNWayRangePartial.h"
+
+namespace tudat
+{
+
+namespace observation_partials
+{
+
+double getDsnNWayRangeScalingFactor(
+        const std::function< double( std::vector< observation_models::FrequencyBands >, double ) > transmittedFrequencyFunction,
+        const std::shared_ptr< earth_orientation::TerrestrialTimeScaleConverter > timeScaleConverter,
+        const std::vector< double >& linkEndTimes,
+        const std::shared_ptr< observation_models::ObservationAncillarySimulationSettings > ancillarySettings )
+{
+    if( ancillarySettings == nullptr )
+    {
+        throw std::runtime_error(
+                "Error when computing DSN N-way range partials scaling factor; no ancillary "
+                "settings found. " );
+    }
+
+    std::vector< observation_models::FrequencyBands > frequencyBands;
+    try
+    {
+        frequencyBands = observation_models::convertDoubleVectorToFrequencyBands(
+                ancillarySettings->getAncillaryDoubleVectorData( observation_models::frequency_bands ) );
+    }
+    catch( std::runtime_error& caughtException )
+    {
+        throw std::runtime_error( "Error when retrieving ancillary settings for DSN N-way range partial: " +
+                                  std::string( caughtException.what( ) ) );
+    }
+
+    if( frequencyBands.empty( ) )
+    {
+        throw std::runtime_error(
+                "Error when computing DSN N-way range partials scaling factor; no frequency bands "
+                "found in ancillary settings." );
+    }
+    double conversionFactor = observation_models::getDsnRangeUnitConversionFactor( frequencyBands.at( 0 ) );
+
+    double utcTransmissionTime = timeScaleConverter->getCurrentTime< double >(
+            basic_astrodynamics::tdb_scale, basic_astrodynamics::utc_scale, linkEndTimes.at( 0 ), Eigen::Vector3d::Zero( ) );
+    double transmittedFrequency = transmittedFrequencyFunction( frequencyBands, utcTransmissionTime );
+
+    return conversionFactor * transmittedFrequency / physical_constants::getSpeedOfLight< double >( );
+}
+
+DsnNWayRangePartial::DsnNWayRangePartial(
+        const std::shared_ptr< NWayRangePartial > nWayRangePartial,
+        const std::function< double( const std::vector< double >&,
+                                     const std::shared_ptr< observation_models::ObservationAncillarySimulationSettings > ) >
+                scalingFactorFunction ):
+    ObservationPartial< 1 >( nWayRangePartial->getParameterIdentifier( ) ), nWayRangePartial_( nWayRangePartial ),
+    scalingFactorFunction_( scalingFactorFunction )
+{}
+
+//! Function to calculate the observation partial(s) at required time and state
+/*!
+ *  Function to calculate the observation partial(s) at required time and state. State and time
+ *  are typically obtained from evaluation of observation model.
+ *  \param states Link end states. Index maps to link end for a given ObsevableType through getLinkEndIndex function.
+ *  \param times Link end time.
+ *  \param linkEndOfFixedTime Link end that is kept fixed when computing the observable.
+ *  \param ancillarySettings Observation ancillary simulation settings.
+ *  \param currentObservation Value of the observation for which the partial is to be computed.
+ *  \return Vector of pairs containing partial values and associated times.
+ */
+std::vector< std::pair< Eigen::Matrix< double, 1, Eigen::Dynamic >, double > > DsnNWayRangePartial::calculatePartial(
+        const std::vector< Eigen::Vector6d >& states,
+        const std::vector< double >& times,
+        const observation_models::LinkEndType linkEndOfFixedTime,
+        const std::shared_ptr< observation_models::ObservationAncillarySimulationSettings > ancillarySettings,
+        const Eigen::Vector1d& currentObservation )
+{
+    // The observation model (and hence the scaling factor computation) is only valid for observations
+    // referenced to the reception time
+    if( linkEndOfFixedTime != observation_models::receiver )
+    {
+        throw std::runtime_error( "Error when computing DSN N-way range partials: the selected reference link end (" +
+                                  observation_models::getLinkEndTypeString( linkEndOfFixedTime ) + ") is not valid." );
+    }
+
+    std::vector< std::pair< Eigen::Matrix< double, 1, Eigen::Dynamic >, double > > scaledPartials =
+            nWayRangePartial_->calculatePartial( states, times, linkEndOfFixedTime, ancillarySettings, currentObservation );
+
+    double scalingFactor = scalingFactorFunction_( times, ancillarySettings );
+    for( auto& scaledPartial : scaledPartials )
+    {
+        scaledPartial.first *= scalingFactor;
+    }
+    return scaledPartials;
+}
+
+}  // namespace observation_partials
+
+}  // namespace tudat

--- a/tests/test_tudat/include/tudat/support/observationPartialTestFunctions.h
+++ b/tests/test_tudat/include/tudat/support/observationPartialTestFunctions.h
@@ -214,6 +214,11 @@ void testObservationPartials(
             runSimulation = false;
         }
 
+        if( observableType == observation_models::dsn_n_way_range && linkEndIterator->first != receiver )
+        {
+            runSimulation = false;
+        }
+
         if( observableType == observation_models::differenced_time_of_arrival && linkEndIterator->first != receiver )
         {
             runSimulation = false;

--- a/tests/test_tudat/src/astro/orbit_determination/observation_partials/CMakeLists.txt
+++ b/tests/test_tudat/src/astro/orbit_determination/observation_partials/CMakeLists.txt
@@ -106,6 +106,12 @@ TUDAT_ADD_TEST_CASE(RelativeAngularPositionPartials
         tudat_test_support
         ${Tudat_ESTIMATION_LIBRARIES}
         )
+
+ TUDAT_ADD_TEST_CASE(DsnNWayRangePartials
+        PRIVATE_LINKS
+        tudat_test_support
+        ${Tudat_ESTIMATION_LIBRARIES}
+        )
 TUDAT_ADD_TEST_CASE(RelativePositionPartials
      PRIVATE_LINKS
      tudat_test_support

--- a/tests/test_tudat/src/astro/orbit_determination/observation_partials/unitTestDsnNWayRangePartials.cpp
+++ b/tests/test_tudat/src/astro/orbit_determination/observation_partials/unitTestDsnNWayRangePartials.cpp
@@ -1,0 +1,184 @@
+/*    Copyright (c) 2010-2023, Delft University of Technology
+ *    All rigths reserved
+ *
+ *    This file is part of the Tudat. Redistribution and use in source and
+ *    binary forms, with or without modification, are permitted exclusively
+ *    under the terms of the Modified BSD license. You should have received
+ *    a copy of the license with this file. If not, please or visit:
+ *    http://tudat.tudelft.nl/LICENSE.
+ *
+ */
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MAIN
+
+#include <string>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+#include "tudat/io/basicInputOutput.h"
+#include "tudat/io/readOdfFile.h"
+#include "tudat/simulation/estimation_setup/processOdfFile.h"
+#include "tudat/simulation/estimation_setup/createObservationModelFactory.h"
+
+#include "tudat/support/observationPartialTestFunctions.h"
+
+namespace tudat
+{
+namespace unit_tests
+{
+
+using namespace tudat::gravitation;
+using namespace tudat::ephemerides;
+using namespace tudat::observation_models;
+using namespace tudat::simulation_setup;
+using namespace tudat::spice_interface;
+using namespace tudat::observation_partials;
+using namespace tudat::estimatable_parameters;
+using namespace tudat::input_output;
+
+BOOST_AUTO_TEST_SUITE( test_dsn_n_way_range_observation_partials )
+
+std::vector< double > getRetransmissionDelays( const double evaluationTime, const int numberOfRetransmitters )
+{
+    std::vector< double > retransmissionDelays;
+
+    for( int i = 0; i < numberOfRetransmitters; i++ )
+    {
+        retransmissionDelays.push_back( evaluationTime * 5.0E-17 * static_cast< double >( i + 1 ) );
+    }
+    return retransmissionDelays;
+}
+
+//! Test partial derivatives of DSN N-way range observable, using general test suite of observation partials.
+BOOST_AUTO_TEST_CASE( testDsnNWayRangePartials )
+{
+    Eigen::VectorXd parameterPerturbationMultipliers = ( Eigen::VectorXd( 4 ) << 1000.0, 1000.0, 1.0, 100.0 ).finished( );
+
+    // Define and create ground stations.
+    std::vector< std::pair< std::string, std::string > > groundStations;
+    groundStations.resize( 2 );
+    groundStations[ 0 ] = std::make_pair( "Earth", "DSS-55" );
+    groundStations[ 1 ] = std::make_pair( "Mars", "MSL" );
+
+    double initialEphemerisTime = 544845633.0;
+    double finalEphemerisTime = 544869060.0;
+    double stateEvaluationTime = initialEphemerisTime + 8.0e3;
+
+    // Use a large lowest ranging component, such that the modulo term of the observable is much larger than the
+    // observable changes due to the numerical perturbations (preventing wrapping of the perturbed observables).
+    double lowestRangingComponent = 30.0;
+
+    // Read ODF file - used just for the automatic creation of ground station ramp frequency calculator
+    auto rawOdfFileContents =
+            std::make_shared< OdfRawFileContents >( tudat::paths::getTudatTestDataPath( ) + "mromagr2017_097_1335xmmmv1.odf" );
+
+    // Test partials with constant ephemerides (allows test of position partials)
+    {
+        // Create environment
+        SystemOfBodies bodies = setupEnvironment( groundStations, initialEphemerisTime, finalEphemerisTime, stateEvaluationTime, true );
+
+        // Process ODF file
+        auto const& processedOdfFileContents = std::make_shared< ProcessedOdfFileContents< Time > >( rawOdfFileContents, "MSL", true );
+        // Create ground stations
+        setTransmittingFrequenciesInGroundStations( processedOdfFileContents, bodies.getBody( "Earth" ) );
+        // Set turnaround ratios in spacecraft (ground station)
+        auto vehicleSystems = std::make_shared< system_models::VehicleSystems >( );
+        vehicleSystems->setTransponderTurnaroundRatio( &getDsnDefaultTurnaroundRatios );
+        bodies.getBody( "Mars" )->getGroundStation( "MSL" )->setVehicleSystems( vehicleSystems );
+
+        // Set link ends for observation model
+        LinkEnds linkEnds;
+        linkEnds[ transmitter ] = groundStations[ 0 ];
+        linkEnds[ retransmitter ] = groundStations[ 1 ];
+        linkEnds[ receiver ] = groundStations[ 0 ];
+
+        // Generate DSN n-way range model
+        std::vector< std::string > perturbingBodies;
+        perturbingBodies.push_back( "Earth" );
+        std::vector< std::shared_ptr< LightTimeCorrectionSettings > > lightTimeCorrectionsList;
+        lightTimeCorrectionsList.push_back( std::make_shared< FirstOrderRelativisticLightTimeCorrectionSettings >( perturbingBodies ) );
+
+        std::shared_ptr< ObservationModel< 1, double, Time > > dsnNWayRangeModel =
+                observation_models::ObservationModelCreator< 1, double, Time >::createObservationModel(
+                        std::make_shared< observation_models::DsnNWayRangeObservationModelSettings >( linkEnds, lightTimeCorrectionsList ),
+                        bodies );
+
+        // Create parameter objects.
+        std::shared_ptr< EstimatableParameterSet< double > > fullEstimatableParameterSet =
+                createEstimatableParameters( bodies, stateEvaluationTime );
+
+        testObservationPartials< 1 >( dsnNWayRangeModel,
+                                      bodies,
+                                      fullEstimatableParameterSet,
+                                      linkEnds,
+                                      dsn_n_way_range,
+                                      1.0E-4,
+                                      true,
+                                      true,
+                                      1.0E-2,
+                                      parameterPerturbationMultipliers,
+                                      getDsnNWayRangeAncillarySettings( std::vector< FrequencyBands >{ x_band, x_band },
+                                                                        lowestRangingComponent,
+                                                                        getRetransmissionDelays( initialEphemerisTime, 1 ) ),
+                                      stateEvaluationTime );
+    }
+
+    // Test partials with real ephemerides (without test of position partials)
+    {
+        // Create environment
+        SystemOfBodies bodies = setupEnvironment( groundStations, initialEphemerisTime, finalEphemerisTime, stateEvaluationTime, false );
+
+        // Process ODF file
+        auto const& processedOdfFileContents = std::make_shared< ProcessedOdfFileContents< Time > >( rawOdfFileContents, "MSL", true );
+        // Create ground stations
+        setTransmittingFrequenciesInGroundStations( processedOdfFileContents, bodies.getBody( "Earth" ) );
+        // Set turnaround ratios in spacecraft (ground station)
+        auto vehicleSystems = std::make_shared< system_models::VehicleSystems >( );
+        vehicleSystems->setTransponderTurnaroundRatio( &getDsnDefaultTurnaroundRatios );
+        bodies.getBody( "Mars" )->getGroundStation( "MSL" )->setVehicleSystems( vehicleSystems );
+
+        // Set link ends for observation model
+        LinkEnds linkEnds;
+        linkEnds[ transmitter ] = groundStations[ 0 ];
+        linkEnds[ retransmitter ] = groundStations[ 1 ];
+        linkEnds[ receiver ] = groundStations[ 0 ];
+
+        // Generate DSN n-way range model
+        std::vector< std::string > perturbingBodies;
+        perturbingBodies.push_back( "Earth" );
+        std::vector< std::shared_ptr< LightTimeCorrectionSettings > > lightTimeCorrectionsList;
+        lightTimeCorrectionsList.push_back( std::make_shared< FirstOrderRelativisticLightTimeCorrectionSettings >( perturbingBodies ) );
+
+        std::shared_ptr< ObservationModel< 1, double, Time > > dsnNWayRangeModel =
+                observation_models::ObservationModelCreator< 1, double, Time >::createObservationModel(
+                        std::make_shared< observation_models::DsnNWayRangeObservationModelSettings >( linkEnds, lightTimeCorrectionsList ),
+                        bodies );
+
+        // Create parameter objects.
+        std::shared_ptr< EstimatableParameterSet< double > > fullEstimatableParameterSet =
+                createEstimatableParameters( bodies, stateEvaluationTime );
+
+        testObservationPartials< 1 >( dsnNWayRangeModel,
+                                      bodies,
+                                      fullEstimatableParameterSet,
+                                      linkEnds,
+                                      dsn_n_way_range,
+                                      1.0E-4,
+                                      false,
+                                      true,
+                                      1.0E-2,
+                                      parameterPerturbationMultipliers,
+                                      getDsnNWayRangeAncillarySettings( std::vector< FrequencyBands >{ x_band, x_band },
+                                                                        lowestRangingComponent,
+                                                                        getRetransmissionDelays( initialEphemerisTime, 1 ) ),
+                                      stateEvaluationTime );
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END( )
+
+}  // namespace unit_tests
+
+}  // namespace tudat

--- a/tests/test_tudat/src/astro/orbit_determination/observation_partials/unitTestDsnNWayRangePartials.cpp
+++ b/tests/test_tudat/src/astro/orbit_determination/observation_partials/unitTestDsnNWayRangePartials.cpp
@@ -54,7 +54,9 @@ std::vector< double > getRetransmissionDelays( const double evaluationTime, cons
 //! Test partial derivatives of DSN N-way range observable, using general test suite of observation partials.
 BOOST_AUTO_TEST_CASE( testDsnNWayRangePartials )
 {
-    Eigen::VectorXd parameterPerturbationMultipliers = ( Eigen::VectorXd( 4 ) << 1000.0, 1000.0, 1.0, 100.0 ).finished( );
+    const double tolerance = 5.0E-7;
+    const double positionPerturbationMultiplier = 5.0E0;
+    Eigen::VectorXd parameterPerturbationMultipliers = ( Eigen::VectorXd( 4 ) << 1.0E3, 5.0E2, 2.0E0, 1.0E1 ).finished( );
 
     // Define and create ground stations.
     std::vector< std::pair< std::string, std::string > > groundStations;
@@ -114,10 +116,10 @@ BOOST_AUTO_TEST_CASE( testDsnNWayRangePartials )
                                       fullEstimatableParameterSet,
                                       linkEnds,
                                       dsn_n_way_range,
-                                      1.0E-4,
+                                      tolerance,
                                       true,
                                       true,
-                                      1.0E-2,
+                                      positionPerturbationMultiplier,
                                       parameterPerturbationMultipliers,
                                       getDsnNWayRangeAncillarySettings( std::vector< FrequencyBands >{ x_band, x_band },
                                                                         lowestRangingComponent,
@@ -165,10 +167,10 @@ BOOST_AUTO_TEST_CASE( testDsnNWayRangePartials )
                                       fullEstimatableParameterSet,
                                       linkEnds,
                                       dsn_n_way_range,
-                                      1.0E-4,
+                                      tolerance,
                                       false,
                                       true,
-                                      1.0E-2,
+                                      positionPerturbationMultiplier,
                                       parameterPerturbationMultipliers,
                                       getDsnNWayRangeAncillarySettings( std::vector< FrequencyBands >{ x_band, x_band },
                                                                         lowestRangingComponent,


### PR DESCRIPTION
First draft of DSN n-way range partials.
The partials for the _DSN_ n-way range model are implemented as scaling factors to the partials of the n-way range model, which already implements the partials of the precise light time. The scaling factors then account for the conversion from meters in the n-way range partials to Range Units in the DSN n-way range model, according to Moyer (2003), eq. 13-128.
The unit test follows the DSN n-way doppler unit test but needs more checking for the tolerance settings.