### PR TITLE
Skip unavailable remote-data services

### DIFF
--- a/tests/test_tudatpy/conftest.py
+++ b/tests/test_tudatpy/conftest.py
@@ -1,6 +1,9 @@
 import os
+import socket
+from urllib.error import URLError
 
 import pytest
+import requests
 
 
 def pytest_addoption(parser):
@@ -68,3 +71,28 @@ def pytest_collection_modifyitems(config, items):
             "missing environment variable(s): " + ", ".join(missing_env),
             yellow=True,
         )
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """Treat unavailable remote services as skips, not test failures."""
+    outcome = yield
+    report = outcome.get_result()
+
+    if (
+        report.when not in ("setup", "call")
+        or report.outcome != "failed"
+        or item.get_closest_marker("remote_data") is None
+        or call.excinfo is None
+        or not call.excinfo.errisinstance(
+            (requests.exceptions.RequestException, URLError, TimeoutError, socket.timeout)
+        )
+    ):
+        return
+
+    report.outcome = "skipped"
+    report.longrepr = (
+        str(item.path),
+        call.excinfo.traceback[-1].lineno,
+        f"Remote service unavailable: {call.excinfo.value}",
+    )

--- a/tests/test_tudatpy/conftest.py
+++ b/tests/test_tudatpy/conftest.py
@@ -1,9 +1,30 @@
 import os
 import socket
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 
 import pytest
 import requests
+
+
+def _is_connectivity_failure(exception):
+    """Return whether an exception represents an unavailable remote service."""
+    if isinstance(
+        exception,
+        (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            ConnectionRefusedError,
+            ConnectionResetError,
+            socket.gaierror,
+            TimeoutError,
+        ),
+    ):
+        return not isinstance(
+            exception,
+            (requests.exceptions.SSLError, requests.exceptions.InvalidURL),
+        )
+
+    return isinstance(exception, URLError) and not isinstance(exception, HTTPError)
 
 
 def pytest_addoption(parser):
@@ -84,9 +105,7 @@ def pytest_runtest_makereport(item, call):
         or report.outcome != "failed"
         or item.get_closest_marker("remote_data") is None
         or call.excinfo is None
-        or not call.excinfo.errisinstance(
-            (requests.exceptions.RequestException, URLError, TimeoutError, socket.timeout)
-        )
+        or not _is_connectivity_failure(call.excinfo.value)
     ):
         return
 

--- a/tests/test_tudatpy/test_remote_data_policy.py
+++ b/tests/test_tudatpy/test_remote_data_policy.py
@@ -1,0 +1,52 @@
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import requests
+
+_CONFTEST_SPEC = importlib.util.spec_from_file_location(
+    "remote_data_conftest", Path(__file__).with_name("conftest.py")
+)
+conftest = importlib.util.module_from_spec(_CONFTEST_SPEC)
+_CONFTEST_SPEC.loader.exec_module(conftest)
+
+
+class _HookOutcome:
+    def __init__(self, report):
+        self.report = report
+
+    def get_result(self):
+        return self.report
+
+
+def _run_report_hook(exception):
+    try:
+        raise exception
+    except Exception:
+        excinfo = pytest.ExceptionInfo.from_current()
+
+    item = SimpleNamespace(
+        path="test_remote.py",
+        get_closest_marker=lambda marker: object() if marker == "remote_data" else None,
+    )
+    call = SimpleNamespace(excinfo=excinfo)
+    report = SimpleNamespace(when="call", outcome="failed", longrepr=None)
+    hook = conftest.pytest_runtest_makereport(item, call)
+    next(hook)
+    with pytest.raises(StopIteration):
+        hook.send(_HookOutcome(report))
+    return report
+
+
+def test_remote_connection_failure_is_skipped():
+    report = _run_report_hook(requests.ConnectionError("offline"))
+
+    assert report.outcome == "skipped"
+    assert "Remote service unavailable: offline" in report.longrepr[2]
+
+
+def test_remote_assertion_failure_still_fails():
+    report = _run_report_hook(AssertionError("incorrect result"))
+
+    assert report.outcome == "failed"

--- a/tests/test_tudatpy/test_remote_data_policy.py
+++ b/tests/test_tudatpy/test_remote_data_policy.py
@@ -1,6 +1,8 @@
 import importlib.util
+import socket
 from pathlib import Path
 from types import SimpleNamespace
+from urllib.error import HTTPError, URLError
 
 import pytest
 import requests
@@ -39,14 +41,37 @@ def _run_report_hook(exception):
     return report
 
 
-def test_remote_connection_failure_is_skipped():
-    report = _run_report_hook(requests.ConnectionError("offline"))
+@pytest.mark.parametrize(
+    "exception",
+    (
+        requests.ConnectionError("offline"),
+        requests.ConnectTimeout("connect timed out"),
+        requests.ReadTimeout("read timed out"),
+        ConnectionRefusedError("connection refused"),
+        ConnectionResetError("connection reset"),
+        socket.gaierror("name resolution failed"),
+        URLError("offline"),
+    ),
+)
+def test_remote_connectivity_failure_is_skipped(exception):
+    report = _run_report_hook(exception)
 
     assert report.outcome == "skipped"
-    assert "Remote service unavailable: offline" in report.longrepr[2]
+    assert "Remote service unavailable:" in report.longrepr[2]
 
 
-def test_remote_assertion_failure_still_fails():
-    report = _run_report_hook(AssertionError("incorrect result"))
+@pytest.mark.parametrize(
+    "exception",
+    (
+        AssertionError("incorrect result"),
+        requests.HTTPError("HTTP 500"),
+        requests.exceptions.InvalidURL("invalid URL"),
+        requests.exceptions.InvalidJSONError("invalid JSON"),
+        requests.exceptions.SSLError("certificate verification failed"),
+        HTTPError("https://example.invalid", 500, "server error", None, None),
+    ),
+)
+def test_non_connectivity_failure_still_fails(exception):
+    report = _run_report_hook(exception)
 
     assert report.outcome == "failed"


### PR DESCRIPTION
## Summary

Run remote-data tests by default, but skip them when an external service is unavailable or times out. Real test failures remain failures.

Adds regression tests for this behavior.

 Closes #643.
