### PR TITLE
Allow choosing transponder vs ancillary link-end delays

### DIFF
--- a/include/tudat/astro/observation_models/lightTimeSolution.h
+++ b/include/tudat/astro/observation_models/lightTimeSolution.h
@@ -19,6 +19,7 @@
 #include <iomanip>
 #include <map>
 #include <numeric>
+#include <string>
 #include <vector>
 
 #include "tudat/basics/basicTypedefs.h"
@@ -908,57 +909,102 @@ public:
     void resetLinkEndDelays( const std::shared_ptr< ObservationAncillarySimulationSettings > ancillarySettings = nullptr,
                              const bool performFullComputation = true )
     {
-        linkEndsDelays_.clear( );
+        std::vector< double > ancillaryDelays;
+        std::vector< double > delaySources;
         if( ancillarySettings != nullptr )
         {
-            linkEndsDelays_ = ancillarySettings->getAncillaryDoubleVectorData( link_ends_delays, false );
+            ancillaryDelays = ancillarySettings->getAncillaryDoubleVectorData( link_ends_delays, false );
+            delaySources = ancillarySettings->getLinkEndDelaySources( );
         }
 
-        if( !linkEndsDelays_.empty( ) )
+        completeLinkEndDelayVector( ancillaryDelays, "retransmission delays" );
+        if( !delaySources.empty( ) )
         {
-            if( hasDefaultLinkEndDelayFunctions_ && !ancillaryDelayOverrideWarningPrinted_ )
-            {
-                std::cerr << "Warning when computing observation: transponder delay functions are present in the observation model, "
-                             "but retransmission delays are provided through ancillary settings. The ancillary settings will be used. "
-                             "This warning is printed only once for this light-time calculator."
-                          << std::endl;
-                ancillaryDelayOverrideWarningPrinted_ = true;
-            }
+            completeLinkEndDelayVector( delaySources, "link-end delay sources" );
+        }
 
-            // Delays vector not including delays at receiving and transmitting stations: set them to 0
-            if( linkEndsDelays_.size( ) == numberOfLinkEnds_ - 2 )
-            {
-                linkEndsDelays_.insert( linkEndsDelays_.begin( ), 0.0 );
-                linkEndsDelays_.push_back( 0.0 );
-            }
-            else if( linkEndsDelays_.size( ) != numberOfLinkEnds_ )
-            {
-                throw std::runtime_error( "Error when computing multi-leg light time: size of retransmission delays (" +
-                                          std::to_string( linkEndsDelays_.size( ) ) + ") is invalid, should be " +
-                                          std::to_string( numberOfLinkEnds_ ) + " or " + std::to_string( numberOfLinkEnds_ - 2 ) + "." );
-            }
+        const bool hasAncillaryDelays = !ancillaryDelays.empty( );
+        if( hasAncillaryDelays )
+        {
+            linkEndsDelays_ = ancillaryDelays;
         }
         else
         {
-            if( hasDefaultLinkEndDelayFunctions_ )
+            linkEndsDelays_.assign( numberOfLinkEnds_, 0.0 );
+        }
+
+        bool ignoredDefaultDueToAncillary = false;
+        if( hasDefaultLinkEndDelayFunctions_ )
+        {
+            for( unsigned int i = 0; i < numberOfLinkEnds_; i++ )
             {
-                for( unsigned int i = 0; i < numberOfLinkEnds_; i++ )
+                const bool hasDefaultFunction =
+                        ( i < defaultLinkEndDelayFunctions_.size( ) && defaultLinkEndDelayFunctions_.at( i ) != nullptr );
+                const bool vehicleSystemsDelayRequested = !delaySources.empty( ) && delaySources.at( i ) != 0.0;
+
+                if( !hasDefaultFunction )
                 {
-                    linkEndsDelays_.push_back(
-                            defaultLinkEndDelayFunctions_.at( i ) == nullptr ? 0.0 : defaultLinkEndDelayFunctions_.at( i )( ) );
+                    if( vehicleSystemsDelayRequested )
+                    {
+                        throw std::runtime_error(
+                                "Error when computing observation: vehicle-systems transponder delay was selected for link end index " +
+                                std::to_string( i ) +
+                                ", but no default transponder delay function is defined for that link end. Set the transponder delay on "
+                                "the spacecraft VehicleSystems before creating the observation model." );
+                    }
+                    continue;
                 }
-            }
-            else
-            {
-                for( unsigned int i = 0; i < numberOfLinkEnds_; i++ )
+
+                bool useDefaultDelay = !hasAncillaryDelays;
+                if( hasAncillaryDelays )
                 {
-                    linkEndsDelays_.push_back( 0.0 );
+                    if( !delaySources.empty( ) )
+                    {
+                        useDefaultDelay = vehicleSystemsDelayRequested;
+                    }
+                    else if( i < defaultLinkEndDelayOverrideFlags_.size( ) && defaultLinkEndDelayOverrideFlags_.at( i ) != nullptr )
+                    {
+                        useDefaultDelay = defaultLinkEndDelayOverrideFlags_.at( i )( );
+                    }
+                }
+
+                if( useDefaultDelay )
+                {
+                    linkEndsDelays_.at( i ) = defaultLinkEndDelayFunctions_.at( i )( );
+                }
+                else
+                {
+                    ignoredDefaultDueToAncillary = true;
                 }
             }
         }
+        else if( !delaySources.empty( ) )
+        {
+            for( unsigned int i = 0; i < delaySources.size( ); i++ )
+            {
+                if( delaySources.at( i ) != 0.0 )
+                {
+                    throw std::runtime_error(
+                            "Error when computing observation: vehicle-systems transponder delay was selected, but no default transponder "
+                            "delay functions are present in the observation model. Set the transponder delay on the spacecraft "
+                            "VehicleSystems before creating the observation model." );
+                }
+            }
+        }
+
+        if( hasAncillaryDelays && ignoredDefaultDueToAncillary && !ancillaryDelayOverrideWarningPrinted_ )
+        {
+            std::cerr << "Warning when computing observation: transponder delay functions are present in the observation model, "
+                         "but retransmission delays are provided through ancillary settings. The ancillary settings will be used. "
+                         "This warning is printed only once for this light-time calculator."
+                      << std::endl;
+            ancillaryDelayOverrideWarningPrinted_ = true;
+        }
     }
 
