### PR TITLE
Improvements to crashing `to_python_datetime` edge cases

### DIFF
--- a/src/tudatpy/astro/time_representation/expose_time_representation.cpp
+++ b/src/tudatpy/astro/time_representation/expose_time_representation.cpp
@@ -830,10 +830,10 @@ In this example, the calendar date corresponding to when 122 days have passed in
                             microsecond = 0;
                         }
 
-                        // Handle potential leap second
+                        // Python datetime cannot represent leap seconds.
                         if( sec_int >= 60 )
                         {
-                            sec_int = 59;
+                            throw py::value_error( "Cannot convert a Tudat DateTime containing a leap second to Python datetime." );
                         }
 
                         // Call the cached constructor

--- a/src/tudatpy/astro/time_representation/expose_time_representation.cpp
+++ b/src/tudatpy/astro/time_representation/expose_time_representation.cpp
@@ -815,17 +815,35 @@ In this example, the calendar date corresponding to when 122 days have passed in
             .def(
                     "to_python_datetime",
                     []( const tba::DateTime& self ) {
-                        const auto sec_int = static_cast< int >( self.getSeconds( ) );
-                        const auto microsecond = static_cast< int >(
-                                std::round( ( self.getSeconds( ) - static_cast< long double >( sec_int ) ) * 1000000.0L ) );
-                        return py::module_::import( "datetime" )
-                                .attr( "datetime" )( self.getYear( ),
-                                                     self.getMonth( ),
-                                                     self.getDay( ),
-                                                     self.getHour( ),
-                                                     self.getMinute( ),
-                                                     sec_int,
-                                                     microsecond );
+                        // Cache the Python datetime class constructor
+                        static py::object py_datetime = py::module_::import( "datetime" ).attr( "datetime" );
+
+                        tba::DateTime normalizedDateTime = self;
+                        auto sec_int = static_cast< int >( normalizedDateTime.getSeconds( ) );
+                        auto microsecond = static_cast< int >(
+                                std::round( ( normalizedDateTime.getSeconds( ) - static_cast< long double >( sec_int ) ) * 1000000.0L ) );
+
+                        if( microsecond == 1000000 )
+                        {
+                            normalizedDateTime = normalizedDateTime.addSecondsToDateTime( 1.0L );
+                            sec_int = static_cast< int >( normalizedDateTime.getSeconds( ) );
+                            microsecond = 0;
+                        }
+
+                        // Handle potential leap second
+                        if( sec_int >= 60 )
+                        {
+                            sec_int = 59;
+                        }
+
+                        // Call the cached constructor
+                        return py_datetime( normalizedDateTime.getYear( ),
+                                            normalizedDateTime.getMonth( ),
+                                            normalizedDateTime.getDay( ),
+                                            normalizedDateTime.getHour( ),
+                                            normalizedDateTime.getMinute( ),
+                                            sec_int,
+                                            microsecond );
                     },
                     R"doc(
 

--- a/tests/test_tudatpy/test_time_conversions.py
+++ b/tests/test_tudatpy/test_time_conversions.py
@@ -30,6 +30,21 @@ PYTHON_DATETIME_CASES = [
     datetime(2012, 10, 28, 2, 30, 0),  # ambiguous local time
 ]
 
+TUDAT_DATETIME_MICROSECONDS_OVERFLOW = [
+    (
+        DateTime(
+            2024, 12, 31, 23, 59, 59.9999996
+        ),  # probe (with microsecond overflow, last day of year)
+        datetime(2025, 1, 1, 0, 0, 0, 0),  # expected result
+    ),
+    (
+        DateTime(
+            2024, 12, 30, 22, 51, 59.9999996
+        ),  # probe (with microsecond overflow, random day of year)
+        datetime(2024, 12, 30, 22, 52, 0, 0),
+    ),
+]
+
 
 @pytest.mark.parametrize("dt", PYTHON_DATETIME_CASES)
 def test_from_python_datetime_preserves_fields(dt):
@@ -97,3 +112,13 @@ def test_datetime_conversions():
         time_representation.DateTime.from_julian_day(julian_day).to_python_datetime()
     )
     assert julian_day == pytest.approx(tudat_datettime.to_julian_day(), abs=1e-9)
+
+
+@pytest.mark.parametrize(
+    ("dt", "expected"),
+    TUDAT_DATETIME_MICROSECONDS_OVERFLOW,
+)
+def test_to_python_datetime_microseconds_overflow(dt, expected):
+    """Verify that to_python_datetime correctly handles microsecond overflow."""
+    result = dt.to_python_datetime()
+    assert result == expected

--- a/tests/test_tudatpy/test_time_conversions.py
+++ b/tests/test_tudatpy/test_time_conversions.py
@@ -122,3 +122,16 @@ def test_to_python_datetime_microseconds_overflow(dt, expected):
     """Verify that to_python_datetime correctly handles microsecond overflow."""
     result = dt.to_python_datetime()
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "dt",
+    [
+        DateTime(2016, 12, 31, 23, 59, 60.5),
+        DateTime(2016, 12, 31, 23, 59, 59.9999996),
+    ],
+)
+def test_to_python_datetime_rejects_leap_seconds(dt):
+    """Python datetime cannot represent explicit or rounded leap seconds."""
+    with pytest.raises(ValueError, match="leap second"):
+        dt.to_python_datetime()


### PR DESCRIPTION
@valeriof7 could you check this out?

Changes motivated by the following error:

Input
```
t_utc = 1723456789.9999999
DateTime.from_epoch(t_utc).to_python_datetime(`
```

Output
```
ValueError: microsecond must be in 0..999999
```

Improve `to_python_datetime`: 1) improved performance by caching the static `py_datetime` import 2) avoid microsecond overflow crash when converting to python datetimes 3) for similar reasons, avoid leap second crash (checks if sec_int >=60 and clamps it to 59)