### PR TITLE
Fix/933

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -16,3 +16,5 @@ values =
 [bumpversion:part:dev]
 
 [bumpversion:file:version]
+
+[bumpversion:file:src/tudatpy/__init__.py]

--- a/.github/workflows/bump_dev_version_nightly.yml
+++ b/.github/workflows/bump_dev_version_nightly.yml
@@ -79,14 +79,14 @@ jobs:
           ref: develop
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Install bump2version and run bumpversion
+      - name: Install Bump My Version and bump the version
         run: |
             python3 -m venv venv
             source venv/bin/activate
-            pip install bump2version
+            pip install 'bump-my-version>=1,<2'
             git config --global user.email "actions@github.com"
             git config --global user.name "GitHub Actions"
-            bump2version dev --config-file .bumpversion.cfg --verbose
+            bump-my-version bump dev --config-file .bumpversion.cfg --verbose
       - name: Push tag to tudatpy repository
         run: git push origin --follow-tags
         env:
@@ -114,14 +114,14 @@ jobs:
             token: ${{ steps.app-token.outputs.token }}
             ref: develop
 
-        - name: Install bump2version and run bumpversion
+        - name: Install Bump My Version and bump the version
           run: |
                python3 -m venv venv
                source venv/bin/activate
-               pip install bump2version
+               pip install 'bump-my-version>=1,<2'
                git config --global user.email "actions@github.com"
                git config --global user.name "GitHub Actions"
-               bump2version dev --config-file .bumpversion.cfg --verbose
+               bump-my-version bump dev --config-file .bumpversion.cfg --verbose
         - name: Reset build number in meta.yml to 0
           shell: bash
           run: |

--- a/src/tudatpy/__init__.py
+++ b/src/tudatpy/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2025 - Tudat Development Team
 # This file is part of tudatpy.
 
-__version__ = "1.0.0.dev66"
+__version__ = "1.0.0.dev70"


### PR DESCRIPTION
 Update the version-bump configuration to modify src/tudatpy/__init__.py alongside the root version file, preventing CMake from leaving the repository dirty after a bump.

Replace deprecated bump2version with its maintained successor, 'bump my version', keeping the existing version scheme and workflow behavior.

 Closes #933