-    void setDefaultLinkEndDelayFunctions( const std::vector< std::function< double( ) > >& defaultLinkEndDelayFunctions )
+    void setDefaultLinkEndDelayFunctions(
+            const std::vector< std::function< double( ) > >& defaultLinkEndDelayFunctions,
+            const std::vector< std::function< bool( ) > >& defaultLinkEndDelayOverrideFlags = std::vector< std::function< bool( ) > >( ) )
     {
         if( !defaultLinkEndDelayFunctions.empty( ) && defaultLinkEndDelayFunctions.size( ) != numberOfLinkEnds_ )
         {
@@ -966,7 +1012,14 @@ public:
                                       std::to_string( defaultLinkEndDelayFunctions.size( ) ) +
                                       ") is inconsistent with number of link ends (" + std::to_string( numberOfLinkEnds_ ) + ")." );
         }
+        if( !defaultLinkEndDelayOverrideFlags.empty( ) && defaultLinkEndDelayOverrideFlags.size( ) != numberOfLinkEnds_ )
+        {
+            throw std::runtime_error( "Error when setting default link-end delay override flags: size (" +
+                                      std::to_string( defaultLinkEndDelayOverrideFlags.size( ) ) +
+                                      ") is inconsistent with number of link ends (" + std::to_string( numberOfLinkEnds_ ) + ")." );
+        }
         defaultLinkEndDelayFunctions_ = defaultLinkEndDelayFunctions;
+        defaultLinkEndDelayOverrideFlags_ = defaultLinkEndDelayOverrideFlags;
         hasDefaultLinkEndDelayFunctions_ = false;
         for( const auto& defaultLinkEndDelayFunction : defaultLinkEndDelayFunctions_ )
         {
@@ -1180,6 +1233,25 @@ public:
     }
 
 private:
+    void completeLinkEndDelayVector( std::vector< double >& delays, const std::string& vectorName ) const
+    {
+        if( delays.empty( ) )
+        {
+            return;
+        }
+        if( delays.size( ) == numberOfLinkEnds_ - 2 )
+        {
+            delays.insert( delays.begin( ), 0.0 );
+            delays.push_back( 0.0 );
+        }
+        else if( delays.size( ) != numberOfLinkEnds_ )
+        {
+            throw std::runtime_error( "Error when computing multi-leg light time: size of " + vectorName + " (" +
+                                      std::to_string( delays.size( ) ) + ") is invalid, should be " + std::to_string( numberOfLinkEnds_ ) +
+                                      " or " + std::to_string( numberOfLinkEnds_ - 2 ) + "." );
+        }
+    }
+
     void initializeFullLinkLightTimeCalculator( )
     {
         correctionsNeedFrequency_ = false;
@@ -1271,6 +1343,8 @@ private:
     std::vector< double > linkEndsDelays_;
 
     std::vector< std::function< double( ) > > defaultLinkEndDelayFunctions_;
+
+    std::vector< std::function< bool( ) > > defaultLinkEndDelayOverrideFlags_;
 
     bool hasDefaultLinkEndDelayFunctions_;
 

--- a/include/tudat/astro/observation_models/observationAncillarySettings.h
+++ b/include/tudat/astro/observation_models/observationAncillarySettings.h
@@ -41,6 +41,9 @@ enum ObservationAncillarySimulationVariable {
     range_conversion_factor,
 };
 
+//! Source of a link-end delay when both ancillary settings and vehicle-system delays are available.
+enum LinkEndDelaySource { ancillary_settings_delay_source = 0, vehicle_systems_delay_source = 1 };
+
 enum ObservationIntermediateSimulationVariable { transmitter_frequency_intermediate, received_frequency_intermediate };
 
 struct ObservationAncillarySimulationSettings {
@@ -248,7 +251,18 @@ public:
 
     bool operator==( const ObservationAncillarySimulationSettings& rightSettings ) const
     {
-        return doubleData_ == rightSettings.doubleData_ && doubleVectorData_ == rightSettings.doubleVectorData_;
+        return doubleData_ == rightSettings.doubleData_ && doubleVectorData_ == rightSettings.doubleVectorData_ &&
+                linkEndDelaySources_ == rightSettings.linkEndDelaySources_;
+    }
+
+    void setLinkEndDelaySources( const std::vector< double >& linkEndDelaySources )
+    {
+        linkEndDelaySources_ = linkEndDelaySources;
+    }
+
+    std::vector< double > getLinkEndDelaySources( ) const
+    {
+        return linkEndDelaySources_;
     }
 
     std::map< ObservationAncillarySimulationVariable, double > getDoubleData( ) const
@@ -266,6 +280,8 @@ protected:
     std::map< ObservationAncillarySimulationVariable, std::vector< double > > doubleVectorData_;
 
     std::map< ObservationIntermediateSimulationVariable, double > doubleIntermediateData_;
+
+    std::vector< double > linkEndDelaySources_;
 };
 
 inline std::shared_ptr< ObservationAncillarySimulationSettings > getAveragedDopplerAncillarySettings( const double integrationTime = 60.0 )

--- a/include/tudat/astro/observation_models/observationModel.h
+++ b/include/tudat/astro/observation_models/observationModel.h
@@ -332,13 +332,15 @@ public:
         timeScaleConverter_ = earth_orientation::createDefaultTimeConverter( );
     }
 
