### PR TITLE
Complement and Expose TLE Fitting Functionality

### DIFF
--- a/include/tudat/astro/ephemerides/tleEphemeris.h
+++ b/include/tudat/astro/ephemerides/tleEphemeris.h
@@ -178,6 +178,45 @@ public:
         return rawLine2_;
     }
 
+    //! (Re)compute the raw two-line-element text representation from the stored numerical parameters.
+    /*!
+     * Formats the current numerical TLE parameters (epoch, mean elements, B*, identification fields, ...) into a
+     * standard fixed-width, checksummed 69-character two-line element set, and stores the result in rawLine1_ /
+     * rawLine2_. This is needed whenever a Tle was built from numerical elements rather than parsed from TLE text
+     * (e.g. the constructor taking epoch/bStar/inclination/.../meanMotion, or a TLE produced by
+     * fitTleToCartesianStateHistory), since those construction paths never populate the raw lines themselves.
+     * Identification fields that were never set (NORAD catalog number, international designator, element set
+     * number, ...) are serialized using their default values.
+     */
+    void computeRawLines( );
+
+    //! Set identification/administrative fields that cannot be derived from orbital elements alone (e.g. by
+    //! fitTleToCartesianStateHistory, which fits only a Cartesian state history and has no catalog to consult).
+    /*!
+     * Does not itself refresh rawLine1_/rawLine2_: call computeRawLines() afterwards to serialize the new values.
+     * @param noradCatalogNumber NORAD catalog number.
+     * @param classification Security classification character (typically 'U', 'C' or 'S').
+     * @param internationalDesignatorLaunchYear International designator launch year (2- or 4-digit; only the last
+     * two digits are serialized).
+     * @param internationalDesignatorLaunchNumber International designator launch number.
+     * @param internationalDesignatorPiece International designator launch piece (up to 3 characters).
+     * @param elementSetNumber Element set number.
+     */
+    void setIdentification( const int noradCatalogNumber,
+                            const char classification,
+                            const int internationalDesignatorLaunchYear,
+                            const int internationalDesignatorLaunchNumber,
+                            const std::string& internationalDesignatorPiece,
+                            const int elementSetNumber )
+    {
+        noradCatalogNumber_ = noradCatalogNumber;
+        classification_ = classification;
+        internationalDesignatorLaunchYear_ = internationalDesignatorLaunchYear;
+        internationalDesignatorLaunchNumber_ = internationalDesignatorLaunchNumber;
+        internationalDesignatorPiece_ = internationalDesignatorPiece;
+        elementSetNumber_ = elementSetNumber;
+    }
+
 private:
     basic_astrodynamics::DateTime referenceDate_;
     double epoch_;

--- a/include/tudat/astro/ephemerides/tleEphemeris.h
+++ b/include/tudat/astro/ephemerides/tleEphemeris.h
@@ -143,6 +143,21 @@ public:
         return classification_;
     }
 
