### PR TITLE
Fix sporadic Windows observation viability test failure

### DIFF
--- a/src/tudat/astro/observation_models/observationViabilityCalculator.cpp
+++ b/src/tudat/astro/observation_models/observationViabilityCalculator.cpp
@@ -192,35 +192,22 @@ bool computeOccultation( const Eigen::Vector3d observer1Position,
                          const Eigen::Vector3d occulterPosition,
                          const double radius )
 {
-    double observerRelativeDistance = ( observer2Position - observer1Position ).norm( );
-    double observer1OcculterDistance = ( occulterPosition - observer1Position ).norm( );
-    double observer2OcculterDistance = ( occulterPosition - observer2Position ).norm( );
+    const Eigen::Vector3d linkVector = observer2Position - observer1Position;
+    const Eigen::Vector3d observer1ToOcculter = occulterPosition - observer1Position;
+    const double linkLengthSquared = linkVector.squaredNorm( );
+    const double projectedDistanceAlongLink = observer1ToOcculter.dot( linkVector );
 
-    double cosineBody1Angle =
-            -( observer1OcculterDistance * observer1OcculterDistance - observer2OcculterDistance * observer2OcculterDistance -
-               observerRelativeDistance * observerRelativeDistance ) /
-            ( 2.0 * observer2OcculterDistance * observerRelativeDistance );
-    double cosineBody2Angle =
-            -( observer2OcculterDistance * observer2OcculterDistance - observer1OcculterDistance * observer1OcculterDistance -
-               observerRelativeDistance * observerRelativeDistance ) /
-            ( 2.0 * observer1OcculterDistance * observerRelativeDistance );
-
-    if( cosineBody1Angle < 0.0 || cosineBody2Angle < 0.0 )
+    // Preserve the existing segment semantics: an occultation is only possible when the closest
+    // point lies on the link segment.
+    if( linkLengthSquared == 0.0 || projectedDistanceAlongLink < 0.0 || projectedDistanceAlongLink > linkLengthSquared )
     {
         return false;
     }
-    else
-    {
-        double distanceToTest = observer2OcculterDistance * std::sqrt( 1.0 - cosineBody1Angle * cosineBody1Angle );
-        if( distanceToTest < radius )
-        {
-            return true;
-        }
-        else
-        {
-            return false;
-        }
-    }
+
+    // Avoid the catastrophic cancellation that occurs in a law-of-cosines formulation when one
+    // link end is many orders of magnitude farther from the occulter than the other.
+    const double distanceToLink = observer1ToOcculter.cross( linkVector.normalized( ) ).norm( );
+    return distanceToLink < radius;
 }
 
 //! Function for determining whether the link is occulted during the observataion.

--- a/tests/test_tudat/src/astro/observation_models/unitTestObservationViabilityCalculators.cpp
+++ b/tests/test_tudat/src/astro/observation_models/unitTestObservationViabilityCalculators.cpp
@@ -37,6 +37,35 @@ using namespace tudat::unit_conversions;
 
 BOOST_AUTO_TEST_SUITE( test_observation_viability_calculators )
 
+BOOST_AUTO_TEST_CASE( testInterplanetaryOccultationNumericalStability )
+{
+    const double earthRadius = 5.0E6;
+    const double spacecraftOrbitalRadius = earthRadius + 10.0;
+    const double spacecraftXPosition = -14169.6;
+
+    Eigen::Vector3d spacecraftPosition =
+            ( Eigen::Vector3d( ) << spacecraftXPosition,
+              std::sqrt( spacecraftOrbitalRadius * spacecraftOrbitalRadius - spacecraftXPosition * spacecraftXPosition ),
+              0.0 )
+                    .finished( );
+    Eigen::Vector3d distantBodyPosition = ( Eigen::Vector3d( ) << 1.0E12, 0.0, 0.0 ).finished( );
+
+    // Squared-distance forms of this calculation suffer catastrophic cancellation at interplanetary
+    // distances and have sporadically classified this near-limb geometry as viable on Windows.
+    BOOST_CHECK( computeOccultation( spacecraftPosition, distantBodyPosition, Eigen::Vector3d::Zero( ), earthRadius ) );
+    BOOST_CHECK( computeOccultation( distantBodyPosition, spacecraftPosition, Eigen::Vector3d::Zero( ), earthRadius ) );
+
+    spacecraftPosition( 0 ) = -5000.0;
+    spacecraftPosition( 1 ) =
+            std::sqrt( spacecraftOrbitalRadius * spacecraftOrbitalRadius - spacecraftPosition( 0 ) * spacecraftPosition( 0 ) );
+    BOOST_CHECK( !computeOccultation( spacecraftPosition, distantBodyPosition, Eigen::Vector3d::Zero( ), earthRadius ) );
+
+    spacecraftPosition( 0 ) = -spacecraftXPosition;
+    spacecraftPosition( 1 ) =
+            std::sqrt( spacecraftOrbitalRadius * spacecraftOrbitalRadius - spacecraftPosition( 0 ) * spacecraftPosition( 0 ) );
+    BOOST_CHECK( !computeOccultation( spacecraftPosition, distantBodyPosition, Eigen::Vector3d::Zero( ), earthRadius ) );
+}
+
 BOOST_AUTO_TEST_CASE( testSeparateObservationViabilityCalculators )
 {
     // Load spice kernels.
@@ -1211,11 +1240,7 @@ BOOST_AUTO_TEST_CASE( testOrbiterOccultationObservationViabilityCalculators )
                         BOOST_CHECK_SMALL( std::fabs( rotatedJupiter( 1 ) ), 1.0E-3 );
                         BOOST_CHECK_SMALL( std::fabs( rotatedJupiter( 2 ) ), 1.0E-3 );
 
-                        // Define tolerance for ambiguous cases near zero
-                        double tolerance = 10.0 * std::numeric_limits< double >::epsilon( ) * rotatedSpacecraft.norm( );
-
-                        // Skip ambiguous region near 0 (test on tolerance, not 0)
-                        if( rotatedSpacecraft( 0 ) < tolerance )
+                        if( rotatedSpacecraft( 0 ) < 0.0 )
                         {
                             currentObservationIsViable = false;
                         }


### PR DESCRIPTION
The observation viability calculator test occasionally fails on Windows because the occultation calculation uses a law-of-cosines formulation involving differences between squared interplanetary distances. This is susceptible to catastrophic cancellation and can produce platform-dependent occultation results.

This PR:
• Replaces the unstable calculation with a projection and cross-product formulation.
• Adds regression cases using interplanetary, near-limb geometry based on the observed CI failure.
• Removes the ineffective tolerance adjustment left by the earlier attempt in #412.

Closes #613 