-    void setDefaultLinkEndDelayFunctions( const std::vector< std::function< double( ) > >& defaultLinkEndDelayFunctions )
+    void setDefaultLinkEndDelayFunctions(
+            const std::vector< std::function< double( ) > >& defaultLinkEndDelayFunctions,
+            const std::vector< std::function< bool( ) > >& defaultLinkEndDelayOverrideFlags = std::vector< std::function< bool( ) > >( ) )
     {
         for( auto lightTimeCalculator : lightTimeCalculators_ )
         {
             if( lightTimeCalculator != nullptr )
             {
-                lightTimeCalculator->setDefaultLinkEndDelayFunctions( defaultLinkEndDelayFunctions );
+                lightTimeCalculator->setDefaultLinkEndDelayFunctions( defaultLinkEndDelayFunctions, defaultLinkEndDelayOverrideFlags );
             }
         }
     }

--- a/include/tudat/astro/system_models/vehicleSystems.h
+++ b/include/tudat/astro/system_models/vehicleSystems.h
@@ -47,7 +47,8 @@ public:
      * \param dryMass Total dry mass of the vehicle (not defined; NaN by default).
      */
     VehicleSystems( const double dryMass = TUDAT_NAN ):
-        currentOrientationTime_( TUDAT_NAN ), dryMass_( dryMass ), transponderDelay_( TUDAT_NAN )
+        currentOrientationTime_( TUDAT_NAN ), dryMass_( dryMass ), transponderDelay_( TUDAT_NAN ),
+        transponderDelayOverridesAncillarySettings_( false )
     {}
 
     //! Destructor
@@ -374,6 +375,16 @@ public:
         return transponderDelay_;
     }
 
+    void setTransponderDelayOverridesAncillarySettings( const bool transponderDelayOverridesAncillarySettings )
+    {
+        transponderDelayOverridesAncillarySettings_ = transponderDelayOverridesAncillarySettings;
+    }
+
+    bool getTransponderDelayOverridesAncillarySettings( ) const
+    {
+        return transponderDelayOverridesAncillarySettings_;
+    }
+
     bool doesReferencePointExist( const std::string referencePoint )
     {
         return ( referencePoints_.count( referencePoint ) > 0 );
@@ -537,6 +548,8 @@ private:
             transponderTurnaroundRatio_;
 
     double transponderDelay_;
+
+    bool transponderDelayOverridesAncillarySettings_;
 
     std::shared_ptr< ground_stations::StationFrequencyInterpolator > transmittedFrequencyCalculator_;
 };

--- a/include/tudat/simulation/estimation_setup/createObservationModelFactory.h
+++ b/include/tudat/simulation/estimation_setup/createObservationModelFactory.h
@@ -212,6 +212,7 @@ void setDefaultTransponderDelayFunctions(
 
     LinkEnds linkEnds = observationModel->getLinkEnds( );
     std::vector< std::function< double( ) > > defaultLinkEndDelayFunctions( linkEnds.size( ), nullptr );
+    std::vector< std::function< bool( ) > > defaultLinkEndDelayOverrideFlags( linkEnds.size( ), nullptr );
     bool hasDefaultTransponderDelay = false;
     const int numberOfLinkEnds = static_cast< int >( linkEnds.size( ) );
 
@@ -230,13 +231,16 @@ void setDefaultTransponderDelayFunctions(
         {
             defaultLinkEndDelayFunctions.at( linkEndIndex ) =
                     std::bind( &system_models::VehicleSystems::getTransponderDelay, bodies.at( linkEndBody )->getVehicleSystems( ) );
+            defaultLinkEndDelayOverrideFlags.at( linkEndIndex ) =
+                    std::bind( &system_models::VehicleSystems::getTransponderDelayOverridesAncillarySettings,
+                               bodies.at( linkEndBody )->getVehicleSystems( ) );
             hasDefaultTransponderDelay = true;
         }
     }
 
     if( hasDefaultTransponderDelay )
     {
-        observationModel->setDefaultLinkEndDelayFunctions( defaultLinkEndDelayFunctions );
+        observationModel->setDefaultLinkEndDelayFunctions( defaultLinkEndDelayFunctions, defaultLinkEndDelayOverrideFlags );
     }
 }
 

