### PR TITLE
Add new constrainedTranslationalStateParameter

### DIFF
--- a/include/tudat/astro/orbit_determination/estimatable_parameters/constrainedTranslationalState.h
+++ b/include/tudat/astro/orbit_determination/estimatable_parameters/constrainedTranslationalState.h
@@ -24,8 +24,26 @@ template< typename InitialStateParameterType = double >
 class ConstrainedTranslationalStateParameter : public InitialTranslationalStateParameter< InitialStateParameterType >
 {
 public:
-    //! Inherit constructors from the base class
-    using InitialTranslationalStateParameter< InitialStateParameterType >::InitialTranslationalStateParameter;
+    //! Constructor, sets initial value of translational state.
+    /*!
+     * Constructor, sets initial value of translational state. Explicitly forwards to the base class constructor with
+     * parameterType set to constrained_initial_body_state, so that this parameter correctly identifies itself as distinct
+     * from a plain InitialTranslationalStateParameter (e.g. via getParameterName()).
+     * \param associatedBody Body for which initial state is to be estimated.
+     * \param initialTranslationalState Current value of initial state (w.r.t. centralBody)
+     * \param centralBody Body w.r.t. which the initial state is to be estimated.
+     * \param frameOrientation Orientation of the frame in which the state is defined.
+     */
+    ConstrainedTranslationalStateParameter( const std::string& associatedBody,
+                                            const Eigen::Matrix< InitialStateParameterType, Eigen::Dynamic, 1 >& initialTranslationalState,
+                                            const std::string& centralBody = "SSB",
+                                            const std::string& frameOrientation = "ECLIPJ2000" ):
+        InitialTranslationalStateParameter< InitialStateParameterType >( associatedBody,
+                                                                         initialTranslationalState,
+                                                                         centralBody,
+                                                                         frameOrientation,
+                                                                         constrained_initial_body_state )
+    {}
 
     //! Function to get the size of the constraint
     /*!

--- a/include/tudat/astro/orbit_determination/estimatable_parameters/constrainedTranslationalState.h
+++ b/include/tudat/astro/orbit_determination/estimatable_parameters/constrainedTranslationalState.h
@@ -1,0 +1,91 @@
+/*    Copyright (c) 2010-2026, Delft University of Technology
+ *    All rigths reserved
+ *
+ *    This file is part of the Tudat. Redistribution and use in source and
+ *    binary forms, with or without modification, are permitted exclusively
+ *    under the terms of the Modified BSD license. You should have received
+ *    a copy of the license with this file. If not, please or visit:
+ *    http://tudat.tudelft.nl/LICENSE.
+ */
+
+#ifndef TUDAT_CONSTRAINED_TRANSLATIONAL_STATE_H
+#define TUDAT_CONSTRAINED_TRANSLATIONAL_STATE_H
+
+#include <Eigen/Core>
+#include "tudat/astro/orbit_determination/estimatable_parameters/initialTranslationalState.h"
+
+namespace tudat
+{
+namespace estimatable_parameters
+{
+
+//! Constrained initial translational state parameter for Line of Variations (LOV) differential correction.
+template< typename InitialStateParameterType = double >
+class ConstrainedTranslationalStateParameter : public InitialTranslationalStateParameter< InitialStateParameterType >
+{
+public:
+    //! Inherit constructors from the base class
+    using InitialTranslationalStateParameter< InitialStateParameterType >::InitialTranslationalStateParameter;
+
+    //! Function to get the size of the constraint
+    /*!
+     * \return Size of the constraint (1 for the orthogonality condition).
+     */
+    int getConstraintSize( ) override
+    {
+        return 1;
+    }
+
+    //! Function to get the multiplier of the parameter constraint
+    /*!
+     * \return Multiplier of the parameter constraint (transposed weak direction).
+     * NOTE: The spelling 'Multipler' intentionally matches the base EstimatableParameter class.
+     */
+    Eigen::MatrixXd getConstraintStateMultipler( ) override
+    {
+        // Initialize 1xN matrix (N=6 for translational state) for the constraint multiplier
+        Eigen::MatrixXd constraintMultiplier = Eigen::MatrixXd::Zero( 1, this->getParameterSize( ) );
+
+        // Populate the row with the transposed weak direction
+        constraintMultiplier.row( 0 ) = weakDirection_.transpose( );
+
+        return constraintMultiplier;
+    }
+
+    //! Function to get the right-hand side of the parameter constraint
+    /*!
+     * \return Right-hand side of the parameter constraint (0 for exact orthogonality).
+     */
+    Eigen::VectorXd getConstraintRightHandSide( ) override
+    {
+        // For exact orthogonality, dot product = 0
+        return Eigen::VectorXd::Zero( 1 );
+    }
+
+    //! Function to dynamically set the weak direction used for the constraint
+    /*!
+     * \param newWeakDirection New weak direction vector evaluated at the current state.
+     */
+    void setWeakDirection( const Eigen::Matrix< double, 6, 1 >& newWeakDirection )
+    {
+        weakDirection_ = newWeakDirection;
+    }
+
+    //! Function to retrieve the currently set weak direction
+    /*!
+     * \return Current weak direction vector.
+     */
+    Eigen::Matrix< double, 6, 1 > getWeakDirection( ) const
+    {
+        return weakDirection_;
+    }
+
+private:
+    //! Weak direction vector restricting the differential correction.
+    Eigen::Matrix< double, 6, 1 > weakDirection_ = Eigen::Matrix< double, 6, 1 >::Zero( );
+};
+
+}  // namespace estimatable_parameters
+}  // namespace tudat
+
+#endif  // TUDAT_CONSTRAINED_TRANSLATIONAL_STATE_H

--- a/include/tudat/astro/orbit_determination/estimatable_parameters/estimatableParameter.h
+++ b/include/tudat/astro/orbit_determination/estimatable_parameters/estimatableParameter.h
@@ -744,6 +744,10 @@ bool isDynamicalParameterSingleArc(
             flag = true;
             break;
         }
+        case constrained_initial_body_state: {
+            flag = true;
+            break;
+        }
         case initial_rotational_body_state: {
             flag = true;
             break;

--- a/include/tudat/astro/orbit_determination/estimatable_parameters/estimatableParameter.h
+++ b/include/tudat/astro/orbit_determination/estimatable_parameters/estimatableParameter.h
@@ -38,6 +38,7 @@ namespace estimatable_parameters
 enum EstimatebleParametersEnum {
     arc_wise_initial_body_state,
     initial_body_state,
+    constrained_initial_body_state,
     initial_rotational_body_state,
     initial_mass_state,
     gravitational_parameter,

--- a/include/tudat/astro/orbit_determination/estimatable_parameters/estimatableParameterSet.h
+++ b/include/tudat/astro/orbit_determination/estimatable_parameters/estimatableParameterSet.h
@@ -985,7 +985,8 @@ std::vector< std::string > getListOfBodiesWithTranslationalStateToEstimate(
     // Iterate over list of bodies of which the partials of the accelerations acting on them are required.
     for( unsigned int i = 0; i < initialDynamicalParameters.size( ); i++ )
     {
-        if( initialDynamicalParameters.at( i )->getParameterName( ).first == initial_body_state )
+        if( ( initialDynamicalParameters.at( i )->getParameterName( ).first == initial_body_state ) ||
+            ( initialDynamicalParameters.at( i )->getParameterName( ).first == constrained_initial_body_state ) )
         {
             bodiesToEstimate.push_back( initialDynamicalParameters.at( i )->getParameterName( ).second.first );
         }
@@ -1091,6 +1092,7 @@ std::map< propagators::IntegratedStateType, std::vector< std::string > > getList
     for( unsigned int i = 0; i < initialDynamicalParameters.size( ); i++ )
     {
         if( ( initialDynamicalParameters.at( i )->getParameterName( ).first == initial_body_state ) ||
+            ( initialDynamicalParameters.at( i )->getParameterName( ).first == constrained_initial_body_state ) ||
             ( initialDynamicalParameters.at( i )->getParameterName( ).first == arc_wise_initial_body_state ) )
         {
             bodiesToEstimate[ propagators::translational_state ].push_back(
@@ -1129,6 +1131,7 @@ getListOfTranslationalStateParametersToEstimate(
     for( unsigned int i = 0; i < initialDynamicalParameters.size( ); i++ )
     {
         if( ( initialDynamicalParameters.at( i )->getParameterName( ).first == initial_body_state ) ||
+            ( initialDynamicalParameters.at( i )->getParameterName( ).first == constrained_initial_body_state ) ||
             ( initialDynamicalParameters.at( i )->getParameterName( ).first == arc_wise_initial_body_state ) )
         {
             translationalStateParameters.push_back( initialDynamicalParameters.at( i ) );
@@ -1216,6 +1219,7 @@ getListOfInitialDynamicalStateParametersEstimate(
     for( unsigned int i = 0; i < initialDynamicalParameters.size( ); i++ )
     {
         if( ( initialDynamicalParameters.at( i )->getParameterName( ).first == initial_body_state ) ||
+            ( initialDynamicalParameters.at( i )->getParameterName( ).first == constrained_initial_body_state ) ||
             ( initialDynamicalParameters.at( i )->getParameterName( ).first == arc_wise_initial_body_state ) )
         {
             initialDynamicalStateParametersEstimate[ propagators::translational_state ].push_back(

--- a/include/tudat/astro/orbit_determination/estimatable_parameters/initialTranslationalState.h
+++ b/include/tudat/astro/orbit_determination/estimatable_parameters/initialTranslationalState.h
@@ -31,12 +31,15 @@ public:
      * \param initialTranslationalState Current value of initial state (w.r.t. centralBody)
      * \param centralBody Body w.r.t. which the initial state is to be estimated.
      * \param frameOrientation Orientation of the frame in which the state is defined.
+     * \param parameterType Enum identifying the type of this parameter, used by derived classes to identify themselves as a
+     * distinct parameter type (e.g. ConstrainedTranslationalStateParameter) while reusing this constructor.
      */
     InitialTranslationalStateParameter( const std::string& associatedBody,
                                         const Eigen::Matrix< InitialStateParameterType, Eigen::Dynamic, 1 >& initialTranslationalState,
                                         const std::string& centralBody = "SSB",
-                                        const std::string& frameOrientation = "ECLIPJ2000" ):
-        EstimatableParameter< Eigen::Matrix< InitialStateParameterType, Eigen::Dynamic, 1 > >( initial_body_state, associatedBody ),
+                                        const std::string& frameOrientation = "ECLIPJ2000",
+                                        const EstimatebleParametersEnum parameterType = initial_body_state ):
+        EstimatableParameter< Eigen::Matrix< InitialStateParameterType, Eigen::Dynamic, 1 > >( parameterType, associatedBody ),
         initialTranslationalState_( initialTranslationalState ), centralBody_( centralBody ), frameOrientation_( frameOrientation )
     {}
 

--- a/include/tudat/astro/propagators/variationalEquations.h
+++ b/include/tudat/astro/propagators/variationalEquations.h
@@ -458,7 +458,9 @@ private:
         // Retrieve propagated bodies and central bodies of estimation.
         for( unsigned int i = 0; i < initialDynamicalParameters.size( ); i++ )
         {
-            if( initialDynamicalParameters.at( i )->getParameterName( ).first == estimatable_parameters::initial_body_state )
+            if( ( initialDynamicalParameters.at( i )->getParameterName( ).first == estimatable_parameters::initial_body_state ) ||
+                ( initialDynamicalParameters.at( i )->getParameterName( ).first ==
+                  estimatable_parameters::constrained_initial_body_state ) )
             {
                 propagatedBodies.push_back( initialDynamicalParameters.at( i )->getParameterName( ).second.first );
                 centralBodies.push_back(

--- a/include/tudat/simulation/estimation_setup/createAccelerationPartials.h
+++ b/include/tudat/simulation/estimation_setup/createAccelerationPartials.h
@@ -64,10 +64,12 @@ std::shared_ptr< estimatable_parameters::CustomAccelerationPartialCalculator > c
     if( numericalCustomPartialSettings != nullptr )
     {
         if( !( ( parameter->getParameterName( ).first == estimatable_parameters::initial_body_state ) ||
+               ( parameter->getParameterName( ).first == estimatable_parameters::constrained_initial_body_state ) ||
                ( parameter->getParameterName( ).first == estimatable_parameters::arc_wise_initial_body_state ) ) )
         {
             throw std::runtime_error(
-                    "Error, only (single-arc or arc-wise) initial cartesian state supported for custom numerical acceleration partial" );
+                    "Error, only (single-arc, constrained, or arc-wise) initial cartesian state supported for custom numerical "
+                    "acceleration partial" );
         }
         std::string bodyName = parameter->getParameterName( ).second.first;
         if( bodies.count( bodyName ) == 0 )
@@ -1002,6 +1004,8 @@ orbit_determination::StateDerivativePartialsMap createAccelerationPartialsMap(
             if( initialDynamicalParameters.at( i )->getParameterName( ).second.first == accelerationIterator->first )
             {
                 if( ( initialDynamicalParameters.at( i )->getParameterName( ).first == estimatable_parameters::initial_body_state ) ||
+                    ( initialDynamicalParameters.at( i )->getParameterName( ).first ==
+                      estimatable_parameters::constrained_initial_body_state ) ||
                     ( initialDynamicalParameters.at( i )->getParameterName( ).first ==
                       estimatable_parameters::arc_wise_initial_body_state ) )
                 {

--- a/include/tudat/simulation/estimation_setup/createDirectObservationPartials.h
+++ b/include/tudat/simulation/estimation_setup/createDirectObservationPartials.h
@@ -244,6 +244,7 @@ createSingleLinkObservationPartials(
     {
         std::string acceleratedBody;
         if( initialDynamicalParameters.at( i )->getParameterName( ).first == estimatable_parameters::initial_body_state ||
+            initialDynamicalParameters.at( i )->getParameterName( ).first == estimatable_parameters::constrained_initial_body_state ||
             initialDynamicalParameters.at( i )->getParameterName( ).first == estimatable_parameters::arc_wise_initial_body_state )
         {
             acceleratedBody = initialDynamicalParameters.at( i )->getParameterName( ).second.first;

--- a/include/tudat/simulation/estimation_setup/createEstimatableParametersFactory.h
+++ b/include/tudat/simulation/estimation_setup/createEstimatableParametersFactory.h
@@ -1047,6 +1047,53 @@ createInitialDynamicalStateParameterToEstimate(
                     initialStateParameterToEstimate = initialTranslationalStateParameter;
                 }
                 break;
+            case constrained_initial_body_state:
+
+                // Check consistency of input.
+                if( std::dynamic_pointer_cast< ConstrainedTranslationalStateEstimatableParameterSettings< InitialStateParameterType > >(
+                            parameterSettings ) == nullptr )
+                {
+                    throw std::runtime_error( "Error when making constrained body initial state parameter, settings type is incompatible" );
+                }
+                else
+                {
+                    std::shared_ptr< ConstrainedTranslationalStateEstimatableParameterSettings< InitialStateParameterType > >
+                            constrainedInitialStateSettings = std::dynamic_pointer_cast<
+                                    ConstrainedTranslationalStateEstimatableParameterSettings< InitialStateParameterType > >(
+                                    parameterSettings );
+
+                    Eigen::Matrix< InitialStateParameterType, Eigen::Dynamic, 1 > initialTranslationalState;
+
+                    // If initial time is not defined, use preset initial state
+                    if( !( constrainedInitialStateSettings->initialTime_ == constrainedInitialStateSettings->initialTime_ ) )
+                    {
+                        initialTranslationalState = constrainedInitialStateSettings->initialStateValue_;
+                    }
+                    // Compute initial state from environment
+                    else
+                    {
+                        initialTranslationalState = propagators::getInitialStateOfBody< double, InitialStateParameterType >(
+                                constrainedInitialStateSettings->parameterType_.second.first,
+                                constrainedInitialStateSettings->centralBody_,
+                                bodies,
+                                constrainedInitialStateSettings->initialTime_ );
+                    }
+
+                    // Create constrained translational state estimation interface object
+                    std::shared_ptr< ConstrainedTranslationalStateParameter< InitialStateParameterType > >
+                            constrainedTranslationalStateParameter =
+                                    std::make_shared< ConstrainedTranslationalStateParameter< InitialStateParameterType > >(
+                                            constrainedInitialStateSettings->parameterType_.second.first,
+                                            initialTranslationalState,
+                                            constrainedInitialStateSettings->centralBody_,
+                                            constrainedInitialStateSettings->frameOrientation_ );
+                    constrainedTranslationalStateParameter->addStateClosureFunctions(
+                            constrainedInitialStateSettings->initialStateGetFunction_,
+                            constrainedInitialStateSettings->initialStateSetFunction_ );
+                    constrainedTranslationalStateParameter->setWeakDirection( constrainedInitialStateSettings->weakDirection_ );
+                    initialStateParameterToEstimate = constrainedTranslationalStateParameter;
+                }
+                break;
             case arc_wise_initial_body_state:
                 if( std::dynamic_pointer_cast< ArcWiseInitialTranslationalStateEstimatableParameterSettings< InitialStateParameterType > >(
                             parameterSettings ) == nullptr )

--- a/include/tudat/simulation/estimation_setup/createEstimatableParametersFactory.h
+++ b/include/tudat/simulation/estimation_setup/createEstimatableParametersFactory.h
@@ -19,6 +19,7 @@
 #include "tudat/astro/orbit_determination/estimatable_parameters/estimatableParameter.h"
 #include "tudat/astro/orbit_determination/estimatable_parameters/areaToMassScalingFactor.h"
 #include "tudat/astro/orbit_determination/estimatable_parameters/initialTranslationalState.h"
+#include "tudat/astro/orbit_determination/estimatable_parameters/constrainedTranslationalState.h"
 #include "tudat/astro/orbit_determination/estimatable_parameters/initialRotationalState.h"
 #include "tudat/astro/orbit_determination/estimatable_parameters/initialMassState.h"
 #include "tudat/astro/orbit_determination/estimatable_parameters/constantDragCoefficient.h"

--- a/include/tudat/simulation/estimation_setup/createObservationBiasPartial.h
+++ b/include/tudat/simulation/estimation_setup/createObservationBiasPartial.h
@@ -38,7 +38,9 @@ std::shared_ptr< ObservationPartial< ObservationSize > > getPartialWrtBodyTransl
     for( auto it : observationPartials )
     {
         estimatable_parameters::EstimatebleParameterIdentifier currentParameter = it.second->getParameterIdentifier( );
-        if( currentParameter.first == estimatable_parameters::initial_body_state && currentParameter.second.second == bodyName )
+        if( ( currentParameter.first == estimatable_parameters::initial_body_state ||
+              currentParameter.first == estimatable_parameters::constrained_initial_body_state ) &&
+            currentParameter.second.second == bodyName )
         {
             if( selectedObservationPartial != nullptr )
             {

--- a/include/tudat/simulation/estimation_setup/estimatableParameterSettings.h
+++ b/include/tudat/simulation/estimation_setup/estimatableParameterSettings.h
@@ -500,6 +500,73 @@ public:
     std::function< void( const Eigen::Matrix< InitialStateParameterType, Eigen::Dynamic, 1 >& ) > initialStateSetFunction_;
 };
 
+//! Class to define settings for estimating a constrained initial translational state (Line of Variations differential correction).
+template< typename InitialStateParameterType = double >
+class ConstrainedTranslationalStateEstimatableParameterSettings : public EstimatableParameterSettings
+{
+public:
+    //! Constructor, sets initial value of translational state.
+    /*!
+     * Constructor, sets initial value of translational state.
+     * \param associatedBody Body for which initial state is to be estimated.
+     * \param initialStateValue Current value of initial state (w.r.t. centralBody)
+     * \param weakDirection Direction (tangent to the Line of Variations) to which the update of the differential
+     * correction must remain orthogonal. Defaults to the zero vector, to be set later.
+     * \param centralBody Body w.r.t. which the initial state is to be estimated.
+     * \param frameOrientation Orientation of the frame in which the state is defined.
+     */
+    ConstrainedTranslationalStateEstimatableParameterSettings(
+            const std::string& associatedBody,
+            const Eigen::Matrix< InitialStateParameterType, 6, 1 > initialStateValue,
+            const Eigen::Matrix< double, 6, 1 >& weakDirection = Eigen::Matrix< double, 6, 1 >::Zero( ),
+            const std::string& centralBody = "SSB",
+            const std::string& frameOrientation = "ECLIPJ2000" ):
+        EstimatableParameterSettings( associatedBody, constrained_initial_body_state ), initialTime_( TUDAT_NAN ),
+        initialStateValue_( initialStateValue ), weakDirection_( weakDirection ), centralBody_( centralBody ),
+        frameOrientation_( frameOrientation )
+    {}
+
+    //! Constructor, without initial value of translational state.
+    /*!
+     * Constructor, without initial value of translational state. Current initial state is retrieved from environment
+     * (ephemeris objects) during creation of parameter object.
+     * \param associatedBody Body for which initial state is to be estimated.
+     * \param initialTime Time at which initial state is defined.
+     * \param weakDirection Direction (tangent to the Line of Variations) to which the update of the differential
+     * correction must remain orthogonal. Defaults to the zero vector, to be set later.
+     * \param centralBody Body w.r.t. which the initial state is to be estimated.
+     * \param frameOrientation Orientation of the frame in which the state is defined.
+     */
+    ConstrainedTranslationalStateEstimatableParameterSettings(
+            const std::string& associatedBody,
+            const double initialTime,
+            const Eigen::Matrix< double, 6, 1 >& weakDirection = Eigen::Matrix< double, 6, 1 >::Zero( ),
+            const std::string& centralBody = "SSB",
+            const std::string& frameOrientation = "ECLIPJ2000" ):
+        EstimatableParameterSettings( associatedBody, constrained_initial_body_state ), initialTime_( initialTime ),
+        weakDirection_( weakDirection ), centralBody_( centralBody ), frameOrientation_( frameOrientation )
+    {}
+
+    //! Time at which initial state is defined (NaN for user-defined initial state value).
+    double initialTime_;
+
+    //! Current value of initial state (w.r.t. centralBody), set manually by used.
+    Eigen::Matrix< InitialStateParameterType, 6, 1 > initialStateValue_;
+
+    //! Direction (tangent to the Line of Variations) to which the update of the differential correction must remain orthogonal.
+    Eigen::Matrix< double, 6, 1 > weakDirection_;
+
+    //! Body w.r.t. which the initial state is to be estimated.
+    std::string centralBody_;
+
+    //! Orientation of the frame in which the state is defined.
+    std::string frameOrientation_;
+
+    std::function< Eigen::Matrix< InitialStateParameterType, Eigen::Dynamic, 1 >( ) > initialStateGetFunction_;
+
+    std::function< void( const Eigen::Matrix< InitialStateParameterType, Eigen::Dynamic, 1 >& ) > initialStateSetFunction_;
+};
+
 //! Class to define settings for estimating an arcwise initial translational state.
 template< typename InitialStateParameterType >
 class ArcWiseInitialTranslationalStateEstimatableParameterSettings : public EstimatableParameterSettings

--- a/include/tudat/simulation/estimation_setup/estimatableParameterSettings.h
+++ b/include/tudat/simulation/estimation_setup/estimatableParameterSettings.h
@@ -1267,6 +1267,19 @@ inline std::shared_ptr< EstimatableParameterSettings > constantDragCoefficient( 
     return std::make_shared< EstimatableParameterSettings >( bodyName, constant_drag_coefficient );
 }
 
+//! Settings for estimating a constrained initial translational state (Line of Variations differential correction).
+template< typename InitialStateParameterType = double >
+inline std::shared_ptr< EstimatableParameterSettings > constrainedInitialTranslationalState(
+        const std::string& bodyName,
+        const Eigen::Matrix< InitialStateParameterType, 6, 1 >& initialStateValue,
+        const Eigen::Matrix< double, 6, 1 >& weakDirection = Eigen::Matrix< double, 6, 1 >::Zero( ),
+        const std::string& centralBody = "SSB",
+        const std::string& frameOrientation = "ECLIPJ2000" )
+{
+    return std::make_shared< ConstrainedTranslationalStateEstimatableParameterSettings< InitialStateParameterType > >(
+            bodyName, initialStateValue, weakDirection, centralBody, frameOrientation );
+}
+
 inline std::shared_ptr< EstimatableParameterSettings > fullAccelerationScaling(
         const std::string& bodyUndergoingAcceleration,
         const std::string& bodyExertingAcceleration,

--- a/include/tudat/simulation/estimation_setup/orbitDeterminationManagerCovarianceImplementation.h
+++ b/include/tudat/simulation/estimation_setup/orbitDeterminationManagerCovarianceImplementation.h
@@ -78,6 +78,19 @@ OrbitDeterminationManager< ObservationScalarType, TimeType, Dummy >::computeCova
     Eigen::VectorXd constraintRightHandSide;
     parametersToEstimate_->getConstraints( constraintStateMultiplier, constraintRightHandSide );
 
+    // Constraints are expressed in physical parameter units, but designMatrixEstimatedParameters (and therefore
+    // the normal equations into which the constraint is embedded) has already been rescaled to normalized units
+    // by normalizeDesignMatrix. Since the solved correction relates to the physical one by
+    // deltaXSolved(i) = normalizationTerms(i) * deltaXPhysical(i), the constraint row must be divided (not left
+    // as-is) by the same normalizationTerms to remain consistent with that rescaling.
+    if( constraintStateMultiplier.rows( ) > 0 )
+    {
+        for( int i = 0; i < constraintStateMultiplier.cols( ); i++ )
+        {
+            constraintStateMultiplier.col( i ) /= normalizationTerms( i );
+        }
+    }
+
     // Compute inverse of updated covariance
     Eigen::MatrixXd inverseNormalizedCovariance = linear_algebra::calculateInverseOfUpdatedCovarianceMatrix(
             designMatrixEstimatedParameters.block( 0, 0, designMatrixEstimatedParameters.rows( ), numberEstimatedParameters_ ),

--- a/include/tudat/simulation/estimation_setup/orbitDeterminationManagerEstimationImplementation.h
+++ b/include/tudat/simulation/estimation_setup/orbitDeterminationManagerEstimationImplementation.h
@@ -158,6 +158,19 @@ OrbitDeterminationManager< ObservationScalarType, TimeType, Dummy >::estimatePar
             Eigen::VectorXd constraintRightHandSide;
             parametersToEstimate_->getConstraints( constraintStateMultiplier, constraintRightHandSide );
 
+            // Constraints are expressed in physical parameter units, but designMatrixEstimatedParameters (and
+            // therefore the normal equations into which the constraint is embedded) has already been rescaled to
+            // normalized units by normalizeDesignMatrix. Since the solved correction relates to the physical one by
+            // deltaXSolved(i) = normalizationTerms(i) * deltaXPhysical(i), the constraint row must be divided
+            // by the same normalizationTerms to remain consistent with that rescaling.
+            if( constraintStateMultiplier.rows( ) > 0 )
+            {
+                for( int i = 0; i < constraintStateMultiplier.cols( ); i++ )
+                {
+                    constraintStateMultiplier.col( i ) /= normalizationTerms( i );
+                }
+            }
+
             double conditionNumberCheck = estimationInput->getLimitConditionNumberForWarning( );
             if( numberOfIterations > 0 && estimationInput->conditionNumberWarningEachIteration_ == false )
             {

--- a/src/tudat/astro/orbit_determination/estimatable_parameters/estimatableParameter.cpp
+++ b/src/tudat/astro/orbit_determination/estimatable_parameters/estimatableParameter.cpp
@@ -27,6 +27,9 @@ std::string getParameterTypeString( const EstimatebleParametersEnum parameterTyp
         case initial_body_state:
             parameterDescription = "translational state ";
             break;
+        case constrained_initial_body_state:
+            parameterDescription = "constrained translational state ";
+            break;
         case initial_rotational_body_state:
             parameterDescription = "rotational state ";
             break;
@@ -261,6 +264,9 @@ bool isParameterDynamicalPropertyInitialState( const EstimatebleParametersEnum p
             flag = true;
             break;
         case initial_body_state:
+            flag = true;
+            break;
+        case constrained_initial_body_state:
             flag = true;
             break;
         case initial_rotational_body_state:

--- a/src/tudatpy/dynamics/parameters_setup/expose_parameters_setup.cpp
+++ b/src/tudatpy/dynamics/parameters_setup/expose_parameters_setup.cpp
@@ -63,6 +63,7 @@ void expose_parameters_setup_types( py::module& m )
       )doc" )
             .value( "arc_wise_initial_body_state_type", tep::EstimatebleParametersEnum::arc_wise_initial_body_state )
             .value( "initial_body_state_type", tep::EstimatebleParametersEnum::initial_body_state )
+            .value( "constrained_initial_body_state_type", tep::EstimatebleParametersEnum::constrained_initial_body_state )
             .value( "initial_rotational_body_state_type", tep::EstimatebleParametersEnum::initial_rotational_body_state )
             .value( "gravitational_parameter_type", tep::EstimatebleParametersEnum::gravitational_parameter )
             .value( "constant_drag_coefficient_type", tep::EstimatebleParametersEnum::constant_drag_coefficient )
@@ -256,6 +257,79 @@ void expose_parameters_setup( py::module& m )
 
      )doc" );
 
+    py::class_< tep::InitialTranslationalStateParameter< double >, std::shared_ptr< tep::InitialTranslationalStateParameter< double > > >(
+            m,
+            "InitialTranslationalStateParameter",
+            R"doc(
+
+Base class for initial translational state parameters.
+
+Base class representing an estimatable initial translational state parameter.
+It is typically created automatically by the parameter factory.
+
+     )doc" );
+
+    py::class_< tep::ConstrainedTranslationalStateParameter< double >,
+                std::shared_ptr< tep::ConstrainedTranslationalStateParameter< double > >,
+                tep::InitialTranslationalStateParameter< double > >( m,
+                                                                     "ConstrainedTranslationalStateParameter",
+                                                                     R"doc(
+
+Custom parameter class for constrained Line of Variations (LOV) differential corrections.
+
+Class representing a constrained initial translational state parameter.
+It enforces orthogonality to the weak direction during the estimation process by defining a custom parameter constraint.
+
+     )doc" )
+            .def( py::init< const std::string&, const Eigen::VectorXd&, const std::string&, const std::string& >( ),
+                  py::arg( "associated_body" ),
+                  py::arg( "initial_state" ),
+                  py::arg( "central_body" ),
+                  py::arg( "frame_orientation" ) = "",
+                  R"doc(
+
+Constructor for the constrained translational state parameter.
+
+Parameters
+----------
+associated_body : str
+    Name of the body whose initial state is estimated.
+initial_state : numpy.ndarray[numpy.float64[6, 1]]
+    Initial guess for the 6D Cartesian state.
+central_body : str
+    The central body w.r.t. which the state is defined.
+frame_orientation : str = ""
+    Orientation of the frame in which the state is defined.
+
+     )doc" )
+            .def( "set_weak_direction",
+                  &tep::ConstrainedTranslationalStateParameter< double >::setWeakDirection,
+                  py::arg( "weak_direction" ),
+                  R"doc(
+
+Set the weak direction vector for the constrained LOV update.
+
+Method to dynamically update the weak direction vector (the tangent to the Line of Variations) at the current state. This vector acts as the constraint multiplier during the differential correction step.
+
+Parameters
+----------
+weak_direction : numpy.ndarray[numpy.float64[6, 1]]
+    The 6D weak direction vector to which the update step must remain orthogonal.
+
+     )doc" )
+            .def( "get_weak_direction",
+                  &tep::ConstrainedTranslationalStateParameter< double >::getWeakDirection,
+                  R"doc(
+
+Get the current weak direction vector.
+
+Returns
+-------
+numpy.ndarray[numpy.float64[6, 1]]
+    The currently set 6D weak direction vector.
+
+     )doc" );
+
     // ###############    Initial States
     // ################################
 
@@ -308,6 +382,45 @@ void expose_parameters_setup( py::module& m )
  List[ :class:`~tudatpy.dynamics.parameters_setup.EstimatableParameterSettings` ]
      List of :class:`~tudatpy.dynamics.parameters_setup.EstimatableParameterSettings` objects, one per component of each initial state in the simulation.
 
+
+     )doc" );
+
+    // ###############    Constrained Initial States (Line of Variations)
+    // ################################
+
+    m.def( "constrained_initial_states",
+           &tep::constrainedInitialTranslationalState< STATE_SCALAR_TYPE >,
+           py::arg( "body" ),
+           py::arg( "initial_state" ),
+           py::arg( "weak_direction" ) = Eigen::Matrix< double, 6, 1 >::Zero( ),
+           py::arg( "central_body" ) = "SSB",
+           py::arg( "frame_orientation" ) = "ECLIPJ2000",
+           R"doc(
+
+ Function for creating parameter settings for a constrained initial translational state, for use in a Line of Variations (LOV) differential correction.
+
+ Function for creating a parameter settings object for a body's initial translational state, in which the update computed by the differential correction
+ is constrained to remain orthogonal to the given weak direction. Repeatedly re-solving this constrained problem for a range of states displaced along the
+ weak direction (letting the fit adjust the state in all other directions) is used to sample points along the Line of Variations. The weak direction can be
+ provided here, or set (and updated) later via the ``set_weak_direction`` method of the resulting parameter object.
+
+ Parameters
+ ----------
+ body : str
+     Name of the body whose initial state is to be estimated.
+ initial_state : numpy.ndarray[numpy.float64[6, 1]]
+     Initial guess for the 6D Cartesian state.
+ weak_direction : numpy.ndarray[numpy.float64[6, 1]], default = [ 0, 0, 0, 0, 0, 0 ]
+     Direction (tangent to the Line of Variations) to which the update of the differential correction must remain orthogonal.
+ central_body : str, default = "SSB"
+     Body w.r.t. which the initial state is defined.
+ frame_orientation : str, default = "ECLIPJ2000"
+     Orientation of the frame in which the state is defined.
+
+ Returns
+ -------
+ :class:`~tudatpy.dynamics.parameters_setup.EstimatableParameterSettings`
+     Instance of the :class:`~tudatpy.dynamics.parameters_setup.EstimatableParameterSettings` derived class, encoding the settings for the constrained initial translational state.
 
      )doc" );
 


### PR DESCRIPTION
With this PR (written with the help of AI to navigate the architecture of Tudat) we add a template for a `constrainedTranslationalStateParameter` that inherits from the `initialTranslationalState` and allows to trigger a least squares solver with a constraint of the type:

`G \DeltaX = d` 

where `G` is a 1x6 vector, and `d = 0`.

the least squares detects the constraint and modifies the original (unconstrained) system of equations according to Lagrange Multiplier method:

```
N \Delta x + G^T\lambda
G\Delta X = 0
```
The above system is solved for both `\lambda` and `\Delta x` and, at convergence, yields a correction to x, $$\Delta x$$, which is orthogonal to the vector G. 

If G is assumed to be the weak direction vector of the covariance of an unconstrained Least Squares Nominal Solutions, then this parameter allows to find points along the Line of Variations, as explained in [Milani et al, 2005](https://www.researchgate.net/publication/222652291_Nonlinear_impact_monitoring_Line_of_variation_searches_for_impactors).

**Note 1:** since the new parameter inherits from `initialTranslationalState`, a flag was added to the constructor of  `initialTranslationalState` to define the correct identifier for the parameter, as `initialTranslationalState` had a hardcoded one that would make it impossible for tudat to recognize our new parameter (and this would potentially apply to any other defined parameter that inherited from `initialTranslationalState`), see https://github.com/tudat-team/tudatpy/pull/956/commits/52ad9a0408d4ab7f784941918496dbe11a427b75
**Note 2:** some equality checks needed to be able to estimate the new parameter, see https://github.com/tudat-team/tudatpy/pull/956/commits/4f21905216a7043a843cc64b6343cff10c1fc5dd