+    int getInternationalDesignatorLaunchYear( ) const
+    {
+        return internationalDesignatorLaunchYear_;
+    }
+
+    int getInternationalDesignatorLaunchNumber( ) const
+    {
+        return internationalDesignatorLaunchNumber_;
+    }
+
+    std::string getInternationalDesignatorPiece( ) const
+    {
+        return internationalDesignatorPiece_;
+    }
+
     int getElementSetNumber( ) const
     {
         return elementSetNumber_;

--- a/include/tudat/astro/ephemerides/tleFitting.h
+++ b/include/tudat/astro/ephemerides/tleFitting.h
@@ -77,11 +77,32 @@ struct TleFitSettings {
 
     //! Scaled B* step; with bStarScale_=1.0e-4 this is 1.0e-7 in B*, Vallado and Crawford's absolute fallback size.
     double bStarStep_ = 1.0e-3;
+
+    //! NORAD catalog number to embed in the fitted TLE's identification fields. Not derivable from a Cartesian
+    //! state history; defaults to 0 (serialized as "00000") when left unset.
+    int noradCatalogNumber_ = 0;
+
+    //! Security classification character to embed (typically 'U' for unclassified, or 'C'/'S').
+    char classification_ = 'U';
+
+    //! International designator launch year to embed (either 2- or 4-digit; only the last two digits are used).
+    int internationalDesignatorLaunchYear_ = 0;
+
+    //! International designator launch number to embed.
+    int internationalDesignatorLaunchNumber_ = 0;
+
+    //! International designator launch piece to embed (up to 3 characters, space-padded if shorter).
+    std::string internationalDesignatorPiece_ = "";
+
+    //! Element set number to embed in the fitted TLE.
+    int elementSetNumber_ = 0;
 };
 
 //! Result of a Cartesian-state-history-to-TLE fit.
 struct TleFitResult {
-    //! Full-precision fitted TLE. Its raw line strings are empty because no TLE text serialization is performed.
+    //! Full-precision fitted TLE. Its raw line strings are populated (via Tle::computeRawLines) from the fitted
+    //! numerical elements once fitting completes; identification fields that were never set (NORAD catalog number,
+    //! international designator, element set number, ...) are serialized using their default values.
     std::shared_ptr< Tle > fittedTle_;
 
     //! Position residuals (input state position minus fitted SGP4 position), in metres.

--- a/src/tudat/astro/ephemerides/tleEphemeris.cpp
+++ b/src/tudat/astro/ephemerides/tleEphemeris.cpp
@@ -12,10 +12,14 @@
 #include "tudat/astro/ephemerides/tleEphemeris.h"
 #include "tudat/astro/basic_astro/unitConversions.h"
 #include "tudat/astro/basic_astro/dateTime.h"
+#include "tudat/basics/utilities.h"
 #include "tudat/interface/spice/spiceInterface.h"
 #include "tudat/interface/sofa/earthOrientation.h"
 #include "tudat/interface/sofa/sofaTimeConversions.h"
 #include "boost/algorithm/string.hpp"
+
+#include <cmath>
+#include <cstdio>
 
 namespace tudat
 {
@@ -139,6 +143,109 @@ void validateTleChecksumOrThrow( const std::string& line )
     {
         throw std::runtime_error( "Invalid TLE checksum: expected " + std::to_string( expected ) + ", got " + std::to_string( provided ) );
     }
+}
+
+namespace
+{
+
+//! Format a value as a fixed-width, space-padded field with the given number of decimals (e.g. degrees fields).
+std::string formatTleFixedField( const double value, const int totalWidth, const int fractionDigits )
+{
+    char buffer[ 32 ];
+    std::snprintf( buffer, sizeof( buffer ), "%*.*f", totalWidth, fractionDigits, value );
+    return std::string( buffer );
+}
+
+//! Format a value in (-1, 1) without the leading zero, e.g. " .00012345" or "-.00012345" (mean motion first derivative).
+std::string formatTleSignedDecimalField( const double value, const int fractionDigits )
+{
+    const char sign = ( value < 0.0 ) ? '-' : ' ';
+    char buffer[ 32 ];
+    std::snprintf( buffer, sizeof( buffer ), "%.*f", fractionDigits, std::fabs( value ) );
+    const std::string digitsString( buffer );
+    return std::string( 1, sign ) + digitsString.substr( digitsString.find( '.' ) );
+}
+
+//! Format a value using the TLE mantissa/exponent convention: value = sign * mantissa * 10^(exponent - 5),
+//! with mantissa a 5-digit integer (columns: sign + 5 digits) and exponent a signed single digit.
+//! Used for the mean motion second derivative and B* fields.
+std::string formatTleExponentialField( const double value )
+{
+    const char sign = ( value < 0.0 ) ? '-' : ' ';
+    const double absoluteValue = std::fabs( value );
+
+    int exponent = 0;
+    int mantissa = 0;
+    if( absoluteValue > 0.0 )
+    {
+        exponent = static_cast< int >( std::floor( std::log10( absoluteValue ) ) ) + 1;
+        double mantissaValue = absoluteValue / std::pow( 10.0, exponent );
+        mantissa = static_cast< int >( std::llround( mantissaValue * 1.0e5 ) );
+        // Guard against rounding a mantissa such as 99999.6 up to 100000 (would overflow the 5-digit field).
+        if( mantissa >= 100000 )
+        {
+            mantissa /= 10;
+            exponent += 1;
+        }
+    }
+    if( std::abs( exponent ) > 9 )
+    {
+        throw std::runtime_error( "Cannot represent value " + std::to_string( value ) +
+                                  " in a TLE mantissa/exponent field: exponent magnitude exceeds the single allotted digit." );
+    }
+
+    char buffer[ 16 ];
+    std::snprintf( buffer, sizeof( buffer ), "%c%05d%+d", sign, mantissa, exponent );
+    return std::string( buffer );
+}
+
+}  // namespace
+
+void Tle::computeRawLines( )
+{
+    // Convert the stored TDB epoch back to UTC to recover the calendar date used by the TLE format. This mirrors,
+    // in reverse, the UTC-to-TT-to-(approximate)TDB conversion performed by the string-parsing constructor.
+    const double ttEpoch = sofa_interface::convertTDBtoTT< double >( epoch_, Eigen::Vector3d::Zero( ) );
+    const double utcEpoch = sofa_interface::convertTTtoUTC< double >( ttEpoch );
+
+    const basic_astrodynamics::DateTime epochDateTime = basic_astrodynamics::DateTime::fromTime< double >( utcEpoch );
+    const int epochYear = epochDateTime.getYear( );
+    const basic_astrodynamics::DateTime startOfYear( epochYear, 1, 1, 0, 0, 0.0L );
+    // TLE day numbering starts at 1 for January 1st, 00:00.
+    const double epochDayFraction = ( utcEpoch - startOfYear.epoch< double >( ) ) / 86400.0 + 1.0;
+    char dayFractionBuffer[ 16 ];
+    std::snprintf( dayFractionBuffer, sizeof( dayFractionBuffer ), "%012.8f", epochDayFraction );
+
+    std::string pieceField = internationalDesignatorPiece_;
+    pieceField.resize( 3, ' ' );
+
+    // Physical rates are stored in radians/minute^{1,2,3}; the TLE fields are in revolutions/day^{1,2,3}.
+    const double revPerDayToRadPerMin = 2.0 * mathematical_constants::PI / 1440.0;
+
+    // ---- Line 1: identification, epoch and drag/ballistic terms ----
+    std::string line1 = "1 " + utilities::paddedZeroIntString( noradCatalogNumber_, 5 ) + std::string( 1, classification_ ) + " " +
+            utilities::paddedZeroIntString( internationalDesignatorLaunchYear_ % 100, 2 ) +
+            utilities::paddedZeroIntString( internationalDesignatorLaunchNumber_, 3 ) + pieceField + " " +
+            utilities::paddedZeroIntString( epochYear % 100, 2 ) + std::string( dayFractionBuffer ) + " " +
+            formatTleSignedDecimalField( meanMotionFirstDerivative_ / revPerDayToRadPerMin, 8 ) + " " +
+            formatTleExponentialField( meanMotionSecondDerivative_ / ( revPerDayToRadPerMin / 1440.0 / 1440.0 ) ) + " " +
+            formatTleExponentialField( bStar_ ) + " " + std::to_string( ephemerisType_ ) + " " +
+            utilities::paddedZeroIntString( elementSetNumber_, 4 );
+    line1 += std::to_string( computeTleChecksum( line1 + "0" ) );
+
+    // ---- Line 2: mean orbital elements ----
+    std::string line2 = "2 " + utilities::paddedZeroIntString( noradCatalogNumber_, 5 ) + " " +
+            formatTleFixedField( unit_conversions::convertRadiansToDegrees( inclination_ ), 8, 4 ) + " " +
+            formatTleFixedField( unit_conversions::convertRadiansToDegrees( rightAscension_ ), 8, 4 ) + " " +
+            utilities::paddedZeroIntString( static_cast< int >( std::llround( eccentricity_ * 1.0e7 ) ), 7 ) + " " +
+            formatTleFixedField( unit_conversions::convertRadiansToDegrees( argOfPerigee_ ), 8, 4 ) + " " +
+            formatTleFixedField( unit_conversions::convertRadiansToDegrees( meanAnomaly_ ), 8, 4 ) + " " +
+            formatTleFixedField( meanMotion_ / revPerDayToRadPerMin, 11, 8 ) +
+            utilities::paddedZeroIntString( revolutionNumberAtEpoch_, 5 );
+    line2 += std::to_string( computeTleChecksum( line2 + "0" ) );
+
+    rawLine1_ = line1;
+    rawLine2_ = line2;
 }
 
 Tle::Tle( const std::string& lines )

--- a/src/tudat/astro/ephemerides/tleFitting.cpp
+++ b/src/tudat/astro/ephemerides/tleFitting.cpp
@@ -298,6 +298,18 @@ TleFitResult fitTleToCartesianStateHistory( const std::map< double, Eigen::Vecto
         throw std::runtime_error( "TLE fit ended at invalid TLE parameters." );
     }
 
+    // Apply any user-supplied catalog identity (NORAD number, international designator, ...) - none of this is
+    // derivable from the Cartesian state history itself - then serialize the fitted numerical elements into
+    // standard TLE text so that fittedTle_->raw_line_1/2 are usable (e.g. for exporting the fit result or feeding
+    // it to tools that expect TLE text).
+    fittedTle->setIdentification( settings.noradCatalogNumber_,
+                                  settings.classification_,
+                                  settings.internationalDesignatorLaunchYear_,
+                                  settings.internationalDesignatorLaunchNumber_,
+                                  settings.internationalDesignatorPiece_,
+                                  settings.elementSetNumber_ );
+    fittedTle->computeRawLines( );
+
     // Return unweighted physical diagnostics; positionRms_ is the RMS of per-epoch three-dimensional error norms.
     TleFitResult result;
     result.fittedTle_ = fittedTle;

--- a/src/tudatpy/astro/time_representation/expose_time_representation.cpp
+++ b/src/tudatpy/astro/time_representation/expose_time_representation.cpp
@@ -815,17 +815,35 @@ In this example, the calendar date corresponding to when 122 days have passed in
             .def(
                     "to_python_datetime",
                     []( const tba::DateTime& self ) {
-                        const auto sec_int = static_cast< int >( self.getSeconds( ) );
-                        const auto microsecond = static_cast< int >(
-                                std::round( ( self.getSeconds( ) - static_cast< long double >( sec_int ) ) * 1000000.0L ) );
-                        return py::module_::import( "datetime" )
-                                .attr( "datetime" )( self.getYear( ),
-                                                     self.getMonth( ),
-                                                     self.getDay( ),
-                                                     self.getHour( ),
-                                                     self.getMinute( ),
-                                                     sec_int,
-                                                     microsecond );
+                        // Cache the Python datetime class constructor
+                        static py::object py_datetime = py::module_::import( "datetime" ).attr( "datetime" );
+
+                        tba::DateTime normalizedDateTime = self;
+                        auto sec_int = static_cast< int >( normalizedDateTime.getSeconds( ) );
+                        auto microsecond = static_cast< int >(
+                                std::round( ( normalizedDateTime.getSeconds( ) - static_cast< long double >( sec_int ) ) * 1000000.0L ) );
+
+                        if( microsecond == 1000000 )
+                        {
+                            normalizedDateTime = normalizedDateTime.addSecondsToDateTime( 1.0L );
+                            sec_int = static_cast< int >( normalizedDateTime.getSeconds( ) );
+                            microsecond = 0;
+                        }
+
+                        // Handle potential leap second
+                        if( sec_int >= 60 )
+                        {
+                            sec_int = 59;
+                        }
+
+                        // Call the cached constructor
+                        return py_datetime( normalizedDateTime.getYear( ),
+                                            normalizedDateTime.getMonth( ),
+                                            normalizedDateTime.getDay( ),
+                                            normalizedDateTime.getHour( ),
+                                            normalizedDateTime.getMinute( ),
+                                            sec_int,
+                                            microsecond );
                     },
                     R"doc(
 

--- a/src/tudatpy/dynamics/environment/expose_environment.cpp
+++ b/src/tudatpy/dynamics/environment/expose_environment.cpp
@@ -41,6 +41,7 @@
 #include <tudat/astro/ephemerides/tabulatedEphemeris.h>
 #include <tudat/astro/ephemerides/timeEphemeris.h>
 #include <tudat/astro/ephemerides/tleEphemeris.h>
+#include <tudat/astro/ephemerides/tleFitting.h>
 #include <tudat/astro/gravitation/gravityFieldModel.h>
 #include <tudat/astro/gravitation/gravityFieldVariations.h>
 #include <tudat/astro/gravitation/polyhedronGravityField.h>
@@ -658,6 +659,114 @@ void expose_environment( py::module& m )
                 :type: Tle
                 )doc" );
 
+    // TLE fitting settings
+    py::class_< te::TleFitSettings >( m, "TleFitSettings" )
+            .def( py::init<>( ) )
+            .def_readwrite( "tle_epoch", &te::TleFitSettings::tleEpoch_ )
+            .def_readwrite( "initial_tle", &te::TleFitSettings::initialTle_ )
+            .def_readwrite( "estimate_b_star", &te::TleFitSettings::estimateBStar_ )
+            .def_readwrite( "initial_b_star", &te::TleFitSettings::initialBStar_ )
+            .def_readwrite( "maximum_number_of_iterations", &te::TleFitSettings::maximumNumberOfIterations_ )
+            .def_readwrite( "convergence_tolerance", &te::TleFitSettings::convergenceTolerance_ )
+            .def_readwrite( "initial_damping", &te::TleFitSettings::initialDamping_ )
+            .def_readwrite( "b_star_scale", &te::TleFitSettings::bStarScale_ )
+            .def_readwrite( "logarithmic_mean_motion_step", &te::TleFitSettings::logarithmicMeanMotionStep_ )
+            .def_readwrite( "equinoctial_element_step", &te::TleFitSettings::equinoctialElementStep_ )
+            .def_readwrite( "mean_longitude_step", &te::TleFitSettings::meanLongitudeStep_ )
+            .def_readwrite( "b_star_step", &te::TleFitSettings::bStarStep_ )
+            .def_readwrite( "norad_catalog_number",
+                            &te::TleFitSettings::noradCatalogNumber_,
+                            R"doc(
+                    NORAD catalog number to embed in the fitted TLE's identification fields. This cannot be derived
+                    from the Cartesian state history being fit; it defaults to 0 (serialized as ``"00000"``) when left
+                    unset.
+
+                    :type: int
+                    )doc" )
+            .def_readwrite( "classification",
+                            &te::TleFitSettings::classification_,
+                            R"doc(
+                    Security classification character to embed in the fitted TLE, typically ``"U"`` (unclassified),
+                    ``"C"`` or ``"S"``.
+
+                    :type: str
+                    )doc" )
+            .def_readwrite( "international_designator_launch_year",
+                            &te::TleFitSettings::internationalDesignatorLaunchYear_,
+                            R"doc(
+                    International designator launch year to embed in the fitted TLE (either 2- or 4-digit; only the
+                    last two digits are serialized).
+
+                    :type: int
+                    )doc" )
+            .def_readwrite( "international_designator_launch_number",
+                            &te::TleFitSettings::internationalDesignatorLaunchNumber_,
+                            R"doc(
+                    International designator launch number to embed in the fitted TLE.
+
+                    :type: int
+                    )doc" )
+            .def_readwrite( "international_designator_piece",
+                            &te::TleFitSettings::internationalDesignatorPiece_,
+                            R"doc(
+                    International designator launch piece to embed in the fitted TLE (up to 3 characters,
+                    space-padded if shorter).
+
+                    :type: str
+                    )doc" )
+            .def_readwrite( "element_set_number",
+                            &te::TleFitSettings::elementSetNumber_,
+                            R"doc(
+                    Element set number to embed in the fitted TLE.
+
+                    :type: int
+                    )doc" );
+
+    // TLE fitting result
+    py::class_< te::TleFitResult >( m, "TleFitResult" )
+            .def_readonly( "fitted_tle", &te::TleFitResult::fittedTle_ )
+            .def_readonly( "position_residuals", &te::TleFitResult::positionResiduals_ )
+            .def_readonly( "position_rms", &te::TleFitResult::positionRms_ )
+            .def_readonly( "initial_position_rms", &te::TleFitResult::initialPositionRms_ )
+            .def_readonly( "number_of_iterations", &te::TleFitResult::numberOfIterations_ )
+            .def_readonly( "converged", &te::TleFitResult::converged_ );
+
+    // Fit TLE to Cartesian state history
+    // TLE fitting with default settings
+    m.def(
+            "fit_tle_to_cartesian_state_history",
+            []( const std::map< double, Eigen::Vector6d >& cartesianStateHistory, const std::string& frameOrientation ) {
+                return te::fitTleToCartesianStateHistory( cartesianStateHistory, frameOrientation, te::TleFitSettings( ) );
+            },
+            py::arg( "cartesian_state_history" ),
+            py::arg( "frame_orientation" ) );
+
+    // TLE fitting with explicit settings
+    m.def( "fit_tle_to_cartesian_state_history",
+           &te::fitTleToCartesianStateHistory,
+           py::arg( "cartesian_state_history" ),
+           py::arg( "frame_orientation" ),
+           py::arg( "settings" ),
+           R"doc(
+    Fit a full-precision numerical TLE to an Earth-centred Cartesian
+    state history.
+
+    Parameters
+    ----------
+    cartesian_state_history : dict
+        Mapping from epoch to Cartesian state.
+
+    frame_orientation : str
+        Either "J2000" or "ECLIPJ2000".
+
+    settings : TleFitSettings, optional
+        Configuration settings for the nonlinear fit.
+
+    Returns
+    -------
+    TleFitResult
+        The fitted TLE and residual diagnostics.
+    )doc" );
     /*!
      **************   END EPHEMERIDES  ******************
      */

--- a/src/tudatpy/dynamics/environment/expose_environment.cpp
+++ b/src/tudatpy/dynamics/environment/expose_environment.cpp
@@ -558,6 +558,39 @@ void expose_environment( py::module& m )
                 :type: str
                 )doc" )
 
+            .def_property_readonly( "international_designator_launch_year",
+                                    &te::Tle::getInternationalDesignatorLaunchYear,
+                                    R"doc(
+
+                **read-only**
+
+                International designator (COSPAR ID) launch year of the space object, as provided by the TLE.
+
+                :type: int
+                )doc" )
+
+            .def_property_readonly( "international_designator_launch_number",
+                                    &te::Tle::getInternationalDesignatorLaunchNumber,
+                                    R"doc(
+
+                **read-only**
+
+                International designator (COSPAR ID) launch number of the space object, as provided by the TLE.
+
+                :type: int
+                )doc" )
+
+            .def_property_readonly( "international_designator_piece",
+                                    &te::Tle::getInternationalDesignatorPiece,
+                                    R"doc(
+
+                **read-only**
+
+                International designator (COSPAR ID) launch piece of the space object, as provided by the TLE.
+
+                :type: str
+                )doc" )
+
             .def_property_readonly( "element_set_number",
                                     &te::Tle::getElementSetNumber,
                                     R"doc(
@@ -634,6 +667,7 @@ void expose_environment( py::module& m )
 
                 :type: str
                 )doc" )
+
             .def( "epoch", &te::Tle::getEpoch )
             .def( "get_b_star", &te::Tle::getBStar )
             .def( "get_epoch", &te::Tle::getEpoch )


### PR DESCRIPTION
- Add TLE raw lines writer upon fitting
- Add optional Tle Fit settings to set the norad id and intldes of an object
- While I was working on it, I also added getter methods and exposures to get the international designator from the `environment.Tle` object