--- a/include/tudat/simulation/estimation_setup/observationCollection.h
+++ b/include/tudat/simulation/estimation_setup/observationCollection.h
@@ -2017,8 +2017,10 @@ public:
                      "observation model, for example in Python: "
                      "`bodies.get_body(spacecraft_name).vehicle_systems.transponder_delay = transponder_delay`. In C++, call "
                      "`bodies.at(spacecraftName)->getVehicleSystems()->setTransponderDelay(transponderDelay)` before creating the "
-                     "observation model. This deprecated ObservationCollection function is kept for backward compatibility only and "
-                     "will be removed in a future major release."
+                     "observation model. If ancillary link-end delays are already present, use "
+                     "set_transponder_delay_overrides_ancillary_settings(...) so that the vehicle-systems transponder delay is used "
+                     "for that spacecraft. This deprecated ObservationCollection function is kept for backward compatibility only "
+                     "and will be removed in a future major release."
                   << std::endl;
 
         // Create observation parser with the spacecraft name
@@ -2052,6 +2054,72 @@ public:
                 linkEndsDelays[ 1 ] = transponderDelay;
                 ancillarySettings->setAncillaryDoubleVectorData( link_ends_delays, linkEndsDelays );
             }
+        }
+    }
+
+    void setTransponderDelayOverridesAncillarySettings( const std::string& spacecraftName,
+                                                        const bool overridesAncillarySettings = true,
+                                                        const std::shared_ptr< ObservationCollectionParser > inputObservationParser =
+                                                                std::make_shared< ObservationCollectionParser >( ) )
+    {
+        std::shared_ptr< ObservationCollectionParser > spacecraftParser = observationParser( spacecraftName );
+        std::shared_ptr< ObservationCollectionMultiTypeParser > jointParser = std::make_shared< ObservationCollectionMultiTypeParser >(
+                std::vector< std::shared_ptr< ObservationCollectionParser > >( { spacecraftParser, inputObservationParser } ), true );
+
+        std::vector< std::shared_ptr< SingleObservationSet< ObservationScalarType, TimeType > > > singleSets =
+                getSingleObservationSets( jointParser );
+
+        bool foundRetransmitter = false;
+        for( auto set : singleSets )
+        {
+            std::shared_ptr< observation_models::ObservationAncillarySimulationSettings > ancillarySettings = set->getAncillarySettings( );
+            if( ancillarySettings == nullptr )
+            {
+                throw std::runtime_error(
+                        "Error when selecting vehicle-systems transponder delay: the selected observation set has no ancillary "
+                        "settings. Set the transponder delay on the spacecraft VehicleSystems before creating the observation model "
+                        "if no link-end delays are stored with the observations." );
+            }
+
+            const LinkEnds linkEnds = set->getLinkEnds( ).linkEnds_;
+            const unsigned int numberOfLinkEnds = static_cast< unsigned int >( linkEnds.size( ) );
+            std::vector< double > delaySources = ancillarySettings->getLinkEndDelaySources( );
+            if( delaySources.empty( ) )
+            {
+                delaySources.assign( numberOfLinkEnds, static_cast< double >( ancillary_settings_delay_source ) );
+            }
+            else if( delaySources.size( ) == numberOfLinkEnds - 2 )
+            {
+                delaySources.insert( delaySources.begin( ), static_cast< double >( ancillary_settings_delay_source ) );
+                delaySources.push_back( static_cast< double >( ancillary_settings_delay_source ) );
+            }
+            else if( delaySources.size( ) != numberOfLinkEnds )
+            {
+                throw std::runtime_error( "Error when selecting vehicle-systems transponder delay: size of link-end delay sources (" +
+                                          std::to_string( delaySources.size( ) ) + ") is invalid, should be " +
+                                          std::to_string( numberOfLinkEnds ) + " or " + std::to_string( numberOfLinkEnds - 2 ) + "." );
+            }
+
+            const double selectedSource =
+                    static_cast< double >( overridesAncillarySettings ? vehicle_systems_delay_source : ancillary_settings_delay_source );
+            for( const auto& linkEnd : linkEnds )
+            {
+                const int linkEndIndex = getNWayLinkIndexFromLinkEndType( linkEnd.first, static_cast< int >( numberOfLinkEnds ) );
+                if( linkEnd.second.bodyName_ == spacecraftName && linkEndIndex > 0 &&
+                    linkEndIndex < static_cast< int >( numberOfLinkEnds ) - 1 )
+                {
+                    delaySources.at( static_cast< unsigned int >( linkEndIndex ) ) = selectedSource;
+                    foundRetransmitter = true;
+                }
+            }
+
+            ancillarySettings->setLinkEndDelaySources( delaySources );
+        }
+
+        if( !foundRetransmitter )
+        {
+            throw std::runtime_error( "Error when selecting vehicle-systems transponder delay: no retransmitter link end with body name " +
+                                      spacecraftName + " was found in the selected observation sets." );
         }
     }
 

--- a/src/tudatpy/dynamics/environment/expose_environment.cpp
+++ b/src/tudatpy/dynamics/environment/expose_environment.cpp
@@ -1425,6 +1425,17 @@ bool
 
          :type: float
      )doc" )
+            .def_property( "transponder_delay_overrides_ancillary_settings",
+                           &tsm::VehicleSystems::getTransponderDelayOverridesAncillarySettings,
+                           &tsm::VehicleSystems::setTransponderDelayOverridesAncillarySettings,
+                           R"doc(
+         If true, the vehicle transponder delay is used even when link-end delays are provided
+         through observation ancillary settings. Station delays from those ancillary settings
+         are left unchanged. The default is false, in which case a complete ancillary delay
+         vector takes precedence.
+
+         :type: bool
+     )doc" )
             .def( "is_transponder_delay_defined",
                   &tsm::VehicleSystems::isTransponderDelayDefined,
                   R"doc(

--- a/src/tudatpy/estimation/observations/expose_observations.cpp
+++ b/src/tudatpy/estimation/observations/expose_observations.cpp
@@ -1597,6 +1597,8 @@ residuals_per_parser : dict[ObservationCollectionParser, np.ndarray]
          For new simulations, set the default transponder delay on the spacecraft vehicle systems
          before creating the observation model:
          ``bodies.get_body(spacecraft_name).vehicle_systems.transponder_delay = transponder_delay``.
+         If the observations already contain link-end delays, use
+         ``set_transponder_delay_overrides_ancillary_settings`` instead of overwriting the ancillary values.
 
          Parameters
          ----------
@@ -1604,6 +1606,29 @@ residuals_per_parser : dict[ObservationCollectionParser, np.ndarray]
              Name of the spacecraft with the transponder.
          transponder_delay : float
              The transponder delay in seconds.
+         observation_parser : tudatpy.estimation.observations.observations_processing.ObservationCollectionParser, default = observations_processing.observation_parser()
+             Parser to select the observation sets.
+     )doc" )
+            .def( "set_transponder_delay_overrides_ancillary_settings",
+                  &tom::ObservationCollection< STATE_SCALAR_TYPE, TIME_TYPE >::setTransponderDelayOverridesAncillarySettings,
+                  py::arg( "spacecraft_name" ),
+                  py::arg( "overrides_ancillary_settings" ) = true,
+                  py::arg_v( "observation_parser", tom::observationParser( ), "..." ),
+                  R"doc(
+         Select whether the vehicle-systems transponder delay should be used for a spacecraft
+         instead of the retransmitter entry in the ancillary link-end delays.
+
+         Station delays stored in the ancillary settings are left unchanged. The transponder
+         delay itself must still be set on the spacecraft vehicle systems before the
+         observation model is created.
+
+         Parameters
+         ----------
+         spacecraft_name : str
+             Name of the spacecraft whose transponder delay should be taken from the vehicle systems.
+         overrides_ancillary_settings : bool, default = True
+             If true, use the vehicle-systems transponder delay for that spacecraft. If false,
+             revert to the ancillary retransmitter delay.
          observation_parser : tudatpy.estimation.observations.observations_processing.ObservationCollectionParser, default = observations_processing.observation_parser()
              Parser to select the observation sets.
      )doc" )

--- a/tests/test_tudat/src/astro/observation_models/unitTestNWayRangeObservationModel.cpp
+++ b/tests/test_tudat/src/astro/observation_models/unitTestNWayRangeObservationModel.cpp
@@ -923,6 +923,195 @@ BOOST_AUTO_TEST_CASE( testDeprecatedObservationCollectionTransponderDelay )
     BOOST_CHECK_EQUAL( moonLinkEndDelays.at( 1 ), originalMoonDelay );
 }
 
+BOOST_AUTO_TEST_CASE( testVehicleSystemTransponderDelayOverrideOfAncillarySettings )
+{
+    spice_interface::loadStandardSpiceKernels( );
+
+    std::vector< std::string > bodiesToCreate = { "Earth", "Mars", "Moon" };
+    BodyListSettings defaultBodySettings = getDefaultBodySettings( bodiesToCreate );
+    SystemOfBodies bodies = createSystemOfBodies( defaultBodySettings );
+
+    createGroundStation( bodies.at( "Earth" ),
+                         "EarthStation",
+                         ( Eigen::Vector3d( ) << 1.0, 0.1, -1.4 ).finished( ),
+                         coordinate_conversions::geodetic_position );
+    createGroundStation( bodies.at( "Mars" ),
+                         "MarsStation",
+                         ( Eigen::Vector3d( ) << 100.0, 0.5, 2.1 ).finished( ),
+                         coordinate_conversions::geodetic_position );
+
+    LinkEnds twoWayLinkEnds;
+    twoWayLinkEnds[ transmitter ] = std::make_pair< std::string, std::string >( "Earth", "EarthStation" );
+    twoWayLinkEnds[ retransmitter ] = std::make_pair< std::string, std::string >( "Mars", "MarsStation" );
+    twoWayLinkEnds[ receiver ] = std::make_pair< std::string, std::string >( "Earth", "EarthStation" );
+
+    const double vehicleSystemDelay = 7.0E-6;
+    const double uplinkDelay = 4.0E-6;
+    const double fileTransponderDelay = 2.0E-6;
+    const double downlinkDelay = 3.0E-6;
+    bodies.at( "Mars" )->getVehicleSystems( )->setTransponderDelay( vehicleSystemDelay );
+
+    std::shared_ptr< ObservationModelSettings > twoWayObservableSettings = twoWayRangeSimple( twoWayLinkEnds );
+    std::shared_ptr< ObservationModel< 1, double, double > > observationModel =
+            ObservationModelCreator< 1, double, double >::createObservationModel( twoWayObservableSettings, bodies );
+
+    const double observationTime = 1.0E5;
+    std::vector< double > linkEndTimes;
+    std::vector< Eigen::Vector6d > linkEndStates;
+    std::shared_ptr< ObservationAncillarySimulationSettings > fileAncillarySettings =
+            getNWayRangeAncillarySettings( { uplinkDelay, fileTransponderDelay, downlinkDelay } );
+    std::shared_ptr< ObservationAncillarySimulationSettings > hybridAncillarySettings =
+            getNWayRangeAncillarySettings( { uplinkDelay, vehicleSystemDelay, downlinkDelay } );
+
+    const Eigen::VectorXd fileDelayObservation = observationModel->computeIdealObservationsWithLinkEndData(
+            observationTime, receiver, linkEndTimes, linkEndStates, fileAncillarySettings );
+    BOOST_CHECK_SMALL( std::fabs( linkEndTimes.at( 2 ) - linkEndTimes.at( 1 ) - fileTransponderDelay ),
+                       observationTime * std::numeric_limits< double >::epsilon( ) );
+
+    const Eigen::VectorXd hybridDelayObservation = observationModel->computeIdealObservationsWithLinkEndData(
+            observationTime, receiver, linkEndTimes, linkEndStates, hybridAncillarySettings );
+
+    bodies.at( "Mars" )->getVehicleSystems( )->setTransponderDelayOverridesAncillarySettings( true );
+    const Eigen::VectorXd overriddenObservation = observationModel->computeIdealObservationsWithLinkEndData(
+            observationTime, receiver, linkEndTimes, linkEndStates, fileAncillarySettings );
+    BOOST_CHECK_SMALL( std::fabs( linkEndTimes.at( 2 ) - linkEndTimes.at( 1 ) - vehicleSystemDelay ),
+                       observationTime * std::numeric_limits< double >::epsilon( ) );
+    BOOST_CHECK_CLOSE_FRACTION( overriddenObservation( 0 ), hybridDelayObservation( 0 ), 1.0E-12 );
+    BOOST_CHECK_GT( std::fabs( overriddenObservation( 0 ) - fileDelayObservation( 0 ) ),
+                    0.5 * physical_constants::SPEED_OF_LIGHT * ( vehicleSystemDelay - fileTransponderDelay ) );
+
+    std::vector< double > storedFileDelays = fileAncillarySettings->getAncillaryDoubleVectorData( link_ends_delays );
+    BOOST_CHECK_EQUAL( storedFileDelays.at( 0 ), uplinkDelay );
+    BOOST_CHECK_EQUAL( storedFileDelays.at( 1 ), fileTransponderDelay );
+    BOOST_CHECK_EQUAL( storedFileDelays.at( 2 ), downlinkDelay );
+
+    LinkEnds nWayLinkEnds;
+    nWayLinkEnds[ transmitter ] = LinkEndId( "Earth", "EarthStation" );
+    nWayLinkEnds[ retransmitter ] = LinkEndId( "Mars", "MarsStation" );
+    nWayLinkEnds[ retransmitter2 ] = LinkEndId( "Moon" );
+    nWayLinkEnds[ receiver ] = LinkEndId( "Earth", "EarthStation" );
+
+    const double marsVehicleDelay = 5.0E-6;
+    const double moonVehicleDelay = 8.0E-6;
+    const double ancillaryMarsDelay = 1.0E-6;
+    const double ancillaryMoonDelay = 3.0E-6;
+    bodies.at( "Mars" )->getVehicleSystems( )->setTransponderDelay( marsVehicleDelay );
+    bodies.at( "Mars" )->getVehicleSystems( )->setTransponderDelayOverridesAncillarySettings( true );
+    bodies.at( "Moon" )->getVehicleSystems( )->setTransponderDelay( moonVehicleDelay );
+    bodies.at( "Moon" )->getVehicleSystems( )->setTransponderDelayOverridesAncillarySettings( false );
+
+    std::shared_ptr< ObservationModel< 1, double, double > > nWayObservationModel =
+            ObservationModelCreator< 1, double, double >::createObservationModel( nWayRangeSimple( nWayLinkEnds ), bodies );
+    nWayObservationModel->computeIdealObservationsWithLinkEndData(
+            observationTime,
+            receiver,
+            linkEndTimes,
+            linkEndStates,
+            getNWayRangeAncillarySettings( { uplinkDelay, ancillaryMarsDelay, ancillaryMoonDelay, downlinkDelay } ) );
+    BOOST_CHECK_SMALL( std::fabs( linkEndTimes.at( 2 ) - linkEndTimes.at( 1 ) - marsVehicleDelay ),
+                       observationTime * std::numeric_limits< double >::epsilon( ) );
+    BOOST_CHECK_SMALL( std::fabs( linkEndTimes.at( 4 ) - linkEndTimes.at( 3 ) - ancillaryMoonDelay ),
+                       observationTime * std::numeric_limits< double >::epsilon( ) );
+}
+
+BOOST_AUTO_TEST_CASE( testObservationCollectionTransponderDelaySourceSelection )
+{
+    LinkEnds marsLinkEnds;
+    marsLinkEnds[ transmitter ] = LinkEndId( "Earth", "EarthStation" );
+    marsLinkEnds[ retransmitter ] = LinkEndId( "Mars", "MarsStation" );
+    marsLinkEnds[ receiver ] = LinkEndId( "Earth", "EarthStation" );
+
+    LinkEnds moonLinkEnds;
+    moonLinkEnds[ transmitter ] = LinkEndId( "Earth", "EarthStation" );
+    moonLinkEnds[ retransmitter ] = LinkEndId( "Moon", "MoonStation" );
+    moonLinkEnds[ receiver ] = LinkEndId( "Earth", "EarthStation" );
+
+    Eigen::VectorXd observationValue = Eigen::VectorXd::Zero( 1 );
+    std::vector< Eigen::VectorXd > observations = { observationValue };
+    std::vector< double > observationTimes = { 1.0E5 };
+
+    const double uplinkDelay = 4.0E-6;
+    const double marsFileDelay = 1.0E-6;
+    const double moonFileDelay = 3.0E-6;
+    const double downlinkDelay = 2.0E-6;
+
+    std::shared_ptr< ObservationAncillarySimulationSettings > marsAncillarySettings =
+            getNWayRangeAncillarySettings( { uplinkDelay, marsFileDelay, downlinkDelay } );
+    std::shared_ptr< ObservationAncillarySimulationSettings > moonAncillarySettings =
+            getNWayRangeAncillarySettings( { uplinkDelay, moonFileDelay, downlinkDelay } );
+
+    std::shared_ptr< SingleObservationSet< double, double > > marsObservationSet =
+            std::make_shared< SingleObservationSet< double, double > >( n_way_range,
+                                                                        LinkDefinition( marsLinkEnds ),
+                                                                        observations,
+                                                                        observationTimes,
+                                                                        receiver,
+                                                                        std::vector< Eigen::VectorXd >( ),
+                                                                        nullptr,
+                                                                        marsAncillarySettings );
+    std::shared_ptr< SingleObservationSet< double, double > > moonObservationSet =
+            std::make_shared< SingleObservationSet< double, double > >( n_way_range,
+                                                                        LinkDefinition( moonLinkEnds ),
+                                                                        observations,
+                                                                        observationTimes,
+                                                                        receiver,
+                                                                        std::vector< Eigen::VectorXd >( ),
+                                                                        nullptr,
+                                                                        moonAncillarySettings );
+
+    ObservationCollection< double, double > observationCollection(
+            std::vector< std::shared_ptr< SingleObservationSet< double, double > > >{ marsObservationSet, moonObservationSet } );
+    observationCollection.setTransponderDelayOverridesAncillarySettings( "Mars", true );
+
+    std::vector< double > marsDelaySources = marsAncillarySettings->getLinkEndDelaySources( );
+    std::vector< double > moonDelaySources = moonAncillarySettings->getLinkEndDelaySources( );
+    std::vector< double > marsLinkEndDelays = marsAncillarySettings->getAncillaryDoubleVectorData( link_ends_delays );
+    std::vector< double > moonLinkEndDelays = moonAncillarySettings->getAncillaryDoubleVectorData( link_ends_delays );
+
+    BOOST_CHECK_EQUAL( marsDelaySources.size( ), 3 );
+    BOOST_CHECK_EQUAL( marsDelaySources.at( 0 ), static_cast< double >( ancillary_settings_delay_source ) );
+    BOOST_CHECK_EQUAL( marsDelaySources.at( 1 ), static_cast< double >( vehicle_systems_delay_source ) );
+    BOOST_CHECK_EQUAL( marsDelaySources.at( 2 ), static_cast< double >( ancillary_settings_delay_source ) );
+    BOOST_CHECK( moonDelaySources.empty( ) || moonDelaySources.at( 1 ) == static_cast< double >( ancillary_settings_delay_source ) );
+    BOOST_CHECK_EQUAL( marsLinkEndDelays.at( 0 ), uplinkDelay );
+    BOOST_CHECK_EQUAL( marsLinkEndDelays.at( 1 ), marsFileDelay );
+    BOOST_CHECK_EQUAL( marsLinkEndDelays.at( 2 ), downlinkDelay );
+    BOOST_CHECK_EQUAL( moonLinkEndDelays.at( 1 ), moonFileDelay );
+
+    spice_interface::loadStandardSpiceKernels( );
+    std::vector< std::string > bodiesToCreate = { "Earth", "Mars" };
+    BodyListSettings defaultBodySettings = getDefaultBodySettings( bodiesToCreate );
+    SystemOfBodies bodies = createSystemOfBodies( defaultBodySettings );
+    createGroundStation( bodies.at( "Earth" ),
+                         "EarthStation",
+                         ( Eigen::Vector3d( ) << 1.0, 0.1, -1.4 ).finished( ),
+                         coordinate_conversions::geodetic_position );
+    createGroundStation( bodies.at( "Mars" ),
+                         "MarsStation",
+                         ( Eigen::Vector3d( ) << 100.0, 0.5, 2.1 ).finished( ),
+                         coordinate_conversions::geodetic_position );
+
+    const double marsVehicleDelay = 7.0E-6;
+    bodies.at( "Mars" )->getVehicleSystems( )->setTransponderDelay( marsVehicleDelay );
+
+    std::shared_ptr< ObservationModel< 1, double, double > > observationModel =
+            ObservationModelCreator< 1, double, double >::createObservationModel( twoWayRangeSimple( marsLinkEnds ), bodies );
+
+    const double observationTime = 1.0E5;
+    std::vector< double > linkEndTimes;
+    std::vector< Eigen::Vector6d > linkEndStates;
+    observationModel->computeIdealObservationsWithLinkEndData(
+            observationTime, receiver, linkEndTimes, linkEndStates, marsAncillarySettings );
+    BOOST_CHECK_SMALL( std::fabs( linkEndTimes.at( 2 ) - linkEndTimes.at( 1 ) - marsVehicleDelay ),
+                       observationTime * std::numeric_limits< double >::epsilon( ) );
+
+    observationCollection.setTransponderDelayOverridesAncillarySettings( "Mars", false );
+    observationModel->computeIdealObservationsWithLinkEndData(
+            observationTime, receiver, linkEndTimes, linkEndStates, marsAncillarySettings );
+    BOOST_CHECK_SMALL( std::fabs( linkEndTimes.at( 2 ) - linkEndTimes.at( 1 ) - marsFileDelay ),
+                       observationTime * std::numeric_limits< double >::epsilon( ) );
+}
+
 BOOST_AUTO_TEST_SUITE_END( )
 
 }  // namespace unit_tests

--- a/tests/test_tudatpy/conftest.py
+++ b/tests/test_tudatpy/conftest.py
@@ -2,6 +2,34 @@ import os
 
 import pytest
 
+# Connection failures from requests/urllib3/the stdlib. HTTP errors after a
+# completed request are left as failures.
+_REMOTE_NETWORK_EXCEPTION_NAMES = {
+    "ConnectTimeout",
+    "ConnectTimeoutError",
+    "ConnectionError",
+    "NewConnectionError",
+    "ReadTimeout",
+    "Timeout",
+    "TimeoutError",
+}
+
+
+def _exception_chain(exc):
+    seen = set()
+    while exc is not None and id(exc) not in seen:
+        seen.add(id(exc))
+        yield exc
+        exc = exc.__cause__ or exc.__context__
+
+
+def _is_remote_network_outage(exc):
+    if exc is None:
+        return False
+    return any(
+        type(item).__name__ in _REMOTE_NETWORK_EXCEPTION_NAMES for item in _exception_chain(exc)
+    )
+
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -68,3 +96,23 @@ def pytest_collection_modifyitems(config, items):
             "missing environment variable(s): " + ", ".join(missing_env),
             yellow=True,
         )
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    report = outcome.get_result()
+    if (
+        report.when != "call"
+        or not report.failed
+        or item.get_closest_marker("remote_data") is None
+        or call.excinfo is None
+        or not _is_remote_network_outage(call.excinfo.value)
+    ):
+        return
+
+    # Keep assertion/API failures as errors; skip when the remote host is unreachable.
+    report.outcome = "skipped"
+    reason = f"remote service unavailable: {call.excinfo.value}"
+    location = item.location[1] if item.location is not None else 0
+    report.longrepr = (str(item.path), location, reason)


### PR DESCRIPTION
Closes #937

ODF/TNF observations always carry a full `link_ends_delays` vector, so the VehicleSystems transponder delay from #854 never gets used, even when the spacecraft entry is just 0. Station delays from the file should still be applied.

This keeps those station delays and lets the vehicle-systems delay be used at the spacecraft instead, either from the body (`transponder_delay_overrides_ancillary_settings`) or per observation set (`set_transponder_delay_overrides_ancillary_settings`).