### PR TITLE
  Clean and validate generated API documentation types

### DIFF
--- a/docs/tudatpy/source/conf.py
+++ b/docs/tudatpy/source/conf.py
@@ -256,6 +256,7 @@ def _rewrite_overloaded_list_items(lines):
             continue
 
         indent, index, signature = match.groups()
+        signature = simplify_type_annotations(signature)
         rewritten_lines.append(f"{indent}Overload {index}:")
         rewritten_lines.append(f"{indent}``{signature}``")
 
@@ -352,7 +353,17 @@ def replace_annotated_nparrays(text: str) -> str:
         typing\.Annotated\[
             \s*numpy\.typing\.ArrayLike\s*,
             \s*(?P<dtype>[^,\]]+)\s*,
-            \s*"\[(?P<shape>[^\]]+)\]"\s*
+            \s*(?P<quote>["'])\[(?P<shape>[^\]]+)\](?P=quote)\s*
+        \]
+        """,
+        re.VERBOSE,
+    )
+
+    pattern_unshaped_arraylike = re.compile(
+        r"""
+        typing\.Annotated\[
+            \s*numpy\.typing\.ArrayLike\s*,
+            \s*(?P<dtype>[^,\]]+)\s*
         \]
         """,
         re.VERBOSE,
@@ -366,7 +377,7 @@ def replace_annotated_nparrays(text: str) -> str:
                 \s*(?P<dtype>[^\]]+)\s*
             \]
             \s*,\s*
-            "\[(?P<shape>[^\]]+)\]"
+            (?P<quote>["'])\[(?P<shape>[^\]]+)\](?P=quote)
             \s*
         \]
         """,
@@ -379,38 +390,73 @@ def replace_annotated_nparrays(text: str) -> str:
         return f"numpy.ndarray[{dtype}[{shape}]]"
 
     text = pattern_arraylike.sub(repl, text)
+    text = pattern_unshaped_arraylike.sub(
+        lambda match: f"numpy.ndarray[{match.group('dtype').strip()}]", text
+    )
     text = pattern_ndarray.sub(repl, text)
 
     return text
 
 
-def simplify_signature_types(app, what, name, obj, options, signature, return_annotation):
+SCALAR_PROTOCOL_UNIONS = (
+    (
+        re.compile(
+            r"(?:(?:typing\.)?SupportsComplex|complex)\s*\|\s*"
+            r"(?:(?:typing\.)?SupportsFloat|float)\s*\|\s*"
+            r"(?:typing\.)?SupportsIndex"
+        ),
+        "complex",
+    ),
+    (
+        re.compile(r"(?:(?:typing\.)?SupportsFloat|float)\s*\|\s*" r"(?:typing\.)?SupportsIndex"),
+        "float",
+    ),
+    (
+        re.compile(r"(?:(?:typing\.)?SupportsInt|int)\s*\|\s*" r"(?:typing\.)?SupportsIndex"),
+        "int",
+    ),
+)
+
+
+def simplify_type_annotations(text: str) -> str:
+    """Replace converter-oriented annotations with public Python types."""
+
+    text = re.sub(r"(?<!\w)~(?=[A-Za-z_])", "", text)
+
+    for pattern, replacement in SCALAR_PROTOCOL_UNIONS:
+        text = pattern.sub(replacement, text)
 
     # map complex type hints to simpler representations
     type_replacements = {
+        "typing.SupportsComplex": "complex",
         "typing.SupportsInt": "int",
         "typing.SupportsFloat": "float",
+        "typing.SupportsIndex": "int",
         "typing.List": "list",
         "typing.Dict": "dict",
         "typing.Callable": "Callable",
-        "typing.Any": "any",
+        "typing.Any": "Any",
         "collections.abc.Sequence": "list",
         "collections.abc.Mapping": "dict",
         "collections.abc.Callable": "Callable",
+        "SupportsComplex": "complex",
         "SupportsFloat": "float",
         "SupportsInt": "int",
+        "SupportsIndex": "int",
     }
 
     for full_type, simple_type in type_replacements.items():
-        if signature:
-            signature = signature.replace(full_type, simple_type)
-        if return_annotation:
-            return_annotation = return_annotation.replace(full_type, simple_type)
+        text = text.replace(full_type, simple_type)
+
+    return replace_annotated_nparrays(text)
+
+
+def simplify_signature_types(app, what, name, obj, options, signature, return_annotation):
 
     if signature:
-        signature = replace_annotated_nparrays(signature)
+        signature = simplify_type_annotations(signature)
     if return_annotation:
-        return_annotation = replace_annotated_nparrays(return_annotation)
+        return_annotation = simplify_type_annotations(return_annotation)
 
     return signature, return_annotation
 

--- a/docs/tudatpy/source/conf.py
+++ b/docs/tudatpy/source/conf.py
@@ -175,6 +175,30 @@ def process_constants_docstring(app, what, name, obj, options, lines):
         lines.append(f":type: {type(obj).__name__}")
 
 
+READ_ONLY_MARKER = "**read-only**"
+
+
+def mark_property_mutability(app, what, name, obj, options, lines):
+    """Keep rendered property mutability labels consistent with the runtime API."""
+
+    if not isinstance(obj, property):
+        return
+
+    marker_indices = [
+        index
+        for index, line in enumerate(lines)
+        if line.strip().lower() == READ_ONLY_MARKER.lower()
+    ]
+
+    if obj.fset is None:
+        if not marker_indices:
+            lines[:0] = [READ_ONLY_MARKER, ""]
+        return
+
+    for index in reversed(marker_indices):
+        del lines[index]
+
+
 NUMPY_DOCSTRING_SECTION_TITLES = {
     "Parameters",
     "Returns",
@@ -465,6 +489,7 @@ def setup(app):
     app.add_config_value("has_mcd_support", has_mcd_support, "env")
     app.connect("source-read", insert_optional_mcd_documentation)
     app.connect("autodoc-process-docstring", process_constants_docstring)
+    app.connect("autodoc-process-docstring", mark_property_mutability, priority=100)
     # run before default-priority (500) docstring processors
     app.connect("autodoc-process-docstring", fix_docstring_section_title_spacing, priority=200)
     app.connect("autodoc-process-signature", simplify_signature_types)

--- a/docs/tudatpy/source/conf.py
+++ b/docs/tudatpy/source/conf.py
@@ -441,10 +441,13 @@ SCALAR_PROTOCOL_UNIONS = (
     ),
 )
 
+ADDRESS_BEARING_OBJECT_REPR = re.compile(r"<[A-Za-z_][A-Za-z0-9_.]* object at 0x[0-9A-Fa-f]+>")
+
 
 def simplify_type_annotations(text: str) -> str:
     """Replace converter-oriented annotations with public Python types."""
 
+    text = ADDRESS_BEARING_OBJECT_REPR.sub("...", text)
     text = re.sub(r"(?<!\w)~(?=[A-Za-z_])", "", text)
 
     for pattern, replacement in SCALAR_PROTOCOL_UNIONS:

--- a/src/tudatpy/astro/element_conversion/expose_element_conversion.cpp
+++ b/src/tudatpy/astro/element_conversion/expose_element_conversion.cpp
@@ -1338,7 +1338,7 @@ Enumeration describing different types of position element types (typically used
  Parameters
  ----------
  epoch : float
-     Time object representing the epoch as seconds since J2000
+     Floating-point epoch in seconds since J2000.
  Returns
  -------
  numpy.ndarray
@@ -1357,7 +1357,7 @@ Enumeration describing different types of position element types (typically used
  Parameters
  ----------
  epoch : float
-     Time object representing the epoch as seconds since J2000
+     Floating-point epoch in seconds since J2000.
  Returns
  -------
  numpy.ndarray

--- a/src/tudatpy/astro/element_conversion/expose_element_conversion.cpp
+++ b/src/tudatpy/astro/element_conversion/expose_element_conversion.cpp
@@ -577,7 +577,7 @@ Enumeration describing different types of position element types (typically used
      Boolean to determine whether the user-defined initial guess (for mean-to-eccentric anomaly conversion) is used, or an automatically generated one.
  non_default_initial_guess : float, default = NaN
      User-defined initial guess for mean-to-eccentric anomaly conversion, to be used only if ``use_default_initial_guess`` is set to ``False``.
- root_finder : RootFinder, default = None
+ root_finder : RootFinderCore, default = None
      User-defined root finder, overriding default root-finding algorithm for mean-to-eccentric anomaly conversion (default is used if this input is left empty)
  Returns
  -------
@@ -725,7 +725,7 @@ Enumeration describing different types of position element types (typically used
      Boolean to determine whether the user-defined initial guess is used for conversion, or an automatically generated one.
  non_default_initial_guess : float, default = NaN
      User-defined initial guess for conversion, to be used only if ``use_default_initial_guess`` is set to ``False``.
- root_finder : RootFinder, default = None
+ root_finder : RootFinderCore, default = None
      User-defined root finder, overriding default root-finding algorithm for conversion (default is used if this input is left empty)
  Returns
  -------
@@ -1337,7 +1337,7 @@ Enumeration describing different types of position element types (typically used
 
  Parameters
  ----------
- epoch : astro.time_representation.Time
+ epoch : float
      Time object representing the epoch as seconds since J2000
  Returns
  -------
@@ -1356,7 +1356,7 @@ Enumeration describing different types of position element types (typically used
 
  Parameters
  ----------
- epoch : astro.time_representation.Time
+ epoch : float
      Time object representing the epoch as seconds since J2000
  Returns
  -------

--- a/src/tudatpy/astro/gravitation/expose_gravitation.cpp
+++ b/src/tudatpy/astro/gravitation/expose_gravitation.cpp
@@ -608,8 +608,8 @@ void expose_gravitation( py::module& m )
      Boolean denoting whether the coefficients computed are normalized (if true) or unnormalized (if false)
  Returns
  -------
- tuple[numpy.ndarray, numpy.ndarray]
-     Tuple of two matrices, containing the spherical harmonic coefficients :math:`{C}_{lm}` (first) and :math:`{S}_{lm}` (second) up to degree and order 2.
+ tuple[numpy.ndarray, numpy.ndarray, float]
+     Tuple containing the spherical harmonic coefficients :math:`{C}_{lm}` (first), :math:`{S}_{lm}` (second), and the mean moment of inertia (third).
      The degree-two coefficients are computed from the inertia tensor, the degree-one coefficients are set to zero (and :math:`C_{00}=0`)
 
 

--- a/src/tudatpy/astro/gravitation/expose_gravitation.cpp
+++ b/src/tudatpy/astro/gravitation/expose_gravitation.cpp
@@ -598,7 +598,7 @@ void expose_gravitation( py::module& m )
 
  Parameters
  ----------
- inertia tensor : numpy.ndarray[numpy.float64[3, 3]]
+ inertia_tensor : numpy.ndarray[numpy.float64[3, 3]]
      Full inertia tensor :math:`\mathbf{I}` of the body for which spherical harmonic coefficients are to be computed.
  gravitational_parameter : float
      Gravitational parameter :math:`\mu` of the body for which spherical harmonic coefficients are to be computed.

--- a/src/tudatpy/astro/time_representation/expose_time_representation.cpp
+++ b/src/tudatpy/astro/time_representation/expose_time_representation.cpp
@@ -1322,11 +1322,11 @@ datetime.datetime
  Parameters
  ----------
  TCB_time : float
-     Time object representing the epoch as seconds since J2000, in the TCB time scale.
+     Floating-point epoch in seconds since J2000, in the TCB time scale.
  Returns
  -------
  epoch : float
-     Time object representing the epoch as seconds since J2000, in the TDB time scale.
+     Floating-point epoch in seconds since J2000, in the TDB time scale.
 
 
 
@@ -1368,11 +1368,11 @@ datetime.datetime
  Parameters
  ----------
  TDB_time : float
-     Time object representing the epoch as seconds since J2000, in the TDB time scale.
+     Floating-point epoch in seconds since J2000, in the TDB time scale.
  Returns
  -------
  epoch : float
-     Time object representing the epoch as seconds since J2000, in the TCB time scale.
+     Floating-point epoch in seconds since J2000, in the TCB time scale.
 
 
 
@@ -1393,11 +1393,11 @@ datetime.datetime
  Parameters
  ----------
  TCG_time : float
-     Time object representing the epoch as seconds since J2000, in the TCG time scale.
+     Floating-point epoch in seconds since J2000, in the TCG time scale.
  Returns
  -------
  float
-     Time object representing the epoch as seconds since J2000, in the TT time scale.
+     Floating-point epoch in seconds since J2000, in the TT time scale.
 
 
 
@@ -1421,11 +1421,11 @@ datetime.datetime
  Parameters
  ----------
  TT_time : float
-     Time object representing the epoch as seconds since J2000, in the TT time scale.
+     Floating-point epoch in seconds since J2000, in the TT time scale.
  Returns
  -------
  float
-    Time object representing the epoch as seconds since J2000, in the TCG time scale.
+    Floating-point epoch in seconds since J2000, in the TCG time scale.
 
 
 
@@ -1446,11 +1446,11 @@ datetime.datetime
  Parameters
  ----------
  TAI_time : float
-    Time object representing the epoch as seconds since J2000, in the TAI time scale.
+    Floating-point epoch in seconds since J2000, in the TAI time scale.
  Returns
  -------
  float
-     Time object representing the epoch as seconds since J2000, in the TT time scale.
+     Floating-point epoch in seconds since J2000, in the TT time scale.
 
 
 
@@ -1474,11 +1474,11 @@ datetime.datetime
  Parameters
  ----------
  TT_time : float
-    Time object representing the epoch as seconds since J2000, in the TT time scale.
+    Floating-point epoch in seconds since J2000, in the TT time scale.
  Returns
  -------
  float
-    Time object representing the epoch as seconds since J2000, in the TAI time scale.
+    Floating-point epoch in seconds since J2000, in the TAI time scale.
 
 
 
@@ -1504,11 +1504,11 @@ datetime.datetime
  Parameters
  ----------
  TT_time : float
-    Time object representing the epoch as seconds since J2000, in the TT time scale.
+    Floating-point epoch in seconds since J2000, in the TT time scale.
  Returns
  -------
  float
-    Time object representing the epoch as seconds since J2000, in the TDB time scale.
+    Floating-point epoch in seconds since J2000, in the TDB time scale.
 
 
 

--- a/src/tudatpy/astro/time_representation/expose_time_representation.cpp
+++ b/src/tudatpy/astro/time_representation/expose_time_representation.cpp
@@ -1321,7 +1321,7 @@ datetime.datetime
 
  Parameters
  ----------
- TCB_time : astro.time_representation.Time
+ TCB_time : float
      Time object representing the epoch as seconds since J2000, in the TCB time scale.
  Returns
  -------
@@ -1367,7 +1367,7 @@ datetime.datetime
 
  Parameters
  ----------
- TDB_time : astro.time_representation.Time
+ TDB_time : float
      Time object representing the epoch as seconds since J2000, in the TDB time scale.
  Returns
  -------
@@ -1392,7 +1392,7 @@ datetime.datetime
 
  Parameters
  ----------
- TCG_time : astro.time_representation.Time
+ TCG_time : float
      Time object representing the epoch as seconds since J2000, in the TCG time scale.
  Returns
  -------
@@ -1420,7 +1420,7 @@ datetime.datetime
 
  Parameters
  ----------
- TT_time : astro.time_representation.Time
+ TT_time : float
      Time object representing the epoch as seconds since J2000, in the TT time scale.
  Returns
  -------
@@ -1445,7 +1445,7 @@ datetime.datetime
 
  Parameters
  ----------
- TAI_time : astro.time_representation.Time
+ TAI_time : float
     Time object representing the epoch as seconds since J2000, in the TAI time scale.
  Returns
  -------
@@ -1473,7 +1473,7 @@ datetime.datetime
 
  Parameters
  ----------
- TT_time : astro.time_representation.Time
+ TT_time : float
     Time object representing the epoch as seconds since J2000, in the TT time scale.
  Returns
  -------
@@ -1503,7 +1503,7 @@ datetime.datetime
 
  Parameters
  ----------
- TT_time : astro.time_representation.Time
+ TT_time : float
     Time object representing the epoch as seconds since J2000, in the TT time scale.
  Returns
  -------

--- a/src/tudatpy/astro/time_representation/expose_time_representation.cpp
+++ b/src/tudatpy/astro/time_representation/expose_time_representation.cpp
@@ -1325,7 +1325,7 @@ datetime.datetime
      Time object representing the epoch as seconds since J2000, in the TCB time scale.
  Returns
  -------
- epoch : astro.time_representation.Time
+ epoch : float
      Time object representing the epoch as seconds since J2000, in the TDB time scale.
 
 
@@ -1371,7 +1371,7 @@ datetime.datetime
      Time object representing the epoch as seconds since J2000, in the TDB time scale.
  Returns
  -------
- epoch : astro.time_representation.Time
+ epoch : float
      Time object representing the epoch as seconds since J2000, in the TCB time scale.
 
 
@@ -1396,7 +1396,7 @@ datetime.datetime
      Time object representing the epoch as seconds since J2000, in the TCG time scale.
  Returns
  -------
- astro.time_representation.Time
+ float
      Time object representing the epoch as seconds since J2000, in the TT time scale.
 
 
@@ -1424,7 +1424,7 @@ datetime.datetime
      Time object representing the epoch as seconds since J2000, in the TT time scale.
  Returns
  -------
- astro.time_representation.Time
+ float
     Time object representing the epoch as seconds since J2000, in the TCG time scale.
 
 
@@ -1449,7 +1449,7 @@ datetime.datetime
     Time object representing the epoch as seconds since J2000, in the TAI time scale.
  Returns
  -------
- astro.time_representation.Time
+ float
      Time object representing the epoch as seconds since J2000, in the TT time scale.
 
 
@@ -1477,7 +1477,7 @@ datetime.datetime
     Time object representing the epoch as seconds since J2000, in the TT time scale.
  Returns
  -------
- astro.time_representation.Time
+ float
     Time object representing the epoch as seconds since J2000, in the TAI time scale.
 
 
@@ -1507,7 +1507,7 @@ datetime.datetime
     Time object representing the epoch as seconds since J2000, in the TT time scale.
  Returns
  -------
- astro.time_representation.Time
+ float
     Time object representing the epoch as seconds since J2000, in the TDB time scale.
 
 

--- a/src/tudatpy/astro/two_body_dynamics/expose_two_body_dynamics.cpp
+++ b/src/tudatpy/astro/two_body_dynamics/expose_two_body_dynamics.cpp
@@ -273,7 +273,7 @@ time_of_flight : float
     Time of flight between departure and arrival [s].
 gravitational_parameter : float
     Gravitational parameter of the central body [m^3/s^2].
-root_finder : RootFinder, default=None
+root_finder : RootFinderCore, default=None
     Root finder to use for solving the Lambert equation. If None, a default Newton-Raphson 
     solver with 1000 iterations and 1e-12 relative tolerance is used.
 
@@ -660,11 +660,11 @@ int
  ----------
  initial_kepler_elements : numpy.ndarray
      Keplerian elements that are to be propagated (see :ref:`element_conversion` for order)
- propagation_time : astro.time_representation.Time
+ propagation_time : float
      Time object for which the elements are to be propagated w.r.t. the initial elements
  gravitational_parameter : float
      Gravitational parameter of central body used for propagation
- root_finder : RootFinder, default = None
+ root_finder : RootFinderCore, default = None
      Root finder used to solve Kepler's equation when converting mean to eccentric anomaly. When no root finder is specified, the default option of the mean to eccentric anomaly function is used (see :func:`~tudatpy.astro.element_conversion.mean_to_eccentric_anomaly`).
  Returns
  -------

--- a/src/tudatpy/astro/two_body_dynamics/expose_two_body_dynamics.cpp
+++ b/src/tudatpy/astro/two_body_dynamics/expose_two_body_dynamics.cpp
@@ -661,7 +661,7 @@ int
  initial_kepler_elements : numpy.ndarray
      Keplerian elements that are to be propagated (see :ref:`element_conversion` for order)
  propagation_time : float
-     Time object for which the elements are to be propagated w.r.t. the initial elements
+     Propagation duration with respect to the initial elements, in seconds.
  gravitational_parameter : float
      Gravitational parameter of central body used for propagation
  root_finder : RootFinderCore, default = None

--- a/src/tudatpy/data/mission_data_downloader/mission_data_downloader.py
+++ b/src/tudatpy/data/mission_data_downloader/mission_data_downloader.py
@@ -796,7 +796,7 @@ class LoadPDS:
 
     #########################################################################################################
 
-    def match_type_extension(self, data_type, filename):
+    def match_type_extension(self, data_type, filename) -> bool:
         """
         Checks if the extension of a given file matches the expected extension for the specified data type.
 
@@ -822,7 +822,7 @@ class LoadPDS:
 
     #########################################################################################################
 
-    def get_extension_for_data_type(self, data_type, first_only=True):
+    def get_extension_for_data_type(self, data_type, first_only=True) -> str | list[str] | None:
         """
         Returns one or more file extensions for the given data type.
 
@@ -1565,7 +1565,7 @@ class LoadPDS:
 
     #########################################################################################################
 
-    def extract_kernels_from_meta_kernel(self, input_mission):
+    def extract_kernels_from_meta_kernel(self, input_mission) -> dict:
         """
         Fetches a meta-kernel file from an HTTPS URL and categorizes kernel files by type
         using the type-to-extension mapping.
@@ -1734,7 +1734,7 @@ class LoadPDS:
 
     #########################################################################################################
 
-    def get_latest_meta_kernel(self, input_mission):
+    def get_latest_meta_kernel(self, input_mission) -> str:
         """
         Finds the most recent meta-kernel file URL based on year and version.
 
@@ -4317,7 +4317,7 @@ class LoadPDS:
 
     #########################################################################################################
 
-    def get_ro_rsi_volume_ID(self, start_date, end_date, mapping_dict):
+    def get_ro_rsi_volume_ID(self, start_date, end_date, mapping_dict) -> list[str]:
         """
         Given a start_date and end_date, iterate over the mapping_dict (which is keyed by rsi_volume_id)
         and return a list of rsi_volume_id values whose associated record's start_date_utc falls within the interval.

--- a/src/tudatpy/data/mpc/mpc.py
+++ b/src/tudatpy/data/mpc/mpc.py
@@ -73,7 +73,7 @@ DEFAULT_CATALOG_FLAGS = [
 def load_bias_file(
     filepath: str,
     Nside: int | None = None,
-    catalog_flags: list = DEFAULT_CATALOG_FLAGS,
+    catalog_flags: list | None = None,
 ) -> tuple[pd.DataFrame, int]:
     """Loads a healpix star catalog debias file and processes it into a dataframe. Automatically retrieves NSIDE parameter.
 
@@ -154,7 +154,7 @@ def get_biases_EFCC18(
     catalog: str | np.ndarray | list,
     bias_file: str | None = BIAS_LOWRES_FILE,
     Nside: int | None = None,
-    catalog_flags: list[str] = DEFAULT_CATALOG_FLAGS,
+    catalog_flags: list[str] | None = None,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Calculate and return star catalog bias values as described in:
     "Star catalog position and proper motion corrections in asteroid astrometry II: The Gaia era" by Eggl et al. (2018).
@@ -1088,7 +1088,7 @@ class BatchMPC:
         for internal processing.
 
         Args:
-            table (astropy.table.Table):
+            table (astropy.table.QTable | astropy.table.Table):
                 The Astropy Table or QTable containing the observation data. It must
                 include the following columns: 'number', 'epoch', 'RA', 'DEC',
                 'band', 'observatory'.
@@ -1471,7 +1471,7 @@ class BatchMPC:
         station_body : str, optional
             Body to attach ground stations to. Does not need to be changed unless the
             `Earth` body has been renamed, by default "Earth"
-        station_body : bool, optional
+        add_sbdb_gravity_model : bool, optional
             Adds a central_sbdb gravity model to the object, generated using JPL's small body database.
             This option is only available for a limited number of bodies and raises an error if unavailable.
             See tudatpy.dynamics.environment_setup.gravity_field.central_sbdb for more info.

--- a/src/tudatpy/data/mpc/mpc.py
+++ b/src/tudatpy/data/mpc/mpc.py
@@ -12,6 +12,7 @@ import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.cm as cm
+from matplotlib.figure import Figure
 import datetime
 from astroquery.mpc import MPC
 from astropy_healpix import HEALPix
@@ -294,10 +295,9 @@ def get_weights_VFCC17(
 
     Returns
     -------
-    np.ndarray
-        If `return_full_table` is False, numpy array with weights with same size as input.
-    pd.DataFrame
-        If `return_full_table` is True, pandas table with all intermediate calculations.
+    np.ndarray | pd.DataFrame
+        A NumPy array with the weights when `return_full_table` is False, or a
+        pandas table with all intermediate calculations when it is True.
 
     Raises
     ------
@@ -1674,7 +1674,7 @@ class BatchMPC:
         self,
         objects: list[str] | None = None,
         figsize: tuple[float] = (9.0, 6.0),
-    ):
+    ) -> Figure:
         """Generates a matplotlib figure with the declination and right ascension
         over time.
 
@@ -1692,7 +1692,7 @@ class BatchMPC:
 
         Returns
         -------
-        Matplotlib figure
+        Figure
             Matplotlib figure with the observations
         """
         fig, (axRA, axDEC) = plt.subplots(2, 1, figsize=figsize, sharex=True)

--- a/src/tudatpy/data/processTrk234/converters/radioBase.py
+++ b/src/tudatpy/data/processTrk234/converters/radioBase.py
@@ -113,7 +113,7 @@ class RadioBase(Converter):
 
         Parameters
         ----------
-        link_end_tuple : tuple
+        link_end_tuple : tuple[str, str, str]
             A tuple containing the uplink, spacecraft, and downlink identifiers.
         spacecraftName : str, optional
             The name of the spacecraft to use in the simulation. If not provided, the spacecraft name

--- a/src/tudatpy/data/sbdb/sbdb.py
+++ b/src/tudatpy/data/sbdb/sbdb.py
@@ -108,7 +108,7 @@ class SBDBquery:
         except Exception as _:
             raise ValueError(f"Gravitational parameter is not available for object {self.name}")
 
-    def estimated_spherical_mass(self, density: float):
+    def estimated_spherical_mass(self, density: float) -> float:
         """Calculate a very simple mass by estimating the object's mass using a given density.
         Will raise an error if the body's diameter is not available on SBDB.
 
@@ -126,7 +126,7 @@ class SBDBquery:
         mass = volume * density
         return mass
 
-    def estimated_spherical_gravitational_parameter(self, density: float):
+    def estimated_spherical_gravitational_parameter(self, density: float) -> float:
         """Calculate a very simple gravitational parameter by estimating the object's mass using a given density.
         Will raise an error if the body's diameter is not available on SBDB.
 

--- a/src/tudatpy/data/spacetrack/spacetrack.py
+++ b/src/tudatpy/data/spacetrack/spacetrack.py
@@ -612,7 +612,7 @@ class OMMUtils:
 
         Returns
         -------
-        dict[str, tuple[str, str]]
+        defaultdict[str, list[tuple[str, str]]]
             Mapping of NORAD ID (str) → (TLE line 1, TLE line 2).
         """
         if isinstance(json_data, dict):
@@ -673,7 +673,7 @@ class OMMUtils:
         return a, e, i, omega, raan, mean_to_true_anomaly(e, mo)
 
     @staticmethod
-    def tle_to_TleEphemeris_object(tle_line_1: str, tle_line_2: str) -> environment.Tle:
+    def tle_to_TleEphemeris_object(tle_line_1: str, tle_line_2: str) -> environment.TleEphemeris:
         """
         Converts a TLE line pair into a Tudat ``TleEphemeris`` object.
 
@@ -686,7 +686,7 @@ class OMMUtils:
 
         Returns
         -------
-        environment.Tle
+        environment.TleEphemeris
             Configured TleEphemeris object.
         """
         return environment.TleEphemeris(
@@ -694,7 +694,7 @@ class OMMUtils:
         )
 
     @staticmethod
-    def tle_to_Tle_object(tle_line_1: str, tle_line_2: str) -> environment.TleEphemeris:
+    def tle_to_Tle_object(tle_line_1: str, tle_line_2: str) -> environment.Tle:
         """
         Converts a TLE line pair into a Tudat ``TleEphemeris`` object.
 

--- a/src/tudatpy/data/spacetrack/spacetrack.py
+++ b/src/tudatpy/data/spacetrack/spacetrack.py
@@ -463,7 +463,7 @@ class SpaceTrackQuery:
 
         Parameters
         ----------
-        filter_oe_dict : dict
+        filter_oe_dict : dict[str, tuple[float | None, float | None]]
             Mapping of orbital element names to ``(min, max)`` bound tuples.
             Either bound may be ``None`` for a one-sided filter.
         limit : int

--- a/src/tudatpy/dynamics/environment/expose_environment.cpp
+++ b/src/tudatpy/dynamics/environment/expose_environment.cpp
@@ -941,7 +941,7 @@ bool
              Geographic latitude (in the body-fixed frame of the body with the atmosphere) at which the property is to be computed
          longitude : float
              Geographic longitude (in the body-fixed frame of the body with the atmosphere) at which the property is to be computed
-         time : astro.time_representation.Time
+         time : float
              Time object representing seconds since J2000 (TDB) at which the property is to be computed.
 
          Returns
@@ -969,7 +969,7 @@ bool
              Geographic latitude (in the body-fixed frame of the body with the atmosphere) at which the property is to be computed
          longitude : float
              Geographic longitude (in the body-fixed frame of the body with the atmosphere) at which the property is to be computed
-         time : astro.time_representation.Time
+         time : float
              Time object representing seconds since J2000 (TDB) at which the property is to be computed.
 
          Returns
@@ -997,7 +997,7 @@ bool
              Geographic latitude (in the body-fixed frame of the body with the atmosphere) at which the property is to be computed
          longitude : float
              Geographic longitude (in the body-fixed frame of the body with the atmosphere) at which the property is to be computed
-         time : astro.time_representation.Time
+         time : float
              Time object representing seconds since J2000 (TDB) at which the property is to be computed.
 
          Returns
@@ -1025,7 +1025,7 @@ bool
              Geographic latitude (in the body-fixed frame of the body with the atmosphere) at which the property is to be computed
          longitude : float
              Geographic longitude (in the body-fixed frame of the body with the atmosphere) at which the property is to be computed
-         time : astro.time_representation.Time
+         time : float
              Time object representing seconds since J2000 (TDB) at which the property is to be computed.
 
          Returns
@@ -1053,7 +1053,7 @@ bool
              Geographic latitude (in the body-fixed frame of the body with the atmosphere) at which the property is to be computed
          longitude : float
              Geographic longitude (in the body-fixed frame of the body with the atmosphere) at which the property is to be computed
-         time : astro.time_representation.Time
+         time : float
              Time object representing seconds since J2000 (TDB) at which the property is to be computed.
 
          Returns
@@ -1085,7 +1085,7 @@ bool
              Geographic latitude (in the body-fixed frame of the body with the atmosphere) at which the property is to be computed
          longitude : float
              Geographic longitude (in the body-fixed frame of the body with the atmosphere) at which the property is to be computed
-         time : astro.time_representation.Time
+         time : float
              Time object representing seconds since J2000 (TDB) at which the property is to be computed.
 
          Returns
@@ -1301,7 +1301,7 @@ bool
              List of inputs from which the aerodynamic coefficients are to be computed, with each entry corresponding to the
              value of the physical variable defined by the :attr:`independent_variable_names` attribute.
 
-         time : astro.time_representation.Time
+         time : float
              Time object representing seconds since J2000 (TDB)
 
          Returns
@@ -1345,7 +1345,7 @@ bool
              with each entry corresponding to the
              value of the physical variable defined by the :attr:`control_surface_independent_variable_names` attribute.
 
-         time : astro.time_representation.Time
+         time : float
              Time object representing seconds since J2000 (TDB)
 
          check_force_contribution : bool, default = True
@@ -1404,12 +1404,12 @@ bool
              this constructor. In case the :class:`tudat.geometry.SurfaceGeometry` object is made up of multiple
              sub-shapes, different settings may be used for each
 
-         number_of_lines : List[ float ]
+         number_of_lines : list[int]
              Number of discretization points in the first independent surface variable of each of the subparts of body_shape.
              The size of this list should match the number of parts of which the body_shape is composed. The first independent
              variable of a subpart typically runs along the longitudinal vehicle direction
 
-         number_of_points : List[ float ]
+         number_of_points : list[int]
              Number of discretization points in the second independent surface variable of each of the subparts of body_shape.
              The size of this list should match the number of parts of which the body_shape is composed. The first independent
              variable of a subpart typically runs along the lateral vehicle direction
@@ -1707,7 +1707,7 @@ bool
 
          Parameters
          ----------
-         current_time : astro.time_representation.Time
+         time : float
              Time object representing seconds since J2000 (TDB) to which this object is to be updated
 
          Returns
@@ -2189,7 +2189,7 @@ bool
 
          Parameters
          ----------
-         current_time : astro.time_representation.Time
+         time : float
              Time object representing seconds since J2000 (TDB) at which the rotation matrix is evaluated
 
          Returns
@@ -2216,7 +2216,7 @@ bool
 
          Parameters
          ----------
-         current_time : astro.time_representation.Time
+         time : float
              Time object representing seconds since J2000 (TDB) at which the rotation matrix derivative is evaluated
 
          Returns
@@ -2242,7 +2242,7 @@ bool
 
          Parameters
          ----------
-         current_time : astro.time_representation.Time
+         time : float
              Time object representing seconds since J2000 (TDB) at which the rotation matrix is evaluated
 
 
@@ -2264,7 +2264,7 @@ bool
 
          Parameters
          ----------
-         current_time : astro.time_representation.Time
+         time : float
              Time object representing seconds since J2000 (TDB) at which the rotation matrix derivative is evaluated
 
          Returns
@@ -2295,7 +2295,7 @@ bool
 
          Parameters
          ----------
-         current_time : astro.time_representation.Time
+         time : float
              Time object representing seconds since J2000 (TDB) at which the angular velocity vector is evaluated
 
          Returns
@@ -2323,7 +2323,7 @@ bool
 
          Parameters
          ----------
-         current_time : astro.time_representation.Time
+         time : float
              Time object representing seconds since J2000 (TDB) at which the angular velocity vector is evaluated
 
          Returns
@@ -2380,7 +2380,7 @@ bool
  state_in_body_fixed_frame : numpy.ndarray[numpy.float64[6, 1]]
      Cartesian state (position and velocity) in the body-fixed frame
 
- current_time : astro.time_representation.Time
+ current_time : float
      Time object representing seconds since J2000 (TDB) at which the transformation is to be computed
 
  rotational_ephemeris : RotationalEphemeris
@@ -2837,7 +2837,7 @@ bool
 
          Parameters
          ----------
-         current_time : astro.time_representation.Time
+         current_time : float
              Time object representing seconds since J2000 (TDB) at which the position is to be computed.
 
          target_frame_origin: str, default = ""
@@ -3023,7 +3023,7 @@ bool
          ----------
          inertial_vector_to_target : numpy.ndarray
              Vector from ground station to target in inertial frame
-         time : astro.time_representation.Time
+         time : float
              Time object representing seconds since J2000 (TDB) at which to calculate the angle
 
          Returns
@@ -3045,7 +3045,7 @@ bool
          ----------
          inertial_vector_to_target : numpy.ndarray
              Vector from ground station to target in inertial frame
-         time : astro.time_representation.Time
+         time : float
              Time object representing seconds since J2000 (TDB) at which to calculate the angle
 
          Returns
@@ -3801,7 +3801,7 @@ bool
          body_to_add : Body
              Body object that is to be added.
 
-         body_name : numpy.ndarray
+         body_name : str
              Name of the Body that is to be added.
 
          process_body : bool, default=True
@@ -3836,7 +3836,7 @@ bool
 
          Parameters
          ----------
-         body_name : numpy.ndarray
+         body_name : str
              Name of the Body that is to be removed.
 
 

--- a/src/tudatpy/dynamics/environment/expose_environment.cpp
+++ b/src/tudatpy/dynamics/environment/expose_environment.cpp
@@ -1269,7 +1269,7 @@ bool
          Returns
          -------
          numpy.ndarray
-             Contribution from the requested control surface to the aerodynamic moment coefficients
+             Contribution from the requested control surface to the aerodynamic moment coefficients.
 
 
 
@@ -1306,8 +1306,8 @@ bool
 
          Returns
          -------
-         numpy.ndarray
-             Contribution from the requested control surface to the aerodynamic moment coefficients
+         None
+             This method updates the stored aerodynamic coefficients in place.
 
 
 
@@ -2443,7 +2443,7 @@ bool
 
          Returns
          -------
-         tuple[list[float],float]
+         tuple[numpy.ndarray[numpy.float64[5, 1]], astro.time_representation.Time]
              Pair (tuple of size two) with the first entry a list of orientation angles :math:`X,Y,s,x_{p},y_{p}` (in that order) and the second entry the current UT1.
 
      )doc" );

--- a/src/tudatpy/dynamics/environment/expose_environment.cpp
+++ b/src/tudatpy/dynamics/environment/expose_environment.cpp
@@ -942,7 +942,7 @@ bool
          longitude : float
              Geographic longitude (in the body-fixed frame of the body with the atmosphere) at which the property is to be computed
          time : float
-             Time object representing seconds since J2000 (TDB) at which the property is to be computed.
+             Epoch in seconds since J2000 (TDB) at which the property is to be computed.
 
          Returns
          -------
@@ -970,7 +970,7 @@ bool
          longitude : float
              Geographic longitude (in the body-fixed frame of the body with the atmosphere) at which the property is to be computed
          time : float
-             Time object representing seconds since J2000 (TDB) at which the property is to be computed.
+             Epoch in seconds since J2000 (TDB) at which the property is to be computed.
 
          Returns
          -------
@@ -998,7 +998,7 @@ bool
          longitude : float
              Geographic longitude (in the body-fixed frame of the body with the atmosphere) at which the property is to be computed
          time : float
-             Time object representing seconds since J2000 (TDB) at which the property is to be computed.
+             Epoch in seconds since J2000 (TDB) at which the property is to be computed.
 
          Returns
          -------
@@ -1026,7 +1026,7 @@ bool
          longitude : float
              Geographic longitude (in the body-fixed frame of the body with the atmosphere) at which the property is to be computed
          time : float
-             Time object representing seconds since J2000 (TDB) at which the property is to be computed.
+             Epoch in seconds since J2000 (TDB) at which the property is to be computed.
 
          Returns
          -------
@@ -1054,7 +1054,7 @@ bool
          longitude : float
              Geographic longitude (in the body-fixed frame of the body with the atmosphere) at which the property is to be computed
          time : float
-             Time object representing seconds since J2000 (TDB) at which the property is to be computed.
+             Epoch in seconds since J2000 (TDB) at which the property is to be computed.
 
          Returns
          -------
@@ -1086,7 +1086,7 @@ bool
          longitude : float
              Geographic longitude (in the body-fixed frame of the body with the atmosphere) at which the property is to be computed
          time : float
-             Time object representing seconds since J2000 (TDB) at which the property is to be computed.
+             Epoch in seconds since J2000 (TDB) at which the property is to be computed.
 
          Returns
          -------
@@ -1302,7 +1302,7 @@ bool
              value of the physical variable defined by the :attr:`independent_variable_names` attribute.
 
          time : float
-             Time object representing seconds since J2000 (TDB)
+             Epoch in seconds since J2000 (TDB).
 
          Returns
          -------
@@ -1341,12 +1341,12 @@ bool
              value of the physical variable defined by the :attr:`independent_variable_names` attribute.
 
          control_surface_independent_variables : dict[str,list[float]]
-             List of inputs from which the control surface aerodynamic coefficients are to be computed (with dictionary key the control surface name),
+             Dictionary of input lists from which the control surface aerodynamic coefficients are to be computed, keyed by control surface name,
              with each entry corresponding to the
              value of the physical variable defined by the :attr:`control_surface_independent_variable_names` attribute.
 
          time : float
-             Time object representing seconds since J2000 (TDB)
+             Epoch in seconds since J2000 (TDB).
 
          check_force_contribution : bool, default = True
              Boolean that determines if the force contribution to the aerodynamic moments should be added. Note that this input is
@@ -1708,7 +1708,7 @@ bool
          Parameters
          ----------
          time : float
-             Time object representing seconds since J2000 (TDB) to which this object is to be updated
+             Epoch in seconds since J2000 (TDB) to which this object is to be updated.
 
          Returns
          -------
@@ -2190,7 +2190,7 @@ bool
          Parameters
          ----------
          time : float
-             Time object representing seconds since J2000 (TDB) at which the rotation matrix is evaluated
+             Epoch in seconds since J2000 (TDB) at which the rotation matrix is evaluated.
 
          Returns
          -------
@@ -2217,7 +2217,7 @@ bool
          Parameters
          ----------
          time : float
-             Time object representing seconds since J2000 (TDB) at which the rotation matrix derivative is evaluated
+             Epoch in seconds since J2000 (TDB) at which the rotation matrix derivative is evaluated.
 
          Returns
          -------
@@ -2243,7 +2243,7 @@ bool
          Parameters
          ----------
          time : float
-             Time object representing seconds since J2000 (TDB) at which the rotation matrix is evaluated
+             Epoch in seconds since J2000 (TDB) at which the rotation matrix is evaluated.
 
 
 
@@ -2265,7 +2265,7 @@ bool
          Parameters
          ----------
          time : float
-             Time object representing seconds since J2000 (TDB) at which the rotation matrix derivative is evaluated
+             Epoch in seconds since J2000 (TDB) at which the rotation matrix derivative is evaluated.
 
          Returns
          -------
@@ -2296,7 +2296,7 @@ bool
          Parameters
          ----------
          time : float
-             Time object representing seconds since J2000 (TDB) at which the angular velocity vector is evaluated
+             Epoch in seconds since J2000 (TDB) at which the angular velocity vector is evaluated.
 
          Returns
          -------
@@ -2324,7 +2324,7 @@ bool
          Parameters
          ----------
          time : float
-             Time object representing seconds since J2000 (TDB) at which the angular velocity vector is evaluated
+             Epoch in seconds since J2000 (TDB) at which the angular velocity vector is evaluated.
 
          Returns
          -------
@@ -2381,7 +2381,7 @@ bool
      Cartesian state (position and velocity) in the body-fixed frame
 
  current_time : float
-     Time object representing seconds since J2000 (TDB) at which the transformation is to be computed
+     Epoch in seconds since J2000 (TDB) at which the transformation is to be computed.
 
  rotational_ephemeris : RotationalEphemeris
      Boy rotation model that is to be used to convert the body-fixed state to inertial state
@@ -2838,7 +2838,7 @@ bool
          Parameters
          ----------
          current_time : float
-             Time object representing seconds since J2000 (TDB) at which the position is to be computed.
+             Epoch in seconds since J2000 (TDB) at which the position is to be computed.
 
          target_frame_origin: str, default = ""
              Identifier for the frame origin w.r.t. which the computed position is to be used.
@@ -3024,7 +3024,7 @@ bool
          inertial_vector_to_target : numpy.ndarray
              Vector from ground station to target in inertial frame
          time : float
-             Time object representing seconds since J2000 (TDB) at which to calculate the angle
+             Epoch in seconds since J2000 (TDB) at which to calculate the angle.
 
          Returns
          -------
@@ -3046,7 +3046,7 @@ bool
          inertial_vector_to_target : numpy.ndarray
              Vector from ground station to target in inertial frame
          time : float
-             Time object representing seconds since J2000 (TDB) at which to calculate the angle
+             Epoch in seconds since J2000 (TDB) at which to calculate the angle.
 
          Returns
          -------

--- a/src/tudatpy/dynamics/environment_setup/aerodynamic_coefficients/expose_aerodynamic_coefficients.cpp
+++ b/src/tudatpy/dynamics/environment_setup/aerodynamic_coefficients/expose_aerodynamic_coefficients.cpp
@@ -873,8 +873,8 @@ In this example, we create :class:`~tudatpy.dynamics.environment_setup.aerodynam
      Interpolator settings object, where the conditions for interpolation of tabulated inputs are saved.
  Returns
  -------
- TabulatedAerodynamicCoefficientSettings
-     Instance of the :class:`~tudatpy.dynamics.environment_setup.aerodynamic_coefficients.AerodynamicCoefficientSettings` derived :class:`~tudatpy.dynamics.environment_setup.aerodynamic_coefficients.TabulatedAerodynamicCoefficientSettings` class (via :class:`~tudatpy.dynamics.environment_setup.aerodynamic_coefficients.TabulatedAerodynamicCoefficientSettingsBase` class)
+ AerodynamicCoefficientSettings
+     Aerodynamic coefficient settings object for tabulated coefficients.
 
 
 
@@ -958,8 +958,8 @@ In this example, we create :class:`~tudatpy.dynamics.environment_setup.aerodynam
 
  Returns
  -------
- TabulatedAerodynamicCoefficientSettings
-     Instance of the :class:`~tudatpy.dynamics.environment_setup.aerodynamic_coefficients.AerodynamicCoefficientSettings` derived :class:`~tudatpy.dynamics.environment_setup.aerodynamic_coefficients.TabulatedAerodynamicCoefficientSettings` class
+ AerodynamicCoefficientSettings
+     Aerodynamic coefficient settings object for tabulated coefficients.
 
 
 
@@ -1028,8 +1028,8 @@ In this example, we create :class:`~tudatpy.dynamics.environment_setup.aerodynam
 
  Returns
  -------
- TabulatedAerodynamicCoefficientSettings
-     Instance of the :class:`~tudatpy.dynamics.environment_setup.aerodynamic_coefficients.AerodynamicCoefficientSettings` derived :class:`~tudatpy.dynamics.environment_setup.aerodynamic_coefficients.TabulatedAerodynamicCoefficientSettings` class
+ AerodynamicCoefficientSettings
+     Aerodynamic coefficient settings object for tabulated coefficients.
 
 
 
@@ -1144,8 +1144,8 @@ In this example, we create :class:`~tudatpy.dynamics.environment_setup.aerodynam
 
  Returns
  -------
- TabulatedAerodynamicCoefficientSettings
-     Instance of the :class:`~tudatpy.dynamics.environment_setup.aerodynamic_coefficients.AerodynamicCoefficientSettings` derived :class:`~tudatpy.dynamics.environment_setup.aerodynamic_coefficients.TabulatedAerodynamicCoefficientSettings` class
+ AerodynamicCoefficientSettings
+     Aerodynamic coefficient settings object for tabulated coefficients.
 
 
 

--- a/src/tudatpy/dynamics/environment_setup/aerodynamic_coefficients/expose_aerodynamic_coefficients.cpp
+++ b/src/tudatpy/dynamics/environment_setup/aerodynamic_coefficients/expose_aerodynamic_coefficients.cpp
@@ -873,8 +873,8 @@ In this example, we create :class:`~tudatpy.dynamics.environment_setup.aerodynam
      Interpolator settings object, where the conditions for interpolation of tabulated inputs are saved.
  Returns
  -------
- AerodynamicCoefficientSettings
-     Aerodynamic coefficient settings object for tabulated coefficients.
+ TabulatedAerodynamicCoefficientSettings
+     Tabulated aerodynamic coefficient settings object.
 
 
 
@@ -958,8 +958,8 @@ In this example, we create :class:`~tudatpy.dynamics.environment_setup.aerodynam
 
  Returns
  -------
- AerodynamicCoefficientSettings
-     Aerodynamic coefficient settings object for tabulated coefficients.
+ TabulatedAerodynamicCoefficientSettings
+     Tabulated aerodynamic coefficient settings object.
 
 
 
@@ -1028,8 +1028,8 @@ In this example, we create :class:`~tudatpy.dynamics.environment_setup.aerodynam
 
  Returns
  -------
- AerodynamicCoefficientSettings
-     Aerodynamic coefficient settings object for tabulated coefficients.
+ TabulatedAerodynamicCoefficientSettings
+     Tabulated aerodynamic coefficient settings object.
 
 
 
@@ -1144,8 +1144,8 @@ In this example, we create :class:`~tudatpy.dynamics.environment_setup.aerodynam
 
  Returns
  -------
- AerodynamicCoefficientSettings
-     Aerodynamic coefficient settings object for tabulated coefficients.
+ TabulatedAerodynamicCoefficientSettings
+     Tabulated aerodynamic coefficient settings object.
 
 
 

--- a/src/tudatpy/dynamics/environment_setup/ephemeris/expose_ephemeris.cpp
+++ b/src/tudatpy/dynamics/environment_setup/ephemeris/expose_ephemeris.cpp
@@ -458,7 +458,7 @@ void expose_ephemeris_setup( py::module& m )
      Kepler elements at epoch given by ``initial_state_epoch``.
 
  initial_state_epoch : float
-     Epoch at which ``initial_state_epoch`` represents the Keplerian state (Time object representing seconds since J2000 TDB).
+     Epoch at which ``initial_state_in_keplerian_elements`` represents the Keplerian state, in seconds since J2000 TDB.
 
  central_body_gravitational_parameter : float
      Effective gravitational parameter of the central body that is used in the computations. Note that when
@@ -532,7 +532,7 @@ void expose_ephemeris_setup( py::module& m )
  body : str
      Name of body for which to create ephemeris settings and infer initial state from Spice.
  initial_state_epoch : float
-     Epoch at which ``initial_state_epoch`` represents the Keplerian state (Time object representing seconds since J2000 TDB).
+     Epoch at which the initial state is defined, in seconds since J2000 TDB.
 
  central_body_gravitational_parameter : float
      Gravitational parameter of the central body that is used in the computations.
@@ -712,9 +712,9 @@ void expose_ephemeris_setup( py::module& m )
  Parameters
  ----------
  initial_time : float
-     Initial time from which interpolated data from Spice should be created (Time object representing seconds since J2000 TDB).
+     Initial epoch from which interpolated data from Spice should be created, in seconds since J2000 TDB.
  final_time : float
-     Final time from which interpolated data from Spice should be created (Time object representing seconds since J2000 TDB).
+     Final epoch through which interpolated data from Spice should be created, in seconds since J2000 TDB.
  time_step : float
      Time step with which interpolated data from Spice should be created.
  frame_origin : str, default="SSB"
@@ -843,9 +843,9 @@ void expose_ephemeris_setup( py::module& m )
  ephemeris_settings : tudatpy.dynamics.environment_setup.ephemeris.EphemerisSettings
      Existing ephemeris settings that have to be tabulated.
  start_time : float
-     Initial time for which to create the tabulated ephemeris (Time object representing seconds since J2000 TDB).
+     Initial epoch for which to create the tabulated ephemeris, in seconds since J2000 TDB.
  end_time : float
-     Final time for which to create the tabulated ephemeris (Time object representing seconds since J2000 TDB).
+     Final epoch for which to create the tabulated ephemeris, in seconds since J2000 TDB.
  time_step : float
      Time step to use to tabulate the existing ephemeris.
  interpolator_settings : tudatpy.math.interpolators.InterpolatorSettings, default = tudatpy.math.interpolators.lagrange_interpolation(8, boundary_interpolation=tudatpy.math.interpolators.extrapolate_at_boundary)

--- a/src/tudatpy/dynamics/environment_setup/ephemeris/expose_ephemeris.cpp
+++ b/src/tudatpy/dynamics/environment_setup/ephemeris/expose_ephemeris.cpp
@@ -457,7 +457,7 @@ void expose_ephemeris_setup( py::module& m )
  initial_state_in_keplerian_elements : numpy.ndarray[numpy.float64[6, 1]]
      Kepler elements at epoch given by ``initial_state_epoch``.
 
- initial_state_epoch : astro.time_representation.Time
+ initial_state_epoch : float
      Epoch at which ``initial_state_epoch`` represents the Keplerian state (Time object representing seconds since J2000 TDB).
 
  central_body_gravitational_parameter : float
@@ -531,7 +531,7 @@ void expose_ephemeris_setup( py::module& m )
  ----------
  body : str
      Name of body for which to create ephemeris settings and infer initial state from Spice.
- initial_state_epoch : astro.time_representation.Time
+ initial_state_epoch : float
      Epoch at which ``initial_state_epoch`` represents the Keplerian state (Time object representing seconds since J2000 TDB).
 
  central_body_gravitational_parameter : float
@@ -711,9 +711,9 @@ void expose_ephemeris_setup( py::module& m )
 
  Parameters
  ----------
- initial_time : astro.time_representation.Time
+ initial_time : float
      Initial time from which interpolated data from Spice should be created (Time object representing seconds since J2000 TDB).
- final_time : astro.time_representation.Time
+ final_time : float
      Final time from which interpolated data from Spice should be created (Time object representing seconds since J2000 TDB).
  time_step : float
      Time step with which interpolated data from Spice should be created.
@@ -775,7 +775,7 @@ void expose_ephemeris_setup( py::module& m )
 
  Parameters
  ----------
- body_state_history : dict
+ body_state_history : dict[float, numpy.ndarray[numpy.float64[6, 1]]]
      Dictionary of the discrete state history data from which ephemeris is to be created. Keys representing the time (float) and values representing Cartesian states (numpy.ndarray).
  frame_origin : str, default="SSB"
      Origin of frame in which ephemeris data is defined.
@@ -842,9 +842,9 @@ void expose_ephemeris_setup( py::module& m )
  ----------
  ephemeris_settings : tudatpy.dynamics.environment_setup.ephemeris.EphemerisSettings
      Existing ephemeris settings that have to be tabulated.
- start_time : astro.time_representation.Time
+ start_time : float
      Initial time for which to create the tabulated ephemeris (Time object representing seconds since J2000 TDB).
- end_time : astro.time_representation.Time
+ end_time : float
      Final time for which to create the tabulated ephemeris (Time object representing seconds since J2000 TDB).
  time_step : float
      Time step to use to tabulate the existing ephemeris.

--- a/src/tudatpy/dynamics/environment_setup/ephemeris/horizons_wrapper.py
+++ b/src/tudatpy/dynamics/environment_setup/ephemeris/horizons_wrapper.py
@@ -1103,12 +1103,16 @@ class HorizonsBatch:
 
         Parameters
         ----------
-        query_id : str
+        query_id_list : list[str]
             List of query terms to retrieve data for,
             all queries behave as type default and the `query_type` behaviour
             can not be set for the `HorizonsBatch` class.
         location : str
             Coordinate centre for the data with syntax `site@body`.
+        epoch_list : Union[list, None], optional
+            List of times in seconds since J2000 TDB. Can be used
+            to retrieve specific times instead of a range.
+            Must be None if start, end and step are set, by default None
         epoch_start : Union[datetime.datetime, float, None], optional
             Starting date to retrieve data for.
             Must be either a python datetime object or a float seconds since J2000 TDB.
@@ -1133,10 +1137,6 @@ class HorizonsBatch:
             Month and Year are normally available in JPL Horizons but are restricted
             here because they may produce ambiguous results (leap years etc.).
             If `epoch_list` is used, value must be None, by default None
-        epoch_list : Union[list, None], optional
-            List of times in seconds since J2000 TDB. Can be used
-            to retrieve specific times instead of a range.
-            Must be None if start, end and step are set, by default None
         extended_query : bool, optional
             Enables the retrieval of larger collections of data, by default False.
         """

--- a/src/tudatpy/dynamics/environment_setup/gravity_field_variation/expose_gravity_field_variation.cpp
+++ b/src/tudatpy/dynamics/environment_setup/gravity_field_variation/expose_gravity_field_variation.cpp
@@ -612,7 +612,7 @@ sine_coefficient_amplitude_sine_time : np.array
 angular_frequency : float
     Angular frequency (in rad/s) at which variations are to be added
 reference_epoch: float
-    Reference epoch :math:`t_{0}` for the variations (Time object representing seconds since J2000 TDB)
+    Reference epoch :math:`t_{0}` for the variations, in seconds since J2000 TDB.
 minimum_degree: int
     Minimum degree :math:`l_{\text{min}}` of gravity field variations
 minimum_order: int
@@ -656,14 +656,14 @@ amplitudes make of the variations in :math:`l,m=2,0`, :math:`l,m=2,1` and :math:
 Parameters
 ----------
 cosine_amplitudes_per_power : dict[int, np.array]
-    Dictionary of cosine coefficient amplitude blocks, with each key in the list corresponding to the polynomial power :math:`p_{i}`, and
+    Dictionary of cosine coefficient amplitude blocks, with each key corresponding to the polynomial power :math:`p_{i}`, and
     the dictionary value the corresponding :math:`K_{i,\bar{C}_{lm}}`. The first entry in each matrix block provides the coefficient variation amplitude at degree equal to ``minimum_degree`` and order equal to ``minimum_order``.
 sine_amplitudes_per_power : dict[int, np.array]
-    Dictionary of sine coefficient amplitude blocks, with each key in the list corresponding to the polynomial power :math:`p_{i}`, and
+    Dictionary of sine coefficient amplitude blocks, with each key corresponding to the polynomial power :math:`p_{i}`, and
     the dictionary value the corresponding :math:`K_{i,\bar{S}_{lm}}`. The first entry in each matrix block provides the coefficient variation amplitude at degree equal to ``minimum_degree`` and order equal to ``minimum_order``.
     Note that if ``minimum_order`` is equal to 0, the first column of values in each matrix will be unused (since there is no :math:`S_{l0}` coefficient).
 reference_epoch: float
-    Reference epoch :math:`t_{0}` for the variations (Time object representing seconds since J2000 TDB)
+    Reference epoch :math:`t_{0}` for the variations, in seconds since J2000 TDB.
 minimum_degree: int
     Minimum degree :math:`l_{\text{min}}` of gravity field variations
 minimum_order: int
@@ -702,7 +702,7 @@ sine_amplitudes : np.array
 polynomial_power: int
     Polynomial power :math:`p` used in the computation
 reference_epoch: float
-    Reference epoch :math:`t_{0}` for the variations (Time object representing seconds since J2000 TDB)
+    Reference epoch :math:`t_{0}` for the variations, in seconds since J2000 TDB.
 minimum_degree: int
     Minimum degree :math:`l_{\text{min}}` of gravity field variations
 minimum_order: int
@@ -740,11 +740,11 @@ amplitudes make of the variations in :math:`l,m=2,0`, :math:`l,m=2,1` and :math:
 Parameters
 ----------
 cosine_variations_table : dict[float, np.array]
-    Dictionary of cosine coefficient variations, with each key in list corresponding to epoch :math:`t_{i}` (as Time object) and the value to the corresponding variation
+    Dictionary of cosine coefficient variations, with each key an epoch :math:`t_{i}` in seconds since J2000 TDB and the value the corresponding variation
     :math:`\Delta \bar{C}_{lm}(t_{i})`. The first entry in each matrix block provides the coefficient variation at degree equal to ``minimum_degree`` and order equal to
     ``minimum_order``.
 sine_variations_table : dict[float, np.array]
-    Dictionary of sine coefficient variations, with each key in list corresponding to epoch :math:`t_{i}` (as Time object) and the value to the corresponding variation
+    Dictionary of sine coefficient variations, with each key an epoch :math:`t_{i}` in seconds since J2000 TDB and the value the corresponding variation
     :math:`\Delta \bar{C}_{lm}(t_{i})`. The first entry in each matrix block provides the coefficient variation at degree equal to ``minimum_degree`` and order equal to
     ``minimum_order``.
     Note that if ``minimum_order`` is equal to 0, the first column of values in each matrix will be unused (since there is no :math:`S_{l0}` coefficient).

--- a/src/tudatpy/dynamics/environment_setup/gravity_field_variation/expose_gravity_field_variation.cpp
+++ b/src/tudatpy/dynamics/environment_setup/gravity_field_variation/expose_gravity_field_variation.cpp
@@ -201,10 +201,10 @@ void expose_gravity_field_variation_setup( py::module& m )
          Parameters
          ----------
 
-         mean_tidal_forcing_cosine_terms : dict{ int, numpy.ndarray}
+         mean_tidal_forcing_cosine_terms : dict[int, list[float]]
              Dictionary in which key represents degree :math:`l` and the value a vector (with index in the vector equal to order :math:`m`) of mean forcing for the cosine coefficient variations
 
-         mean_tidal_forcing_sine_terms : numpy.ndarray
+         mean_tidal_forcing_sine_terms : dict[int, list[float]]
              Dictionary in which key represents degree :math:`l` and the value a vector (with index in the vector equal to order :math:`m`) of mean forcing for the sine coefficient variations
 
     )doc" );
@@ -314,7 +314,7 @@ Parameters
 ----------
 tide_raising_body : str
     Name of body raising the tide.
-love_number_per_degree : dict( int, float )
+love_number_per_degree : dict[int, float]
     Dictionary of Love numbers for each degree that is to be taken into account, with the key representing the degree :math:`l` of the Love number, and value containing the Love number :math:`k_{l}` itself
 
 Returns
@@ -357,7 +357,7 @@ Parameters
 ----------
 tide_raising_body : str
     Name of body raising the tide.
-love_number_per_degree : dict( int, complex )
+love_number_per_degree : dict[int, complex]
     Dictionary of Love numbers for each degree that is to be taken into account, with the key representing the degree :math:`l` of the Love number, and value containing the Love number :math:`k_{l}` itself.
 
 Returns
@@ -393,7 +393,7 @@ Parameters
 ----------
 tide_raising_body : str
     Name of body raising the tide.
-love_number_per_degree_and_order : dict( int, list( float ) )
+love_number_per_degree_and_order : dict[int, list[float]]
     Dictionary of Love numbers for each degree that is to be taken into account, with the key representing the degree :math:`l` of the Love number, and value containing the list of Love numbers :math:`k_{lm}` at this degree. Note that, for Love numbers at degree :math:`l`, the associated list can contain up to :math:`l+1` entries, representing the Love numbers (in order) :math:`k_{l0}`, :math:`k_{l1}`... :math:`k_{ll}`.
 
 Returns
@@ -438,7 +438,7 @@ Parameters
 ----------
 tide_raising_bodies : list[str]
     Names of bodies raising the tide.
-love_number_per_degree_and_order : dict( int, list( float ) )
+love_number_per_degree_and_order : dict[int, list[float]]
     Dictionary of Love numbers for each degree that is to be taken into account, with the key representing the degree :math:`l` of the Love number, and value containing the list of Love numbers :math:`k_{lm}` at this degree. Note that, for Love numbers at degree :math:`l`, the associated list can contain up to :math:`l+1` entries, representing the Love numbers (in order) :math:`k_{l0}`, :math:`k_{l1}`... :math:`k_{ll}`.
 
 Returns
@@ -466,7 +466,7 @@ Parameters
 ----------
 tide_raising_body : str
     Name of body raising the tide.
-love_number_per_degree : dict( int, list( complex ) )
+love_number_per_degree_and_order : dict[int, list[complex]]
     Dictionary of Love numbers for each degree that is to be taken into account, with the key representing the degree :math:`l` of the Love number, and value containing the list of Love numbers :math:`k_{lm}` at this degree. Note that, for Love numbers at degree :math:`l`, the associated list can contain up to :math:`l+1` entries, representing the Love numbers (in order) :math:`k_{l0}`, :math:`k_{l1}`...:math:`k_{ll}`.
 
 Returns
@@ -502,9 +502,9 @@ response
 
 Parameters
 ----------
-tide_raising_body : str
-    Name of body raising the tide.
-love_number_per_degree : dict[tuple[int, int], dict[tuple[int,int],float]]
+deforming_bodies : list[str]
+    Names of the bodies raising the tide.
+love_numbers : dict[tuple[int, int], dict[tuple[int, int], float]]
     Double dictionary of Love numbers for each combination for forcing and response degree and order, and the value (``float``) the associated
     mode-coupled Love number :math:`k_{lm}^{l'm'}`. The first tuple is the forcing degree and order :math:`l,m`, the second tuple is the response degree and order :math:`l',m'`
 
@@ -609,9 +609,9 @@ sine_coefficient_amplitude_cosine_time : np.array
 sine_coefficient_amplitude_sine_time : np.array
     Coefficient amplitude block :math:`B_{i,\bar{S}_{lm}}`. The first entry in each matrix block provides the coefficient variation amplitude at degree equal to ``minimum_degree`` and order equal to ``minimum_order``.
     Note that if ``minimum_order`` is equal to 0, the first column of values in each matrix will be unused (since there is no :math:`S_{l0}` coefficient).
-angular_frequency : list[float]
-    Angular frequencies (in rad/s) at which variations are to be added
-reference_epoch: astro.time_representation.Time
+angular_frequency : float
+    Angular frequency (in rad/s) at which variations are to be added
+reference_epoch: float
     Reference epoch :math:`t_{0}` for the variations (Time object representing seconds since J2000 TDB)
 minimum_degree: int
     Minimum degree :math:`l_{\text{min}}` of gravity field variations
@@ -658,11 +658,11 @@ Parameters
 cosine_amplitudes_per_power : dict[int, np.array]
     Dictionary of cosine coefficient amplitude blocks, with each key in the list corresponding to the polynomial power :math:`p_{i}`, and
     the dictionary value the corresponding :math:`K_{i,\bar{C}_{lm}}`. The first entry in each matrix block provides the coefficient variation amplitude at degree equal to ``minimum_degree`` and order equal to ``minimum_order``.
-sine_amplitudes_per_power : list[np.array]
+sine_amplitudes_per_power : dict[int, np.array]
     Dictionary of sine coefficient amplitude blocks, with each key in the list corresponding to the polynomial power :math:`p_{i}`, and
     the dictionary value the corresponding :math:`K_{i,\bar{S}_{lm}}`. The first entry in each matrix block provides the coefficient variation amplitude at degree equal to ``minimum_degree`` and order equal to ``minimum_order``.
     Note that if ``minimum_order`` is equal to 0, the first column of values in each matrix will be unused (since there is no :math:`S_{l0}` coefficient).
-reference_epoch: astro.time_representation.Time
+reference_epoch: float
     Reference epoch :math:`t_{0}` for the variations (Time object representing seconds since J2000 TDB)
 minimum_degree: int
     Minimum degree :math:`l_{\text{min}}` of gravity field variations
@@ -694,14 +694,14 @@ polynomial power :math:`p`.
 
 Parameters
 ----------
-cosine_amplitudes_per_power : np.array
+cosine_amplitudes : np.array
     Cosine coefficient amplitude block :math:`K_{\bar{C}_{lm}}`. The first entry in each matrix block provides the coefficient variation amplitude at degree equal to ``minimum_degree`` and order equal to ``minimum_order``.
-sine_amplitudes_per_power : list[np.array]
+sine_amplitudes : np.array
     Sine coefficient amplitude block :math:`K_{\bar{S}_{lm}}`. The first entry in each matrix block provides the coefficient variation amplitude at degree equal to ``minimum_degree`` and order equal to ``minimum_order``.
     Note that if ``minimum_order`` is equal to 0, the first column of values in each matrix will be unused (since there is no :math:`S_{l0}` coefficient).
-polynomial_power: float
+polynomial_power: int
     Polynomial power :math:`p` used in the computation
-reference_epoch: astro.time_representation.Time
+reference_epoch: float
     Reference epoch :math:`t_{0}` for the variations (Time object representing seconds since J2000 TDB)
 minimum_degree: int
     Minimum degree :math:`l_{\text{min}}` of gravity field variations
@@ -739,11 +739,11 @@ amplitudes make of the variations in :math:`l,m=2,0`, :math:`l,m=2,1` and :math:
 
 Parameters
 ----------
-cosine_variations_table : dict[astro.time_representation.Time, np.array]
+cosine_variations_table : dict[float, np.array]
     Dictionary of cosine coefficient variations, with each key in list corresponding to epoch :math:`t_{i}` (as Time object) and the value to the corresponding variation
     :math:`\Delta \bar{C}_{lm}(t_{i})`. The first entry in each matrix block provides the coefficient variation at degree equal to ``minimum_degree`` and order equal to
     ``minimum_order``.
-sine_amplitudes_per_power : dict[astro.time_representation.Time, np.array]
+sine_variations_table : dict[float, np.array]
     Dictionary of sine coefficient variations, with each key in list corresponding to epoch :math:`t_{i}` (as Time object) and the value to the corresponding variation
     :math:`\Delta \bar{C}_{lm}(t_{i})`. The first entry in each matrix block provides the coefficient variation at degree equal to ``minimum_degree`` and order equal to
     ``minimum_order``.

--- a/src/tudatpy/dynamics/environment_setup/ground_station/expose_ground_station.cpp
+++ b/src/tudatpy/dynamics/environment_setup/ground_station/expose_ground_station.cpp
@@ -429,7 +429,7 @@ reference_epoch:
  linear_velocity : numpy.ndarray([3,1])
      Linear velocity :math:`\dot{\mathbf{r}}` of the station (in m/s)
  reference_epoch : float, default = 0.0
-     Reference epoch :math:`t_{0}` (Time object representing seconds since J2000 TDB)
+     Reference epoch :math:`t_{0}`, in seconds since J2000 TDB.
  Returns
  -------
  GroundStationMotionSettings
@@ -454,7 +454,7 @@ reference_epoch:
  Parameters
  ----------
  displacement_list : dict[float, numpy.ndarray([3, 1])]
-     Dictionary with the epochs :math:`t_{i}` as keys (as Time objects), and the associated displacement :math:`\Delta\mathbf{r}_{i}` as values
+     Dictionary with epochs :math:`t_{i}` in seconds since J2000 TDB as keys, and the associated displacements :math:`\Delta\mathbf{r}_{i}` as values.
  Returns
  -------
  GroundStationMotionSettings
@@ -481,7 +481,7 @@ reference_epoch:
  Parameters
  ----------
  custom_displacement_function : callable[[float], numpy.ndarray([3, 1])]
-     Function returning :math:`\Delta\mathbf{r}`, with the time :math:`t` (as Time object) as input.
+     Function returning :math:`\Delta\mathbf{r}`, with time :math:`t` in seconds since J2000 TDB as input.
  Returns
  -------
  GroundStationMotionSettings

--- a/src/tudatpy/dynamics/environment_setup/ground_station/expose_ground_station.cpp
+++ b/src/tudatpy/dynamics/environment_setup/ground_station/expose_ground_station.cpp
@@ -428,7 +428,7 @@ reference_epoch:
  ----------
  linear_velocity : numpy.ndarray([3,1])
      Linear velocity :math:`\dot{\mathbf{r}}` of the station (in m/s)
- reference_epoch : astro.time_representation.Time, default = 0.0
+ reference_epoch : float, default = 0.0
      Reference epoch :math:`t_{0}` (Time object representing seconds since J2000 TDB)
  Returns
  -------
@@ -453,7 +453,7 @@ reference_epoch:
 
  Parameters
  ----------
- displacement_list : dict[astro.time_representation.Time,numpy.ndarray([3,1])]
+ displacement_list : dict[float, numpy.ndarray([3, 1])]
      Dictionary with the epochs :math:`t_{i}` as keys (as Time objects), and the associated displacement :math:`\Delta\mathbf{r}_{i}` as values
  Returns
  -------
@@ -480,7 +480,7 @@ reference_epoch:
 
  Parameters
  ----------
- custom_displacement_function : callable[[:class:`~tudatpy.astro.time_representation.Time`],numpy.ndarray([3,1])]
+ custom_displacement_function : callable[[float], numpy.ndarray([3, 1])]
      Function returning :math:`\Delta\mathbf{r}`, with the time :math:`t` (as Time object) as input.
  Returns
  -------

--- a/src/tudatpy/dynamics/environment_setup/radiation_pressure/expose_radiation_pressure.cpp
+++ b/src/tudatpy/dynamics/environment_setup/radiation_pressure/expose_radiation_pressure.cpp
@@ -971,7 +971,7 @@ reference_epoch : float
      Names of bodies to occult the source as seen from this target
  Returns
  -------
- CannonballRadiationPressureTargetModelSettings
+ RadiationPressureTargetModelSettings
      Object defining settings for a cannonball radiation pressure target model
 
 

--- a/src/tudatpy/dynamics/environment_setup/radiation_pressure/expose_radiation_pressure.cpp
+++ b/src/tudatpy/dynamics/environment_setup/radiation_pressure/expose_radiation_pressure.cpp
@@ -219,7 +219,7 @@ void expose_radiation_pressure_setup( py::module& m )
  Parameters
  ----------
  luminosity_function : callable[[float], float]
-     Function returning source luminosity (in Watt) as a function of time (Time object)
+     Function returning source luminosity (in Watt) as a function of time in seconds since J2000 TDB.
  Returns
  -------
  LuminosityModelSettings
@@ -248,7 +248,7 @@ void expose_radiation_pressure_setup( py::module& m )
  Parameters
  ----------
  irradiance_function : callable[[float], float]
-     Function returning irradiance at reference distance from center of source (in :math:`W/m^{2}`) as a function of time (Time object)
+     Function returning irradiance at reference distance from the center of the source (in :math:`W/m^{2}`) as a function of time in seconds since J2000 TDB.
  reference_distance : float
      Distance from center of source at which the irradiance is defined
  Returns
@@ -413,7 +413,7 @@ void expose_radiation_pressure_setup( py::module& m )
  constant_degree_two_contribution : float
      Value of :math:`a_{2}` in above formulation.
 reference_epoch : float
-     Reference epoch :math:`t_{0}` of the periodic variation (Time object representing seconds since J2000 TDB).
+     Reference epoch :math:`t_{0}` of the periodic variation, in seconds since J2000 TDB.
  period : float
      Period :math:`T` of the periodic variation.
  Returns
@@ -469,7 +469,7 @@ reference_epoch : float
  Parameters
  ----------
  custom_function : callable[[float, float, float], float]
-     Function providing surface property as a function of latitude, longitude and time (in that order, with time as a Time object).
+     Function providing surface property as a function of latitude, longitude, and time in seconds since J2000 TDB, in that order.
  Returns
  -------
  SurfacePropertyDistributionSettings
@@ -971,7 +971,7 @@ reference_epoch : float
      Names of bodies to occult the source as seen from this target
  Returns
  -------
- RadiationPressureTargetModelSettings
+ CannonballRadiationPressureTargetModelSettings
      Object defining settings for a cannonball radiation pressure target model
 
 

--- a/src/tudatpy/dynamics/environment_setup/radiation_pressure/expose_radiation_pressure.cpp
+++ b/src/tudatpy/dynamics/environment_setup/radiation_pressure/expose_radiation_pressure.cpp
@@ -218,7 +218,7 @@ void expose_radiation_pressure_setup( py::module& m )
 
  Parameters
  ----------
- luminosity_function : callable[[:class:`~tudatpy.astro.time_representation.Time`], float]
+ luminosity_function : callable[[float], float]
      Function returning source luminosity (in Watt) as a function of time (Time object)
  Returns
  -------
@@ -247,7 +247,7 @@ void expose_radiation_pressure_setup( py::module& m )
 
  Parameters
  ----------
- irradiance_function : callable[[:class:`~tudatpy.astro.time_representation.Time`], float]
+ irradiance_function : callable[[float], float]
      Function returning irradiance at reference distance from center of source (in :math:`W/m^{2}`) as a function of time (Time object)
  reference_distance : float
      Distance from center of source at which the irradiance is defined
@@ -412,7 +412,7 @@ void expose_radiation_pressure_setup( py::module& m )
      Value of :math:`c_{2}` in above formulation.
  constant_degree_two_contribution : float
      Value of :math:`a_{2}` in above formulation.
- reference_epoch : astro.time_representation.Time
+reference_epoch : float
      Reference epoch :math:`t_{0}` of the periodic variation (Time object representing seconds since J2000 TDB).
  period : float
      Period :math:`T` of the periodic variation.
@@ -468,7 +468,7 @@ void expose_radiation_pressure_setup( py::module& m )
 
  Parameters
  ----------
- custom_function : callable[[float, float, astro.time_representation.Time], float]
+ custom_function : callable[[float, float, float], float]
      Function providing surface property as a function of latitude, longitude and time (in that order, with time as a Time object).
  Returns
  -------

--- a/src/tudatpy/dynamics/environment_setup/rigid_body/expose_rigid_body.cpp
+++ b/src/tudatpy/dynamics/environment_setup/rigid_body/expose_rigid_body.cpp
@@ -119,11 +119,11 @@ void expose_rigid_body_setup( py::module& m )
 
  Parameters
  ----------
- mass_function : callable[[:class:`~tudatpy.astro.time_representation.Time`], float]
+ mass_function : callable[[float], float]
      Function returning the mass as a function of time (Time object representing seconds since J2000 TDB) to ne used during the propagation
- center_of_mass_function : callable[[:class:`~tudatpy.astro.time_representation.Time`], numpy.ndarray[numpy.float64[3, 1]]] = None
+ center_of_mass_function : callable[[float], numpy.ndarray[numpy.float64[3, 1]]] = None
      Function returning the center of mass as a function of time (Time object representing seconds since J2000 TDB) to be used during the propagation
- inertia_tensor_function : callable[[:class:`~tudatpy.astro.time_representation.Time`], numpy.ndarray[numpy.float64[3, 3]]] = None
+ inertia_tensor_function : callable[[float], numpy.ndarray[numpy.float64[3, 3]]] = None
      Function returning the inertia tensor as a function of time (Time object representing seconds since J2000 TDB) to be used during the propagation
  Returns
  -------
@@ -152,7 +152,7 @@ void expose_rigid_body_setup( py::module& m )
 
  Parameters
  ----------
- mass : callable[[float], float]
+ mass : float
      Mass of the body (to be overridden during propagation if mass is propagated)
  center_of_mass_function : callable[[float], numpy.ndarray[numpy.float64[3, 1]]] = None
      Function returning the center of mass as a function of mass (to be used during the propagation)

--- a/src/tudatpy/dynamics/environment_setup/rigid_body/expose_rigid_body.cpp
+++ b/src/tudatpy/dynamics/environment_setup/rigid_body/expose_rigid_body.cpp
@@ -120,11 +120,11 @@ void expose_rigid_body_setup( py::module& m )
  Parameters
  ----------
  mass_function : callable[[float], float]
-     Function returning the mass as a function of time (Time object representing seconds since J2000 TDB) to ne used during the propagation
+     Function returning the mass as a function of time in seconds since J2000 TDB, to be used during the propagation.
  center_of_mass_function : callable[[float], numpy.ndarray[numpy.float64[3, 1]]] = None
-     Function returning the center of mass as a function of time (Time object representing seconds since J2000 TDB) to be used during the propagation
+     Function returning the center of mass as a function of time in seconds since J2000 TDB, to be used during the propagation.
  inertia_tensor_function : callable[[float], numpy.ndarray[numpy.float64[3, 3]]] = None
-     Function returning the inertia tensor as a function of time (Time object representing seconds since J2000 TDB) to be used during the propagation
+     Function returning the inertia tensor as a function of time in seconds since J2000 TDB, to be used during the propagation.
  Returns
  -------
  RigidBodyPropertiesSettings

--- a/src/tudatpy/dynamics/environment_setup/rotation_model/expose_rotation_model.cpp
+++ b/src/tudatpy/dynamics/environment_setup/rotation_model/expose_rotation_model.cpp
@@ -200,7 +200,7 @@ void expose_rotation_model_setup( py::module& m )
      Name of the target frame of rotation model.
  initial_orientation : numpy.ndarray[numpy.float64[3, 3]]
      Orientation of target frame in base frame at initial time.
- initial_time : astro.time_representation.Time
+ initial_time : float
      Initial time (reference epoch for rotation matrices, as Time object representing seconds since J2000 TDB).
  rotation_rate : float
      Constant rotation rate [rad/s] about rotational axis.
@@ -261,7 +261,7 @@ void expose_rotation_model_setup( py::module& m )
      Target frame of rotation model - name of frame that Tudat assigns to the body-fixed frame
  target_frame_spice : str
      Spice reference of target frame - name of the frame in Spice for which the initial orientation and rotation rate are extracted.
- initial_time : astro.time_representation.Time
+ initial_time : float
      Initial time (reference epoch for rotation matrices, as Time object representing seconds since J2000 TDB).
  Returns
  -------
@@ -515,7 +515,7 @@ void expose_rotation_model_setup( py::module& m )
      Name of the base frame of rotation model.
  target_frame : str
      Name of the target frame of rotation model.
- angle_function : callable[[:class:`~tudatpy.astro.time_representation.Time`], numpy.ndarray[numpy.float64[3, 1]]], default = None
+ angle_function : callable[[float], numpy.ndarray[numpy.float64[3, 1]]], default = None
      Custom function provided by the user, which returns an array of three values as a function of time (as Time object). The output of this function *must* be ordered as :math:`[\alpha,\beta,\sigma]`. If this input is left empty, these angles are both fixed to 0.
  Returns
  -------
@@ -553,7 +553,7 @@ void expose_rotation_model_setup( py::module& m )
      Name of the base frame of rotation model.
  target_frame : str
      Name of the target frame of rotation model.
- angle_funcion : callable[[:class:`~tudatpy.astro.time_representation.Time`], numpy.ndarray[numpy.float64[2, 1]]], default = None
+ angle_funcion : callable[[float], numpy.ndarray[numpy.float64[2, 1]]], default = None
      Custom function provided by the user, which returns an array of three values as a function of time (as Time object). The output of this function *must* be ordered as :math:`[\beta,\sigma]`. If this input is left empty, these angles are both fixed to 0.
  Returns
  -------
@@ -593,13 +593,13 @@ void expose_rotation_model_setup( py::module& m )
 
  Parameters
  ----------
- inertial_body_axis_direction : callable[[:class:`~tudatpy.astro.time_representation.Time`], numpy.ndarray[numpy.float64[3, 1]]]
+ inertial_body_axis_direction : callable[[float], numpy.ndarray[numpy.float64[3, 1]]]
      Custom function defined by the user, which imposes the inertial orientation of the body-fixed x-axis, by providing :math:`\hat{\mathbf{T}}_{I}(t)`.
  base_frame : str
      Name of the base frame of rotation model.
  target_frame : str
      Name of the target frame of rotation model.
- free_rotation_angle_function : callable[[:class:`~tudatpy.astro.time_representation.Time`], float], default = None
+ free_rotation_angle_function : callable[[float], float], default = None
      Custom function provided by the user, which returns a value for the free rotation angle :math:`\phi` about the body-fixed x-axis as a function of time. If this input is left empty, this angle is fixed to 0.
  Returns
  -------
@@ -643,7 +643,7 @@ void expose_rotation_model_setup( py::module& m )
      Name of the base frame of rotation model.
  target_frame : str
      Name of the target frame of rotation model.
- free_rotation_angle_function : callable[[:class:`~tudatpy.astro.time_representation.Time`], float], default = None
+ free_rotation_angle_function : callable[[float], float], default = None
      Custom function provided by the user, which returns a value for the free rotation angle :math:`\phi` about the body-fixed x-axis as a function of time (as Time object). If this input is left empty, this angle is fixed to 0.
  Returns
  -------
@@ -729,7 +729,7 @@ void expose_rotation_model_setup( py::module& m )
      Name of the base frame of rotation model.
  target_frame : str
      Name of the target frame of rotation model.
- custom_rotation_matrix_function: callable[[:class:`~tudatpy.astro.time_representation.Time`], numpy.ndarray[numpy.float64[3, 3]]]
+ custom_rotation_matrix_function: callable[[float], numpy.ndarray[numpy.float64[3, 3]]]
      Function computing the body-fixed to inertial rotation matrix as a function of time (Time object representing seconds since J2000 TDB)
  finite_difference_time_step: float
      Step size to use when computing the rotation matrix derivative numerically
@@ -1041,7 +1041,7 @@ void expose_rotation_model_setup( py::module& m )
      Values of :math:`[\dot{\alpha},\dot{\delta}]`
  merdian_periodic_terms : dict[float, tuple[float, float]]
      Libration terms in :math:`W` that are to be used. Dictionary key is value of :math:`\omega_{W_i}`. Value is a pair consisting of [:math:`W_{i}`,:math:`\phi_{W_{i}}`]
- pole_periodic_terms : list[dict[float, tuple[numpy.ndarray[numpy.float64[2, 1]], float]]]
+ pole_periodic_terms : dict[float, tuple[numpy.ndarray[numpy.float64[2, 1]], float]]
      Nutation terms for :math:`\alpha,\delta` that are to be used. Dictionary key is value of :math:`\omega_{N_{i}}`. Value is a pair consisting of [[:math:`\alpha_{i},\delta_{i}`],:math:`\phi_{N_{i}}`]
  angle_base_frame : str
      Optional argument to be used when the angles :math:`W,\alpha,\delta` do not define the rotation between ``target_frame`` and ``base_frame``, but between ``target_frame`` and ``angle_base_frame`` (this input).

--- a/src/tudatpy/dynamics/environment_setup/rotation_model/expose_rotation_model.cpp
+++ b/src/tudatpy/dynamics/environment_setup/rotation_model/expose_rotation_model.cpp
@@ -325,8 +325,8 @@ void expose_rotation_model_setup( py::module& m )
      Spice reference of target frame.
  Returns
  -------
- SynchronousRotationModelSettings
-     Instance of the :class:`~tudatpy.dynamics.environment_setup.rotation_model.RotationModelSettings` derived :class:`~tudatpy.dynamics.environment_setup.rotation_model.SynchronousRotationModelSettings` class
+ RotationModelSettings
+     Settings for a synchronous rotation model.
 
 
 
@@ -519,8 +519,8 @@ void expose_rotation_model_setup( py::module& m )
      Custom function provided by the user, which returns an array of three values as a function of time (as Time object). The output of this function *must* be ordered as :math:`[\alpha,\beta,\sigma]`. If this input is left empty, these angles are both fixed to 0.
  Returns
  -------
- CustomRotationModelSettings
-     Instance of the :class:`~tudatpy.dynamics.environment_setup.rotation_model.RotationModelSettings` derived :class:`~tudatpy.dynamics.environment_setup.rotation_model.CustomRotationModelSettings` class, which defines the required settings for the rotation model.
+ RotationModelSettings
+     Settings for a custom rotation model.
 
 
 
@@ -557,8 +557,8 @@ void expose_rotation_model_setup( py::module& m )
      Custom function provided by the user, which returns an array of three values as a function of time (as Time object). The output of this function *must* be ordered as :math:`[\beta,\sigma]`. If this input is left empty, these angles are both fixed to 0.
  Returns
  -------
- CustomRotationModelSettings
-     Instance of the :class:`~tudatpy.dynamics.environment_setup.rotation_model.RotationModelSettings` derived :class:`~tudatpy.dynamics.environment_setup.rotation_model.CustomRotationModelSettings` class, which defines the required settings for the rotation model.
+ RotationModelSettings
+     Settings for an aerodynamic-angle-based rotation model.
 
 
 
@@ -603,8 +603,8 @@ void expose_rotation_model_setup( py::module& m )
      Custom function provided by the user, which returns a value for the free rotation angle :math:`\phi` about the body-fixed x-axis as a function of time. If this input is left empty, this angle is fixed to 0.
  Returns
  -------
- BodyFixedDirectionBasedRotationSettings
-     Instance of the :class:`~tudatpy.dynamics.environment_setup.rotation_model.RotationModelSettings` derived :class:`~tudatpy.dynamics.environment_setup.rotation_model.BodyFixedDirectionBasedRotationSettings` class, which defines the required settings for the rotation model.
+ RotationModelSettings
+     Settings for a body-fixed-direction-based rotation model.
 
 
 
@@ -647,8 +647,8 @@ void expose_rotation_model_setup( py::module& m )
      Custom function provided by the user, which returns a value for the free rotation angle :math:`\phi` about the body-fixed x-axis as a function of time (as Time object). If this input is left empty, this angle is fixed to 0.
  Returns
  -------
- BodyFixedDirectionBasedRotationSettings
-     Instance of the :class:`~tudatpy.dynamics.environment_setup.rotation_model.RotationModelSettings` derived :class:`~tudatpy.dynamics.environment_setup.rotation_model.BodyFixedDirectionBasedRotationSettings` class, which defines the required settings for the rotation model.
+ RotationModelSettings
+     Settings for an orbital-state-direction-based rotation model.
 
 
 
@@ -735,8 +735,8 @@ void expose_rotation_model_setup( py::module& m )
      Step size to use when computing the rotation matrix derivative numerically
  Returns
  -------
- :class:`~tudatpy.dynamics.environment_setup.rotation_model.CustomRotationModelSettings`
-     Instance of the :class:`~tudatpy.dynamics.environment_setup.rotation_model.RotationModelSettings` derived :class:`~tudatpy.dynamics.environment_setup.rotation_model.CustomRotationModelSettings` class, which defines the required settings for the rotation model.
+ :class:`~tudatpy.dynamics.environment_setup.rotation_model.RotationModelSettings`
+     Settings for a zero-pitch-moment aerodynamic-angle-based rotation model.
 
 
 

--- a/src/tudatpy/dynamics/environment_setup/rotation_model/expose_rotation_model.cpp
+++ b/src/tudatpy/dynamics/environment_setup/rotation_model/expose_rotation_model.cpp
@@ -201,7 +201,7 @@ void expose_rotation_model_setup( py::module& m )
  initial_orientation : numpy.ndarray[numpy.float64[3, 3]]
      Orientation of target frame in base frame at initial time.
  initial_time : float
-     Initial time (reference epoch for rotation matrices, as Time object representing seconds since J2000 TDB).
+     Initial time used as the reference epoch for the rotation matrices, in seconds since J2000 TDB.
  rotation_rate : float
      Constant rotation rate [rad/s] about rotational axis.
  Returns
@@ -262,7 +262,7 @@ void expose_rotation_model_setup( py::module& m )
  target_frame_spice : str
      Spice reference of target frame - name of the frame in Spice for which the initial orientation and rotation rate are extracted.
  initial_time : float
-     Initial time (reference epoch for rotation matrices, as Time object representing seconds since J2000 TDB).
+     Initial time used as the reference epoch for the rotation matrices, in seconds since J2000 TDB.
  Returns
  -------
  SimpleRotationModelSettings
@@ -325,7 +325,7 @@ void expose_rotation_model_setup( py::module& m )
      Spice reference of target frame.
  Returns
  -------
- RotationModelSettings
+ SynchronousRotationModelSettings
      Settings for a synchronous rotation model.
 
 
@@ -516,11 +516,11 @@ void expose_rotation_model_setup( py::module& m )
  target_frame : str
      Name of the target frame of rotation model.
  angle_function : callable[[float], numpy.ndarray[numpy.float64[3, 1]]], default = None
-     Custom function provided by the user, which returns an array of three values as a function of time (as Time object). The output of this function *must* be ordered as :math:`[\alpha,\beta,\sigma]`. If this input is left empty, these angles are both fixed to 0.
+     Custom function returning an array of three values as a function of time in seconds since J2000 TDB. The output *must* be ordered as :math:`[\alpha,\beta,\sigma]`. If this input is left empty, all three angles are fixed to 0.
  Returns
  -------
- RotationModelSettings
-     Settings for a custom rotation model.
+ AerodynamicAngleRotationSettings
+     Settings for an aerodynamic-angle-based rotation model.
 
 
 
@@ -554,11 +554,11 @@ void expose_rotation_model_setup( py::module& m )
  target_frame : str
      Name of the target frame of rotation model.
  angle_funcion : callable[[float], numpy.ndarray[numpy.float64[2, 1]]], default = None
-     Custom function provided by the user, which returns an array of three values as a function of time (as Time object). The output of this function *must* be ordered as :math:`[\beta,\sigma]`. If this input is left empty, these angles are both fixed to 0.
+     Custom function returning an array of two values as a function of time in seconds since J2000 TDB. The output *must* be ordered as :math:`[\beta,\sigma]`. If this input is left empty, both angles are fixed to 0.
  Returns
  -------
- RotationModelSettings
-     Settings for an aerodynamic-angle-based rotation model.
+ PitchTrimRotationSettings
+     Settings for a zero-pitch-moment aerodynamic-angle-based rotation model.
 
 
 
@@ -603,7 +603,7 @@ void expose_rotation_model_setup( py::module& m )
      Custom function provided by the user, which returns a value for the free rotation angle :math:`\phi` about the body-fixed x-axis as a function of time. If this input is left empty, this angle is fixed to 0.
  Returns
  -------
- RotationModelSettings
+ BodyFixedDirectionBasedRotationSettings
      Settings for a body-fixed-direction-based rotation model.
 
 
@@ -644,10 +644,10 @@ void expose_rotation_model_setup( py::module& m )
  target_frame : str
      Name of the target frame of rotation model.
  free_rotation_angle_function : callable[[float], float], default = None
-     Custom function provided by the user, which returns a value for the free rotation angle :math:`\phi` about the body-fixed x-axis as a function of time (as Time object). If this input is left empty, this angle is fixed to 0.
+     Custom function returning the free rotation angle :math:`\phi` about the body-fixed x-axis as a function of time in seconds since J2000 TDB. If this input is left empty, this angle is fixed to 0.
  Returns
  -------
- RotationModelSettings
+ OrbitalStateBasedRotationSettings
      Settings for an orbital-state-direction-based rotation model.
 
 
@@ -730,13 +730,13 @@ void expose_rotation_model_setup( py::module& m )
  target_frame : str
      Name of the target frame of rotation model.
  custom_rotation_matrix_function: callable[[float], numpy.ndarray[numpy.float64[3, 3]]]
-     Function computing the body-fixed to inertial rotation matrix as a function of time (Time object representing seconds since J2000 TDB)
+     Function computing the body-fixed-to-inertial rotation matrix as a function of time in seconds since J2000 TDB.
  finite_difference_time_step: float
      Step size to use when computing the rotation matrix derivative numerically
  Returns
  -------
- :class:`~tudatpy.dynamics.environment_setup.rotation_model.RotationModelSettings`
-     Settings for a zero-pitch-moment aerodynamic-angle-based rotation model.
+ CustomRotationModelSettings
+     Settings for a custom rotation model.
 
 
 

--- a/src/tudatpy/dynamics/environment_setup/shape_deformation/expose_shape_deformation.cpp
+++ b/src/tudatpy/dynamics/environment_setup/shape_deformation/expose_shape_deformation.cpp
@@ -78,7 +78,7 @@ void expose_shape_deformation_setup( py::module& m )
  ----------
  tide_raising_bodies : list[ string ]
      List of bodies that raise a tide that induces the shape variation.
- displacement_love_numbers : dict[ int, [float,float] ]
+ displacement_love_numbers : dict[int, tuple[float, float]]
      Dictionary of pairs. The dictionary key the spherical harmonic degree :math:`l` of the tidal deformation (2 or 3 are currently supported). The dictionary value is comprised of a pair of floats representing the :math:`h_{2}` and :math:`l_{2}` deformation Love numbers
  reference_radius : float, default = NaN
      Spherical harmonic reference radius of the deformed body. If this value is left undefined (e.g at NaN), the reference radius of the existing spherical harmonic gravity field of the deformed body is used.

--- a/src/tudatpy/dynamics/environment_setup/vehicle_systems/expose_vehicle_systems.cpp
+++ b/src/tudatpy/dynamics/environment_setup/vehicle_systems/expose_vehicle_systems.cpp
@@ -193,7 +193,7 @@ Panel surface area
 
  Parameters
  ----------
- surface_normal_function : callable[[:class:`~tudatpy.astro.time_representation.Time`], np.ndarray]
+surface_normal_function : callable[[], np.ndarray]
     Function which takes the current epoch as input (as Time object) and returns the panel outward surface normal vector (in specified frame).
  area : float
      Panel surface area

--- a/src/tudatpy/dynamics/environment_setup/vehicle_systems/expose_vehicle_systems.cpp
+++ b/src/tudatpy/dynamics/environment_setup/vehicle_systems/expose_vehicle_systems.cpp
@@ -83,9 +83,9 @@ This class is typically instantiated through the :func:`~tudatpy.dynamics.enviro
             .def_readwrite( "surface_normal_function",
                             &tss::FrameVariableBodyPanelGeometrySettings::surfaceNormalFunction_,
                             R"doc(
-Function which takes the current epoch as input (as Time object) and returns the panel outward surface normal vector (in specified frame).
+Zero-argument function returning the panel outward surface normal vector in the specified frame. Any time dependence must be captured by the callable.
 
-:type: callable[[:class:`~tudatpy.astro.time_representation.Time`], np.ndarray]
+:type: callable[[], np.ndarray]
 )doc" )
             .def_readwrite( "area",
                             &tss::FrameVariableBodyPanelGeometrySettings::area_,
@@ -194,7 +194,7 @@ Panel surface area
  Parameters
  ----------
 surface_normal_function : callable[[], np.ndarray]
-    Function which takes the current epoch as input (as Time object) and returns the panel outward surface normal vector (in specified frame).
+    Zero-argument function returning the panel outward surface normal vector in the specified frame. Any time dependence must be captured by the callable.
  area : float
      Panel surface area
  frame_orientation : str, default = ""

--- a/src/tudatpy/dynamics/parameters/expose_parameters.cpp
+++ b/src/tudatpy/dynamics/parameters/expose_parameters.cpp
@@ -214,7 +214,7 @@ void expose_parameters( py::module& m )
 
          Returns
          -------
-         List[ tuple[int, int] ]
+         list[tuple[int, int]]
              Matching ``(start_index, size)`` entries in parameter-set order.
 
      )doc" )
@@ -261,7 +261,7 @@ void expose_parameters( py::module& m )
 
          Returns
          -------
-         List[ tuple[int, int] ]
+         tuple[int, int]
              Indices of the parameters corresponding to the description. The first element of the tuple is the start index, the second element is the size of the parameter.
 
      )doc" )
@@ -286,7 +286,7 @@ void expose_parameters( py::module& m )
 
          Returns
          -------
-         tuple[ :class:`~tudatpy.dynamics.parameters_setup.EstimatableParameterTypes`, tuple[str, str] ]
+         list[tuple[:class:`~tudatpy.dynamics.parameters_setup.EstimatableParameterTypes`, tuple[str, str]]]
              List of parameter identifiers. The first element of the tuple is the parameter type, the second element is a tuple containing the body name and, if applicable, a secondary identifier (e.g., station name), else this is an empty string.
 
 
@@ -309,8 +309,8 @@ void expose_parameters( py::module& m )
 
  Returns
  -------
- List[]
-     Verbose List of all parameters that shall be estimated. Consider parameters are listed separately.
+ None
+     This function prints the parameter names to standard output.
 
  Examples
  --------

--- a/src/tudatpy/dynamics/parameters_setup/expose_parameters_setup.cpp
+++ b/src/tudatpy/dynamics/parameters_setup/expose_parameters_setup.cpp
@@ -216,7 +216,7 @@ void expose_parameters_setup( py::module& m )
 
  Parameters
  ----------
- parameter_settings : list( :class:`~tudatpy.dynamics.parameters_setup.EstimatableParameterSettings` )
+ parameter_settings : list[:class:`~tudatpy.dynamics.parameters_setup.EstimatableParameterSettings`]
      List of objects that define the settings for the parameters that are to be created. Each entry in this list is typically created by a call to a function in the :ref:`parameters_setup` module.
 
  bodies : :class:`~tudatpy.dynamics.environment.SystemOfBodies`
@@ -225,7 +225,7 @@ void expose_parameters_setup( py::module& m )
  propagator_settings : :class:`~tudatpy.dynamics.propagation_setup.propagator.PropagatorSettings`
      Object containing the consolidated propagation settings of the simulation.
 
- consider_parameters_names : list( :class:`~tudatpy.dynamics.parameters_setup.EstimatableParameterSettings` ) = []
+ consider_parameters_names : list[:class:`~tudatpy.dynamics.parameters_setup.EstimatableParameterSettings`] = []
      List of objects that define the settings for the considered parameters that are to be created. Each entry in this list is typically created by a call to a function in the :ref:`parameters_setup` module.
 
  print_parameter_order_warning : bool = True
@@ -1585,7 +1585,7 @@ EstimatableParameterSettings
 
  Parameters
  ----------
- link_ends : Dict[:class:`~tudatpy.estimation.observable_models_setup.links.LinkEndType`, tuple[str, str]
+ link_ends : :class:`~tudatpy.estimation.observable_models_setup.links.LinkDefinition`
      Set of link ends that define the geometry of the biased observations.
 
  observable_type : ObservableType
@@ -1622,7 +1622,7 @@ EstimatableParameterSettings
 
  Parameters
  ----------
- link_ends : Dict[:class:`~tudatpy.estimation.observable_models_setup.links.LinkEndType`, tuple[str, str]
+ link_ends : :class:`~tudatpy.estimation.observable_models_setup.links.LinkDefinition`
      Set of link ends that define the geometry of the biased observations.
 
  observable_type : ObservableType
@@ -1673,7 +1673,7 @@ EstimatableParameterSettings
 
  Parameters
  ----------
- link_ends : Dict[:class:`~tudatpy.estimation.observable_models_setup.links.LinkEndType`, tuple[str, str]
+ link_ends : :class:`~tudatpy.estimation.observable_models_setup.links.LinkDefinition`
      Set of link ends that define the geometry of the biased observations.
 
  observable_type : ObservableType
@@ -1712,7 +1712,7 @@ EstimatableParameterSettings
 
  Parameters
  ----------
- link_ends : Dict[:class:`~tudatpy.estimation.observable_models_setup.links.LinkEndType`, tuple[str, str]
+ link_ends : :class:`~tudatpy.estimation.observable_models_setup.links.LinkDefinition`
      Set of link ends that define the geometry of the biased observations.
 
  observable_type : ObservableType
@@ -1890,7 +1890,7 @@ deformed_body : str
     Name of the body that is undergoing tidal deformation
 degree : int
     Degree :math:`l` of the Love numbers :math:`k_{lm}` that are to be estimated
-degree : list[int]
+orders : list[int]
     Orders :math:`m` of the Love numbers :math:`k_{lm}` that are to be estimated
 deforming_bodies : list[str]
     List of bodies that raise a tide on ``deformed_body`` for which the Love numbers defined by this setting is to be used. If the list is left empty, all tide-raising bodies will be used. By using this parameter, the values of :math:`k_{lm}` will be identical for the tides raised by each body in this list once parameter values are reset, even if they were different upon environment initialization
@@ -1927,7 +1927,7 @@ Parameters
 ----------
 deformed_body : str
     Name of the body that is undergoing tidal deformation
-love_number_per_degree : dict[tuple[int, int], list[int,int]]]
+love_number_indices : dict[tuple[int, int], list[tuple[int, int]]]
     Dictionary of Love number indices for each combination for forcing and response degree and order.
     The first tuple (key) is the forcing degree and order :math:`l,m`, the list of tuples (key) is the list of associated response degrees and orders :math:`l',m'`
     for which the Love numbers are to be estimated (see :func:`~tudatpy.dynamics.environment_setup.gravity_field_variation.mode_coupled_solid_body_tide` for mathematical definition))
@@ -1964,9 +1964,9 @@ Parameters
 ----------
 body_name : str
     Name of the body that is undergoing gravity field variation
-cosine_indices_per_power : dict[int, list[int,int]]
+cosine_indices_per_power : dict[int, list[tuple[int, int]]]
     Dictionary of powers :math:`i` (as keys) with list of combinations of degrees :math:`l` and orders :math:`m` for which to estimate :math:`K_{i,\bar{C}_{lm}}` as values (see :func:`~tudatpy.dynamics.environment_setup.gravity_field_variation.polynomial` for mathematical definition)
-sine_indices_per_power : dict[int, list[int,int]]
+sine_indices_per_power : dict[int, list[tuple[int, int]]]
     Dictionary of powers :math:`i` (as keys) with list of combinations of degrees :math:`l` and orders :math:`m` for which to estimate :math:`K_{i,\bar{S}_{lm}}` as values (see :func:`~tudatpy.dynamics.environment_setup.gravity_field_variation.polynomial` for mathematical definition)
 
 Returns
@@ -2001,9 +2001,9 @@ Parameters
 ----------
 body_name : str
     Name of the body that is undergoing gravity field variation
-cosine_indices_per_period : dict[int, list[int,int]]
+cosine_indices_per_period : dict[int, list[tuple[int, int]]]
     Dictionary of frequency index :math:`i` (as keys; corresponding to frequency :math:`f_{i}`) with list of combinations of degrees :math:`l` and orders :math:`m` for which to estimate :math:`A_{i,\bar{C}_{lm}}` and :math:`B_{i,\bar{C}_{lm}}` as values (see :func:`~tudatpy.dynamics.environment_setup.gravity_field_variation.periodic` for mathematical definition)
-sine_indices_per_period : dict[int, list[int,int]]
+sine_indices_per_period : dict[int, list[tuple[int, int]]]
     Dictionary of frequency index :math:`i` (as keys; corresponding to frequency :math:`f_{i}`) with list of combinations of degrees :math:`l` and orders :math:`m` for which to estimate :math:`A_{i,\bar{S}_{lm}}` and :math:`B_{i,\bar{S}_{lm}}` as values (see :func:`~tudatpy.dynamics.environment_setup.gravity_field_variation.periodic` for mathematical definition)
 
 Returns
@@ -2030,9 +2030,9 @@ body_name : str
     Name of the body that is undergoing gravity field variation
 power: int
     Power :math:`i` for which to estimate polynomial gravity field variations
-cosine_indices: list[int,int]
+cosine_indices: list[tuple[int, int]]
     List of combinations of degrees :math:`l` and orders :math:`m` for which to estimate :math:`K_{i,\bar{C}_{lm}}` (see :func:`~tudatpy.dynamics.environment_setup.gravity_field_variation.polynomial` for mathematical definition)
-sine_indices: list[int,int]
+sine_indices: list[tuple[int, int]]
     List of combinations of degrees :math:`l` and orders :math:`m` for which to estimate :math:`K_{i,\bar{S}_{lm}}` (see :func:`~tudatpy.dynamics.environment_setup.gravity_field_variation.polynomial` for mathematical definition)
 
 Returns

--- a/src/tudatpy/dynamics/parameters_setup/expose_parameters_setup.cpp
+++ b/src/tudatpy/dynamics/parameters_setup/expose_parameters_setup.cpp
@@ -443,7 +443,7 @@ void expose_parameters_setup( py::module& m )
 
  Returns
  -------
- :class:`~tudatpy.dynamics.parameters_setup.EstimatableParameterSettings`
+ ArcWiseAerodynamicScalingCoefficientEstimatableParameterSettings
      Settings for the arc-wise acceleration scaling parameter. )doc" );
 
     m.def( "side_component_scaling",
@@ -486,7 +486,7 @@ void expose_parameters_setup( py::module& m )
 
  Returns
  -------
- :class:`~tudatpy.dynamics.parameters_setup.EstimatableParameterSettings`
+ ArcWiseAerodynamicScalingCoefficientEstimatableParameterSettings
      Settings for the arc-wise acceleration scaling parameter. )doc" );
 
     m.def( "lift_component_scaling",
@@ -529,7 +529,7 @@ void expose_parameters_setup( py::module& m )
 
  Returns
  -------
- :class:`~tudatpy.dynamics.parameters_setup.EstimatableParameterSettings`
+ ArcWiseAerodynamicScalingCoefficientEstimatableParameterSettings
      Settings for the arc-wise acceleration scaling parameter. )doc" );
 
     m.def( "radiation_pressure_coefficient",

--- a/src/tudatpy/dynamics/parameters_setup/expose_parameters_setup.cpp
+++ b/src/tudatpy/dynamics/parameters_setup/expose_parameters_setup.cpp
@@ -443,8 +443,8 @@ void expose_parameters_setup( py::module& m )
 
  Returns
  -------
- :class:`~tudatpy.dynamics.parameters_setup.ArcWiseEstimatableParameterSettings`
-     Instance of :class:`~tudatpy.dynamics.parameters_setup.ArcWiseEstimatableParameterSettings` class that define the settings. )doc" );
+ :class:`~tudatpy.dynamics.parameters_setup.EstimatableParameterSettings`
+     Settings for the arc-wise acceleration scaling parameter. )doc" );
 
     m.def( "side_component_scaling",
            &tep::sideComponentScaling,
@@ -486,8 +486,8 @@ void expose_parameters_setup( py::module& m )
 
  Returns
  -------
- :class:`~tudatpy.dynamics.parameters_setup.ArcWiseEstimatableParameterSettings`
-     Instance of :class:`~tudatpy.dynamics.parameters_setup.ArcWiseEstimatableParameterSettings` class that define the settings. )doc" );
+ :class:`~tudatpy.dynamics.parameters_setup.EstimatableParameterSettings`
+     Settings for the arc-wise acceleration scaling parameter. )doc" );
 
     m.def( "lift_component_scaling",
            &tep::liftComponentScaling,
@@ -529,8 +529,8 @@ void expose_parameters_setup( py::module& m )
 
  Returns
  -------
- :class:`~tudatpy.dynamics.parameters_setup.ArcWiseEstimatableParameterSettings`
-     Instance of :class:`~tudatpy.dynamics.parameters_setup.ArcWiseEstimatableParameterSettings` class that define the settings. )doc" );
+ :class:`~tudatpy.dynamics.parameters_setup.EstimatableParameterSettings`
+     Settings for the arc-wise acceleration scaling parameter. )doc" );
 
     m.def( "radiation_pressure_coefficient",
            &tep::radiationPressureCoefficient,

--- a/src/tudatpy/dynamics/propagation/expose_propagation_state_utilities.cpp
+++ b/src/tudatpy/dynamics/propagation/expose_propagation_state_utilities.cpp
@@ -275,7 +275,7 @@ void expose_propagation_state_utility_bindings( py::module& m )
 
  Returns
  -------
- DampedInitialRotationalStateResults
+ RotationalProperModeDampingResults
      Object that contains the results of the damping algorithm (final damped rotational state, and forward/backward propagation results).
 
 

--- a/src/tudatpy/dynamics/propagation/expose_propagation_state_utilities.cpp
+++ b/src/tudatpy/dynamics/propagation/expose_propagation_state_utilities.cpp
@@ -120,7 +120,7 @@ void expose_propagation_state_utility_bindings( py::module& m )
      List of names of bodies for which the state is to be extracted
  central_bodies : list[str]
      List of central bodies, w.r.t. which the states are to be computed (in the same order as ``bodies_to_propagate``)
- bodies_to_propagate : SystemOfBodies
+ body_system : SystemOfBodies
      System of bodies that define the environment
  initial_time : astro.time_representation.Time
      Time at which the states are to be extracted from the environment (Time object representing seconds since J2000 TDB)

--- a/src/tudatpy/dynamics/propagation_setup/acceleration/expose_acceleration.cpp
+++ b/src/tudatpy/dynamics/propagation_setup/acceleration/expose_acceleration.cpp
@@ -1422,7 +1422,7 @@ AccelerationSettings
 
  Parameters
  ----------
- acceleration_function : callable[[:class:`~tudatpy.astro.time_representation.Time`], list]
+ acceleration_function : callable[[float], numpy.ndarray[numpy.float64[3, 1]]]
      Custom acceleration function with time as an independent variable, returning the acceleration in an inertial frame (*e.g.* with global frame orientation) as a function of time.
  Returns
  -------
@@ -1625,9 +1625,9 @@ through the spherical harmonic gravity:
      Set of middle point in times :math:`t_{i}` in the maneuver denoting the epoch of each maneuver.
  delta_v_values : list[numpy.ndarray]
      Set of delta V values :math:`\Delta \mathbf{V}_{i}`, one for each maneuver.
- total_maneuver_time : astro.time_representation.Time
+total_maneuver_time : float
      Total duration of every maneuver :math:`t_{M}`.
- maneuver_rise_time : astro.time_representation.Time
+maneuver_rise_time : float
      :math:`t_{R}` taken by the acceleration to go from zero to its maximum level.
  Returns
  -------

--- a/src/tudatpy/dynamics/propagation_setup/dependent_variable/expose_dependent_variable.cpp
+++ b/src/tudatpy/dynamics/propagation_setup/dependent_variable/expose_dependent_variable.cpp
@@ -1431,7 +1431,7 @@ The type of the acceleration that is to be saved.
      Body undergoing acceleration.
  body_exerting_acceleration : str
      Body exerting acceleration.
- component_indices : list[tuple]
+ component_indices : list[tuple[int, int]]
      Tuples of (degree, order) indicating the terms to save.
  Returns
  -------
@@ -1480,7 +1480,7 @@ The type of the acceleration that is to be saved.
      Body undergoing acceleration.
  body_exerting_acceleration : str
      Body exerting acceleration.
- component_indices : list[tuple]
+ component_indices : list[tuple[int, int]]
      Tuples of (degree, order) indicating the terms to save.
  Returns
  -------
@@ -1950,7 +1950,7 @@ The type of the acceleration that is to be saved.
      Body whose dependent variable should be saved.
  body_exerting_acceleration : str
      Body exerting the acceleration.
- component_indices : list[tuple]
+ component_indices : list[tuple[int, int]]
      Tuples of (degree, order) indicating the terms to save.
  deformation_type : BodyDeformationTypes
      Type of gravity field variation for which the acceleration contribution is to be saved

--- a/src/tudatpy/dynamics/propagation_setup/expose_propagation_setup.cpp
+++ b/src/tudatpy/dynamics/propagation_setup/expose_propagation_setup.cpp
@@ -95,9 +95,9 @@ void expose_propagation_setup( py::module& m )
      System of bodies to be used in the propagation.
  selected_acceleration_per_body : Dict[str, Dict[str, List[AccelerationSettings]]]
      Key-value container, with key denoting the body undergoing the acceleration, and the value containing an additional key-value container, with the body exerting acceleration, and list of acceleration settings exerted by this body.
- bodies_to_propagate : list
+ bodies_to_propagate : list[str]
      List of bodies to propagate.
- central_bodies : list
+ central_bodies : list[str]
      List of central bodies, each referred to each propagated body in the same order.
  Returns
  -------
@@ -161,7 +161,7 @@ void expose_propagation_setup( py::module& m )
      System of bodies to be used in the propagation.
  selected_torque_per_body : Dict[str, Dict[str, List[TorqueSettings]]]
      Key-value container, with key denoting the body undergoing the torque, and the value containing an additional key-value container, with the body exerting torque, and list of torque settings exerted by this body.
- bodies_to_propagate : list
+ bodies_to_propagate : list[str]
      List of bodies to propagate.
  Returns
  -------
@@ -225,7 +225,7 @@ void expose_propagation_setup( py::module& m )
      System of bodies to be used in the propagation.
  selected_mass_rates_per_body : Dict[str, List[MassRateModelSettings]]
      Key-value container, with key denoting the body with changing mass, and the value containing a list of mass rate settings (in most cases, this list will have only a single entry)
- acceleration_models : dict[str, list[AccelerationModel]]
+ acceleration_models : dict[str, dict[str, list[AccelerationModel]]]
      Sorted list of acceleration models, as created by :func:`create_acceleration_models`
  Returns
  -------

--- a/src/tudatpy/dynamics/propagation_setup/expose_propagation_setup.cpp
+++ b/src/tudatpy/dynamics/propagation_setup/expose_propagation_setup.cpp
@@ -101,7 +101,7 @@ void expose_propagation_setup( py::module& m )
      List of central bodies, each referred to each propagated body in the same order.
  Returns
  -------
- AccelerationMap : dict[str, list[AccelerationModel]]
+ dict[str, dict[str, list[AccelerationModel]]]
     Set of accelerations acting on the bodies to propagate, provided as dual key-value container (dictionary), similar to the acceleration settings input, but now with ``AccelerationModel`` lists as inner value
 
 
@@ -165,7 +165,7 @@ void expose_propagation_setup( py::module& m )
      List of bodies to propagate.
  Returns
  -------
- TorqueModelMap
+ dict[str, dict[str, list[TorqueModel]]]
      Set of torques acting on the bodies to propagate, provided as dual key-value container, similar to the torque settings input, but now with ``TorqueModel`` lists as inner value
 
 
@@ -229,7 +229,7 @@ void expose_propagation_setup( py::module& m )
      Sorted list of acceleration models, as created by :func:`create_acceleration_models`
  Returns
  -------
- MassRateModelMap
+ dict[str, list[MassRateModel]]
      Set of mass-rate models, as key-value container, same as the settings input, with the difference that the rate settings objects have been processed into the associated objects calculating the actual mass-rate changes.
 
 

--- a/src/tudatpy/dynamics/propagation_setup/integrator/expose_integrator.cpp
+++ b/src/tudatpy/dynamics/propagation_setup/integrator/expose_integrator.cpp
@@ -995,7 +995,7 @@ Sequence for which :math:`n_{j}=2(j+1)` (2, 4, 6, 8, 10, 12, 14, ....)
 
  Parameters
  ----------
- time_step : float
+ time_step : astro.time_representation.Time
      Initial time step to be used.
  coefficient_set : CoefficientSets
      Coefficient set (Butcher's tableau) to be used in the integration.
@@ -1062,7 +1062,7 @@ Sequence for which :math:`n_{j}=2(j+1)` (2, 4, 6, 8, 10, 12, 14, ....)
 
  Parameters
  ----------
- initial_time_step : float
+ initial_time_step : astro.time_representation.Time
      Initial time step to be used.
  coefficient_set : CoefficientSets
      Coefficient set (Butcher's tableau) to be used in the integration.
@@ -1152,7 +1152,7 @@ Sequence for which :math:`n_{j}=2(j+1)` (2, 4, 6, 8, 10, 12, 14, ....)
 
  Parameters
  ----------
- time_step : float
+ initial_time_step : astro.time_representation.Time
      Initial time step to be used.
  extrapolation_sequence : ExtrapolationMethodStepSequences
      Extrapolation sequence to be used for the integration (defining the number of substeps in iteration :math:`i`).
@@ -1217,7 +1217,7 @@ Sequence for which :math:`n_{j}=2(j+1)` (2, 4, 6, 8, 10, 12, 14, ....)
 
  Parameters
  ----------
- time_step : float
+ time_step : astro.time_representation.Time
      Time step to be used.
  extrapolation_sequence : ExtrapolationMethodStepSequences
      Extrapolation sequence to be used for the integration (defining the number of substeps in iteration :math:`i`).
@@ -1279,11 +1279,11 @@ recommended that a reasonable minimum step is provided to this function, to part
 
 Parameters
 ----------
-initial_time_step : float
+initial_time_step : astro.time_representation.Time
     Initial time step to be used.
-minimum_step_size : float
+minimum_step_size : astro.time_representation.Time
     Minimum time step to be used during the integration.
-maximum_step_size : float
+maximum_step_size : astro.time_representation.Time
     Maximum time step to be used during the integration.
 relative_error_tolerance : float, default=1.0E-12
     Relative tolerance to adjust the time step.
@@ -1295,7 +1295,7 @@ maximum_order
     Maximum order of the integrator.
 assess_termination_on_minor_steps : bool, default=false
     Whether the propagation termination conditions should be evaluated during the intermediate sub-steps of the integrator (true) or only at the end of each integration step (false).
-bandwidth : float, default=200.0
+bandwidth : astro.time_representation.Time, default=200.0
     Maximum error factor for doubling the step size.
 Returns
 -------
@@ -1328,11 +1328,11 @@ with fixed order and variable step
 
 Parameters
 ----------
-initial_time_step : float
+initial_time_step : astro.time_representation.Time
     Initial time step to be used.
-minimum_step_size : float
+minimum_step_size : astro.time_representation.Time
     Minimum time step to be used during the integration.
-maximum_step_size : float
+maximum_step_size : astro.time_representation.Time
     Maximum time step to be used during the integration.
 relative_error_tolerance : float, default=1.0E-12
     Relative tolerance to adjust the time step.
@@ -1342,7 +1342,7 @@ order
     Order of the integrator.
 assess_termination_on_minor_steps : bool, default=false
     Whether the propagation termination conditions should be evaluated during the intermediate sub-steps of the integrator (true) or only at the end of each integration step (false).
-bandwidth : float, default=200.0
+bandwidth : astro.time_representation.Time, default=200.0
     Maximum error factor for doubling the step size.
 Returns
 -------
@@ -1375,7 +1375,7 @@ IntegratorSettings
 
  Parameters
  ----------
- time_step : float
+ time_step : astro.time_representation.Time
      Initial time step to be used.
  relative_error_tolerance : float, default=1.0E-12
      Relative tolerance to adjust the time step.
@@ -1387,7 +1387,7 @@ IntegratorSettings
      Maximum order of the integrator.
  assess_termination_on_minor_steps : bool, default=false
      Whether the propagation termination conditions should be evaluated during the intermediate sub-steps of the integrator (true) or only at the end of each integration step (false).
- bandwidth : float, default=200.0
+ bandwidth : astro.time_representation.Time, default=200.0
      Maximum error factor for doubling the step size.
  Returns
  -------
@@ -1416,7 +1416,7 @@ IntegratorSettings
 
  Parameters
  ----------
- time_step : float
+ time_step : astro.time_representation.Time
      Initial time step to be used.
  order
      Order of the integrator.

--- a/src/tudatpy/dynamics/propagation_setup/mass_rate/expose_mass_rate.cpp
+++ b/src/tudatpy/dynamics/propagation_setup/mass_rate/expose_mass_rate.cpp
@@ -220,7 +220,7 @@ void expose_mass_rate_setup( py::module& m )
 
  Parameters
  ----------
- mass_rate_function : callable[[:class:`~tudatpy.astro.time_representation.Time`], float]
+ mass_rate_function : callable[[float], float]
      Function of time defining the custom mass rate.
  Returns
  -------

--- a/src/tudatpy/dynamics/propagation_setup/propagator/expose_propagator.cpp
+++ b/src/tudatpy/dynamics/propagation_setup/propagator/expose_propagator.cpp
@@ -1247,7 +1247,7 @@ Parameters
 ----------
 bodies_with_mass_to_propagate : list[str]
     List of bodies whose mass should be numerically propagated.
-mass_rate_models : SelectedMassRateModelMap
+mass_rate_models : dict[str, list[MassRateModel]]
     Mass rates associated to each body, provided as a mass rate settings object.
 initial_body_masses : numpy.ndarray
     Initial masses of the bodies to integrate (one initial mass for each body), provided in the same order as the bodies to integrate.
@@ -1359,7 +1359,7 @@ integrator_settings : IntegratorSettings
 
     .. note:: The sign of the initial time step in the integrator settings defines whether the propagation will be forward or backward in time
 
-initial_time : float
+initial_time : astro.time_representation.Time
     Initial epoch of the numerical propagation
 termination_settings : PropagationTerminationSettings
     Generic termination settings object to check whether the propagation should be ended.
@@ -1637,7 +1637,7 @@ HybridArcPropagatorSettings
 
  Parameters
  ----------
- custom_condition : callable[[:class:`~tudatpy.astro.time_representation.Time`], bool]
+ custom_condition : callable[[float], bool]
      Function of time (independent variable) which is called during the propagation and returns a boolean value denoting whether the termination condition is verified.
  Returns
  -------
@@ -1899,7 +1899,7 @@ HybridArcPropagatorSettings
      Name of the central body that defines the body-centered coordinate time scale.
  perturbing_bodies : list[str]
      Bodies whose gravity contributes to the external potential terms in the conversion.
- initial_time : float
+ initial_time : astro.time_representation.Time
      Initial time (seconds since J2000).
  integrator_settings : IntegratorSettings
      Numerical integrator settings used to propagate the relativistic time state.
@@ -1993,7 +1993,7 @@ HybridArcPropagatorSettings
  initial_state : numpy.ndarray
      Initial state of the relativistic time variables.
      Accepted shapes are ``[m]``, ``[m,1]`` or ``[1,m]``.
- initial_time : float
+ initial_time : astro.time_representation.Time
      Initial time (seconds since J2000).
  integrator_settings : IntegratorSettings
      Numerical integrator settings used to propagate the relativistic time state.
@@ -2078,7 +2078,7 @@ HybridArcPropagatorSettings
  reference_point_id : tuple[str, str]
      ``(body_name, reference_point_name)`` identifier of the propagated point.
      Use an empty reference-point name to use the body origin.
- initial_time : float
+ initial_time : astro.time_representation.Time
      Initial time (seconds since J2000).
  integrator_settings : IntegratorSettings
      Numerical integrator settings used to propagate the relativistic time state.

--- a/src/tudatpy/dynamics/propagation_setup/propagator/expose_propagator.cpp
+++ b/src/tudatpy/dynamics/propagation_setup/propagator/expose_propagator.cpp
@@ -1654,7 +1654,7 @@ HybridArcPropagatorSettings
  .. code-block:: python
 
    # Create custom function returning a bool
-   def custom_termination_function(time):  # time is a Time object
+   def custom_termination_function(time):  # time is a float in seconds since J2000 TDB
        # Do something
        set_condition = ...
        # Return bool

--- a/src/tudatpy/dynamics/propagation_setup/thrust/expose_thrust.cpp
+++ b/src/tudatpy/dynamics/propagation_setup/thrust/expose_thrust.cpp
@@ -215,8 +215,8 @@ void expose_thrust_setup( py::module& m )
      Function of time returning the value of the specific impulse, useful to link the mass propagation to the thrust model.
  Returns
  -------
- ThrustMagnitudeSettings
-     From function thrust magnitude settings object.
+ CustomThrustMagnitudeSettings
+     Custom thrust magnitude settings object.
 
 
 
@@ -261,8 +261,8 @@ void expose_thrust_setup( py::module& m )
      Constant value for specific impulse, useful to link the mass propagation to the thrust model.
  Returns
  -------
- ThrustMagnitudeSettings
-     From function thrust magnitude settings object.
+ CustomThrustMagnitudeSettings
+     Custom thrust magnitude settings object.
 
 
 
@@ -292,8 +292,8 @@ void expose_thrust_setup( py::module& m )
      Function of time returning the value of the specific impulse, useful to link the mass propagation to the thrust model.
  Returns
  -------
- ThrustMagnitudeSettings
-     From function thrust magnitude settings object.
+ CustomThrustMagnitudeSettings
+     Custom thrust magnitude settings object.
 
 
 
@@ -319,8 +319,8 @@ void expose_thrust_setup( py::module& m )
      Constant value for specific impulse, useful to link the mass propagation to the thrust model.
  Returns
  -------
- ThrustMagnitudeSettings
-     From function thrust magnitude settings object.
+ CustomThrustMagnitudeSettings
+     Custom thrust magnitude settings object.
 
 
 

--- a/src/tudatpy/dynamics/propagation_setup/thrust/expose_thrust.cpp
+++ b/src/tudatpy/dynamics/propagation_setup/thrust/expose_thrust.cpp
@@ -215,7 +215,7 @@ void expose_thrust_setup( py::module& m )
      Function of time returning the value of the specific impulse, useful to link the mass propagation to the thrust model.
  Returns
  -------
- FromFunctionThrustMagnitudeSettings
+ ThrustMagnitudeSettings
      From function thrust magnitude settings object.
 
 
@@ -261,7 +261,7 @@ void expose_thrust_setup( py::module& m )
      Constant value for specific impulse, useful to link the mass propagation to the thrust model.
  Returns
  -------
- FromFunctionThrustMagnitudeSettings
+ ThrustMagnitudeSettings
      From function thrust magnitude settings object.
 
 
@@ -292,7 +292,7 @@ void expose_thrust_setup( py::module& m )
      Function of time returning the value of the specific impulse, useful to link the mass propagation to the thrust model.
  Returns
  -------
- FromFunctionThrustMagnitudeSettings
+ ThrustMagnitudeSettings
      From function thrust magnitude settings object.
 
 
@@ -319,7 +319,7 @@ void expose_thrust_setup( py::module& m )
      Constant value for specific impulse, useful to link the mass propagation to the thrust model.
  Returns
  -------
- FromFunctionThrustMagnitudeSettings
+ ThrustMagnitudeSettings
      From function thrust magnitude settings object.
 
 

--- a/src/tudatpy/dynamics/propagation_setup/thrust/expose_thrust.cpp
+++ b/src/tudatpy/dynamics/propagation_setup/thrust/expose_thrust.cpp
@@ -209,9 +209,9 @@ void expose_thrust_setup( py::module& m )
 
  Parameters
  ----------
- thrust_magnitude_function : callable[[:class:`~tudatpy.astro.time_representation.Time`], float]
+ thrust_magnitude_function : callable[[float], float]
      Function of time returning the value of the thrust force magnitude.
- specific_impulse_function : callable[[:class:`~tudatpy.astro.time_representation.Time`], float]
+ specific_impulse_function : callable[[float], float]
      Function of time returning the value of the specific impulse, useful to link the mass propagation to the thrust model.
  Returns
  -------
@@ -255,7 +255,7 @@ void expose_thrust_setup( py::module& m )
 
  Parameters
  ----------
- thrust_magnitude_function : callable[[:class:`~tudatpy.astro.time_representation.Time`], float]
+ thrust_magnitude_function : callable[[float], float]
      Function of time returning the value of the thrust force magnitude.
  specific_impulse : float
      Constant value for specific impulse, useful to link the mass propagation to the thrust model.
@@ -286,9 +286,9 @@ void expose_thrust_setup( py::module& m )
 
  Parameters
  ----------
- thrust_acceleration_magnitude_function : callable[[:class:`~tudatpy.astro.time_representation.Time`], float]
+ thrust_acceleration_magnitude_function : callable[[float], float]
      Function of time returning the value of the thrust acceleration magnitude.
- specific_impulse_function : callable[[:class:`~tudatpy.astro.time_representation.Time`], float]
+ specific_impulse_function : callable[[float], float]
      Function of time returning the value of the specific impulse, useful to link the mass propagation to the thrust model.
  Returns
  -------
@@ -313,7 +313,7 @@ void expose_thrust_setup( py::module& m )
 
  Parameters
  ----------
- thrust_acceleration_magnitude_function : callable[[:class:`~tudatpy.astro.time_representation.Time`], float]
+ thrust_acceleration_magnitude_function : callable[[float], float]
      Function of time returning the value of the thrust acceleration magnitude.
  specific_impulse : float
      Constant value for specific impulse, useful to link the mass propagation to the thrust model.

--- a/src/tudatpy/dynamics/simulator/expose_simulator_dynamics.cpp
+++ b/src/tudatpy/dynamics/simulator/expose_simulator_dynamics.cpp
@@ -321,7 +321,7 @@ void expose_simulator_dynamics_bindings( py::module& m )
             Parameters
             ----------
 
-            predefined_state_history : :dict[ float, numpy.ndarray([m, 1]) ]
+            predefined_state_history : dict[float, numpy.ndarray([m, 1])]
                 State history (with state entry definition as per the propagator settings of this object) along which the dependent variables are to be computed
 
             Returns

--- a/src/tudatpy/dynamics/simulator/expose_simulator_state_transition.cpp
+++ b/src/tudatpy/dynamics/simulator/expose_simulator_state_transition.cpp
@@ -66,7 +66,7 @@ void expose_simulator_state_transition_bindings( py::module& m )
 
          Parameters
          ----------
-         time : astro.time_representation.Time
+         time : float
              Time at which concatenated state transition and sensitivity matrix are to be retrieved.
          Returns
          -------
@@ -88,7 +88,7 @@ void expose_simulator_state_transition_bindings( py::module& m )
 
          Parameters
          ----------
-         time : astro.time_representation.Time
+         time : float
              Time at which full concatenated state transition and sensitivity matrix are to be retrieved.
          Returns
          -------

--- a/src/tudatpy/dynamics/simulator/expose_simulator_variational.cpp
+++ b/src/tudatpy/dynamics/simulator/expose_simulator_variational.cpp
@@ -122,7 +122,7 @@ void expose_simulator_variational_bindings( py::module& m )
              Boolean defining whether equations of motion and variational equations are to be propagated concurrently
              (if true) or sequentially (of false).
 
-         variational_only_integrator_settings : :class:`~tudatpy.dynamics.propagation_setup.integrator.IntegratorSettings`, default = []
+         variational_only_integrator_settings : :class:`~tudatpy.dynamics.propagation_setup.integrator.IntegratorSettingsFloat`, default = None
              Settings to create the numerical integrator that is to be used for integration the variational equations.
              If none is given (default), the numerical integration settings are taken to be the same as the ones applied
              in the integration of the equations of motions (specified by the `integrator_settings` parameter).

--- a/src/tudatpy/estimation/estimation_analysis/expose_estimation_analysis.cpp
+++ b/src/tudatpy/estimation/estimation_analysis/expose_estimation_analysis.cpp
@@ -283,7 +283,7 @@ void expose_estimation_analysis( py::module& m )
  ----------
  parameter_set : :class:`~tudatpy.dynamics.parameters.EstimatableParameterSet`
      Consolidated set of estimated parameters.
- covariance_diagonal_entries_per_parameter : list
+ covariance_diagonal_entries_per_parameter : list[tuple[tuple[EstimatableParameterTypes, tuple[str, str]], numpy.ndarray]]
      List of ``(parameter_identifier, covariance_diagonal_entries_vector)`` entries.
  require_all_entries_to_match : bool, default = True
      If True, each ``parameter_identifier`` must match at least one parameter block, otherwise a runtime error is raised.
@@ -324,7 +324,7 @@ void expose_estimation_analysis( py::module& m )
      Existing covariance-like matrix (or a 0x0 matrix).
  parameter_set : :class:`~tudatpy.dynamics.parameters.EstimatableParameterSet`
      Consolidated set of estimated parameters.
- covariance_diagonal_entries_per_parameter : list
+ covariance_diagonal_entries_per_parameter : list[tuple[tuple[EstimatableParameterTypes, tuple[str, str]], numpy.ndarray]]
      List of ``(parameter_identifier, covariance_diagonal_entries_vector)`` entries.
  require_all_entries_to_match : bool, default = True
      If True, each ``parameter_identifier`` must match at least one parameter block, otherwise a runtime error is raised.
@@ -1118,7 +1118,7 @@ containing the data, see `user guide description <https://docs.tudat.space/en/la
  state_transition_interface : :class:`~tudatpy.dynamics.simulator.CombinedStateTransitionAndSensitivityMatrixInterface`
      Interface to the variational equations of the system dynamics, handling the propagation of the covariance matrix through time (typically retrieved from :attr:`~tudatpy.estimation.estimation_analysis.Estimator.state_transition_interface`).
 
- output_times : List[ astro.time_representation.Time ]
+ output_times : list[float]
      Times at which the propagated covariance matrix shall be reported.
      Note that this argument has no impact on the integration time-steps of the variational equations,
      which happens before the call to this function, with results stored in the ``state_transition_interface`` input.
@@ -1160,7 +1160,7 @@ containing the data, see `user guide description <https://docs.tudat.space/en/la
  state_transition_interface : :class:`~tudatpy.dynamics.simulator.CombinedStateTransitionAndSensitivityMatrixInterface`
      Interface to the variational equations of the system dynamics, handling the propagation of the covariance matrix through time (typically retrieved from :attr:`~tudatpy.estimation.estimation_analysis.Estimator.state_transition_interface`).
 
- output_times : List[ astro.time_representation.Time ]
+ output_times : list[float]
      Times at which the propagated covariance matrix shall be reported.
      Note that this argument has no impact on the integration time-steps of the covariance propagation,
      which always adheres to the integrator settings that the `state_transition_interface` links to.
@@ -1196,7 +1196,7 @@ containing the data, see `user guide description <https://docs.tudat.space/en/la
  state_transition_interface : :class:`~tudatpy.dynamics.simulator.CombinedStateTransitionAndSensitivityMatrixInterface`
     Interface to the variational equations of the system dynamics, handling the propagation of the covariance matrix through time (typically retrieved from :attr:`~tudatpy.estimation.estimation_analysis.Estimator.state_transition_interface`).
 
- output_times : List[ astro.time_representation.Time ]
+ output_times : list[float]
     Times at which the propagated covariance matrix shall be reported.
     Note that this argument has no impact on the integration time-steps of the variational equations,
     which happens before the call to this function, with results stored in the ``state_transition_interface`` input.

--- a/src/tudatpy/estimation/estimation_analysis/expose_estimation_analysis.cpp
+++ b/src/tudatpy/estimation/estimation_analysis/expose_estimation_analysis.cpp
@@ -1126,7 +1126,7 @@ containing the data, see `user guide description <https://docs.tudat.space/en/la
 
  Returns
  -------
- Dict[ astro.time_representation.Time, numpy.ndarray[numpy.float64[n, n]] ]
+ dict[float, numpy.ndarray[numpy.float64[n, n]]]
      Dictionary reporting the propagated covariances at each output time.
 
 
@@ -1168,7 +1168,7 @@ containing the data, see `user guide description <https://docs.tudat.space/en/la
 
  Returns
  -------
- Dict[ astro.time_representation.Time, numpy.ndarray[numpy.float64[m, n]] ]
+ dict[float, numpy.ndarray[numpy.float64[m, n]]]
      Dictionary reporting the propagated covariances at each output time.
 
 
@@ -1204,7 +1204,7 @@ containing the data, see `user guide description <https://docs.tudat.space/en/la
 
  Returns
  -------
- Dict[ astro.time_representation.Time, numpy.ndarray[numpy.float64[m, 1]] ]
+ dict[float, numpy.ndarray[numpy.float64[m, 1]]]
      Dictionary reporting the propagated formal errors at each output time.
 
 

--- a/src/tudatpy/estimation/estimation_analysis/expose_estimation_analysis_estimator.cpp
+++ b/src/tudatpy/estimation/estimation_analysis/expose_estimation_analysis_estimator.cpp
@@ -84,13 +84,9 @@ void expose_estimation_analysis_estimator( py::module& m )
              Object defining a consolidated set of estimatable parameters,
              linked to the environment and acceleration settings of the simulation.
 
-         observation_settings : :class:`~tudatpy.estimation.observable_models_setup.model_settings.ObservationModelSettings`
+         observation_settings : list[:class:`~tudatpy.estimation.observable_models_setup.model_settings.ObservationModelSettings`]
              List of settings objects, each object defining the observation model settings for one
              combination of observable and link geometry that is to be simulated.
-
-         integrator_settings : :class:`~tudatpy.dynamics.propagation_setup.integrator.IntegratorSettings`
-             Settings to create the numerical integrator that is to be
-             used for the integration of the equations of motion
 
          propagator_settings : :class:`~tudatpy.dynamics.propagation_setup.propagator.PropagatorSettings`
              Settings to create the propagator that is to be

--- a/src/tudatpy/estimation/estimation_analysis/expose_inter_arc_constraints.cpp
+++ b/src/tudatpy/estimation/estimation_analysis/expose_inter_arc_constraints.cpp
@@ -138,9 +138,9 @@ void expose_inter_arc_constraints( py::module& m )
              Bodies whose position and velocity jumps are constrained.
          epochs : dict[str, list[float]]
              Connection epochs :math:`t_{c,bk}` for each body, in seconds since J2000.
-         position_weights : dict[str, float | array_like[float, 3]]
+         position_weights : dict[str, float | numpy.ndarray]
              Isotropic scalar or three Cartesian diagonal position weights for each body.
-         velocity_weights : dict[str, float | array_like[float, 3]]
+         velocity_weights : dict[str, float | numpy.ndarray]
              Isotropic scalar or three Cartesian diagonal velocity weights for each body.
          constraint_scaling_factor : float, default = 1.0
              Positive factor :math:`\mu_s`; larger values weaken the constraint.
@@ -178,7 +178,7 @@ void expose_inter_arc_constraints( py::module& m )
              Bodies whose position jumps are constrained.
          epochs : dict[str, list[float]]
              Connection epochs :math:`t_{c,bk}` for each body, in seconds since J2000.
-         position_weights : dict[str, float | array_like[float, 3]]
+         position_weights : dict[str, float | numpy.ndarray]
              Isotropic scalar or three Cartesian diagonal position weights for each body.
          constraint_scaling_factor : float, default = 1.0
              Positive factor :math:`\mu_s`; larger values weaken the constraint.
@@ -216,7 +216,7 @@ void expose_inter_arc_constraints( py::module& m )
              Bodies whose velocity jumps are constrained.
          epochs : dict[str, list[float]]
              Connection epochs :math:`t_{c,bk}` for each body, in seconds since J2000.
-         velocity_weights : dict[str, float | array_like[float, 3]]
+         velocity_weights : dict[str, float | numpy.ndarray]
              Isotropic scalar or three Cartesian diagonal velocity weights for each body.
          constraint_scaling_factor : float, default = 1.0
              Positive factor :math:`\mu_s`; larger values weaken the constraint.

--- a/src/tudatpy/estimation/observable_models/observables_simulation/expose_observables_simulation.cpp
+++ b/src/tudatpy/estimation/observable_models/observables_simulation/expose_observables_simulation.cpp
@@ -67,7 +67,7 @@ void expose_observables_simulation( py::module& m )
          ----------
          link_end_states : List[ numpy.ndarray[numpy.float64[6, 1]] ]
              Vector of states of the link ends involved in the observation.
-         link_end_times : List[:class:`~tudatpy.astro.time_representation.Time`]
+         link_end_times : list[float]
              Vector of times at the link ends involved in the observation.
          observation_value : numpy.ndarray[numpy.float64[]]
              Current simulated observation value.

--- a/src/tudatpy/estimation/observable_models_setup/biases/expose_biases.cpp
+++ b/src/tudatpy/estimation/observable_models_setup/biases/expose_biases.cpp
@@ -114,8 +114,8 @@ void expose_biases( py::module& m )
 
  Returns
  -------
- :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings`
-     Instance of the :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings` defining the settings for a constant, absolute observation bias.
+ ConstantObservationBiasSettings
+     Settings for a constant, absolute observation bias.
 
  Examples
  --------
@@ -160,9 +160,8 @@ void expose_biases( py::module& m )
 
  Returns
  -------
- :class:`ObservationBiasSettings`
-     Instance of the :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings` class,
-     defining the settings for a constant, relative observation bias.
+ ConstantObservationBiasSettings
+     Settings for a constant, relative observation bias.
 
  Examples
  --------
@@ -212,8 +211,8 @@ void expose_biases( py::module& m )
 
  Returns
  -------
- :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings`
-     Instance of the :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings` derived :class:`~tudatpy.estimation.observable_models_setup.biases.ArcWiseConstantObservationBiasSettings` class.
+ ArcWiseConstantObservationBiasSettings
+     Settings for arc-wise constant absolute observation biases.
 
  Examples
  --------
@@ -262,8 +261,8 @@ void expose_biases( py::module& m )
 
  Returns
  -------
- :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings`
-     Instance of the :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings` derived :class:`~tudatpy.estimation.observable_models_setup.biases.ArcWiseConstantObservationBiasSettings` class.
+ ArcWiseConstantObservationBiasSettings
+     Settings for arc-wise constant absolute observation biases.
 
  Examples
  --------
@@ -318,8 +317,8 @@ void expose_biases( py::module& m )
 
  Returns
  -------
- :class:`ObservationBiasSettings`
-     Instance of the :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings` derived :class:`~tudatpy.estimation.observable_models_setup.biases.ArcWiseConstantObservationBiasSettings` class.
+ ArcWiseConstantObservationBiasSettings
+     Settings for arc-wise constant relative observation biases.
 
  Examples
  --------
@@ -368,8 +367,8 @@ void expose_biases( py::module& m )
 
  Returns
  -------
- :class:`ObservationBiasSettings`
-     Instance of the :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings` derived :class:`~tudatpy.estimation.observable_models_setup.biases.ArcWiseConstantObservationBiasSettings` class.
+ ArcWiseConstantObservationBiasSettings
+     Settings for arc-wise constant relative observation biases.
 
  Examples
  --------
@@ -430,9 +429,8 @@ void expose_biases( py::module& m )
 
  Returns
  -------
- :class:`ObservationBiasSettings`
-     Instance of the :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings` derived :class:`~tudatpy.estimation.observable_models_setup.biases.constantTimeDriftBias` class,
-     defining the settings for a constant, relative observation bias.
+ ConstantTimeDriftBiasSettings
+     Settings for a constant time-drift observation bias.
 
  Examples
  --------
@@ -478,8 +476,8 @@ void expose_biases( py::module& m )
  Parameters
  ----------
  bias_value : list[numpy.ndarray]
-     Constant time drift bias that is to be considered for the observation time. This vector should be the same size as the observable to which it is
-     assigned (*e.g.* size 1 for a range observable, size 2 for angular position, *etc*.)
+     List of constant time-drift bias vectors, one for each arc. Each vector should be the same size as the observable to which it is
+     assigned (*e.g.* size 1 for a range observable, size 2 for angular position, *etc*.).
 
  arc_start_times : list[float]
      List containing starting times for each arc.
@@ -492,8 +490,8 @@ void expose_biases( py::module& m )
 
  Returns
  -------
- :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings`
-     Instance of the :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings` derived :class:`ArcWiseConstantObservationBiasSettings` class.
+ ArcWiseTimeDriftBiasSettings
+     Settings for arc-wise time-drift observation biases.
 
  Examples
  --------
@@ -547,8 +545,8 @@ void expose_biases( py::module& m )
 
  Returns
  -------
- :class:`ObservationBiasSettings`
-     Instance of the :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings` derived :class:`~tudatpy.estimation.observable_models_setup.biases.ArcWiseConstantObservationBiasSettings` class.
+ ArcWiseTimeDriftBiasSettings
+     Settings for arc-wise time-drift observation biases.
 
  Examples
  --------
@@ -661,8 +659,8 @@ void expose_biases( py::module& m )
 
  Returns
  -------
- :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings`
-     Instance of the :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings` derived :class:`~tudatpy.estimation.observable_models_setup.biases.multipleObservationBiasSettings` class, combining the settings for multiple observation biases.
+ MultipleObservationBiasSettings
+     Settings combining multiple observation biases.
 
  Examples
  --------

--- a/src/tudatpy/estimation/observable_models_setup/biases/expose_biases.cpp
+++ b/src/tudatpy/estimation/observable_models_setup/biases/expose_biases.cpp
@@ -200,7 +200,7 @@ void expose_biases( py::module& m )
 
  Parameters
  ----------
- arc_start_times : list[ astro.time_representation.Time ]
+ arc_start_times : list[float]
      List containing starting times for each arc.
 
  bias_values : list[ numpy.ndarray ]
@@ -253,7 +253,7 @@ void expose_biases( py::module& m )
 
  Parameters
  ----------
- bias_values_per_start_time : Dict[astro.time_representation.Time, numpy.ndarray[numpy.float64[m, 1]]]
+ bias_values_per_start_time : dict[float, numpy.ndarray[numpy.float64[m, 1]]]
      Dictionary, in which the bias value vectors for each arc are directly mapped to the starting times of the respective arc.
      The vectors should be the same size as the observable to which it is applied (*e.g.* size 1 for a range observable, size 2 for angular position, *etc*.)
 
@@ -306,7 +306,7 @@ void expose_biases( py::module& m )
 
  Parameters
  ----------
- arc_start_times : list[ astro.time_representation.Time ]
+ arc_start_times : list[float]
      List containing starting times for each arc.
 
  bias_values : list[ numpy.ndarray ]
@@ -359,7 +359,7 @@ void expose_biases( py::module& m )
 
  Parameters
  ----------
- bias_values_per_start_time : Dict[astro.time_representation.Time, numpy.ndarray[numpy.float64[m, 1]]]
+ bias_values_per_start_time : dict[float, numpy.ndarray[numpy.float64[m, 1]]]
      Dictionary, in which the bias value vectors for each arc are directly mapped to the starting times of the respective arc.
      The vectors should be the same size as the observable to which it is applied (*e.g.* size 1 for a range observable, size 2 for angular position, *etc*.)
 
@@ -425,7 +425,7 @@ void expose_biases( py::module& m )
  time_link_end : :class:`LinkEndType`
      Defines the link end (via the :class:`LinkEndType`) which is used the current time.
 
- ref_epoch : astro.time_representation.Time
+ ref_epoch : float
      Defines the reference epoch :math:`t_{0}` at which the effect of the time drift is initialised.
 
  Returns
@@ -477,17 +477,17 @@ void expose_biases( py::module& m )
 
  Parameters
  ----------
- bias_value : numpy.ndarray
+ bias_value : list[numpy.ndarray]
      Constant time drift bias that is to be considered for the observation time. This vector should be the same size as the observable to which it is
      assigned (*e.g.* size 1 for a range observable, size 2 for angular position, *etc*.)
 
- arc_start_times : list[ astro.time_representation.Time ]
+ arc_start_times : list[float]
      List containing starting times for each arc.
 
  time_link_end : :class:`LinkEndType`
      Defines the link end (via the :class:`LinkEndType`) which is used the current time.
 
- ref_epochs : list[ astro.time_representation.Time ]
+ ref_epochs : list[float]
      List containing the arc-wise reference epochs at which the effect of the arc-wise time drift is initialised.
 
  Returns
@@ -535,14 +535,14 @@ void expose_biases( py::module& m )
 
  Parameters
  ----------
- bias_value_per_start_time : Dict[astro.time_representation.Time, numpy.ndarray[numpy.float64[m, 1]]]
+ bias_value_per_start_time : dict[float, numpy.ndarray[numpy.float64[m, 1]]]
      Dictionary, in which the time bias value vectors for each arc are directly mapped to the starting times of the respective arc.
      The vectors should be the same size as the observable to which it is applied (*e.g.* size 1 for a range observable, size 2 for angular position, *etc*.)
 
  time_link_end : :class:`LinkEndType`
      Defines the link end (via the :class:`LinkEndType`) which is used the current time.
 
- ref_epochs : list[ astro.time_representation.Time ]
+ ref_epochs : list[float]
      List containing the arc-wise reference epochs at which the effect of the arc-wise time drift is initialised.
 
  Returns
@@ -620,7 +620,7 @@ void expose_biases( py::module& m )
 
  Parameters
  ----------
- bias_values_per_start_time : Dict[astro.time_representation.Time, float]]
+ time_bias_per_arc_start_time : dict[float, float]
      Dictionary, in which the bias value for each arc are directly mapped to the starting times of the respective arc.
 
  associated_link_end : :class:`LinkEndType`

--- a/src/tudatpy/estimation/observable_models_setup/biases/expose_biases.cpp
+++ b/src/tudatpy/estimation/observable_models_setup/biases/expose_biases.cpp
@@ -114,7 +114,7 @@ void expose_biases( py::module& m )
 
  Returns
  -------
- :class:`~tudatpy.estimation.observable_models_setup.biases.ConstantObservationBiasSettings`
+ :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings`
      Instance of the :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings` defining the settings for a constant, absolute observation bias.
 
  Examples
@@ -160,7 +160,7 @@ void expose_biases( py::module& m )
 
  Returns
  -------
- :class:`ConstantObservationBiasSettings`
+ :class:`ObservationBiasSettings`
      Instance of the :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings` class,
      defining the settings for a constant, relative observation bias.
 
@@ -212,7 +212,7 @@ void expose_biases( py::module& m )
 
  Returns
  -------
- :class:`~tudatpy.estimation.observable_models_setup.biases.ArcWiseConstantObservationBiasSettings`
+ :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings`
      Instance of the :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings` derived :class:`~tudatpy.estimation.observable_models_setup.biases.ArcWiseConstantObservationBiasSettings` class.
 
  Examples
@@ -262,7 +262,7 @@ void expose_biases( py::module& m )
 
  Returns
  -------
- :class:`~tudatpy.estimation.observable_models_setup.biases.ArcWiseConstantObservationBiasSettings`
+ :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings`
      Instance of the :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings` derived :class:`~tudatpy.estimation.observable_models_setup.biases.ArcWiseConstantObservationBiasSettings` class.
 
  Examples
@@ -318,7 +318,7 @@ void expose_biases( py::module& m )
 
  Returns
  -------
- :class:`ArcWiseConstantObservationBiasSettings`
+ :class:`ObservationBiasSettings`
      Instance of the :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings` derived :class:`~tudatpy.estimation.observable_models_setup.biases.ArcWiseConstantObservationBiasSettings` class.
 
  Examples
@@ -368,7 +368,7 @@ void expose_biases( py::module& m )
 
  Returns
  -------
- :class:`ArcWiseConstantObservationBiasSettings`
+ :class:`ObservationBiasSettings`
      Instance of the :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings` derived :class:`~tudatpy.estimation.observable_models_setup.biases.ArcWiseConstantObservationBiasSettings` class.
 
  Examples
@@ -430,7 +430,7 @@ void expose_biases( py::module& m )
 
  Returns
  -------
- :class:`constantTimeDriftBias`
+ :class:`ObservationBiasSettings`
      Instance of the :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings` derived :class:`~tudatpy.estimation.observable_models_setup.biases.constantTimeDriftBias` class,
      defining the settings for a constant, relative observation bias.
 
@@ -492,7 +492,7 @@ void expose_biases( py::module& m )
 
  Returns
  -------
- :class:`~tudatpy.estimation.observable_models_setup.biases.ArcWiseConstantObservationBiasSettings`
+ :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings`
      Instance of the :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings` derived :class:`ArcWiseConstantObservationBiasSettings` class.
 
  Examples
@@ -547,7 +547,7 @@ void expose_biases( py::module& m )
 
  Returns
  -------
- :class:`ArcWiseConstantObservationBiasSettings`
+ :class:`ObservationBiasSettings`
      Instance of the :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings` derived :class:`~tudatpy.estimation.observable_models_setup.biases.ArcWiseConstantObservationBiasSettings` class.
 
  Examples
@@ -661,7 +661,7 @@ void expose_biases( py::module& m )
 
  Returns
  -------
- :class:`~tudatpy.estimation.observable_models_setup.biases.multipleObservationBiasSettings`
+ :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings`
      Instance of the :class:`~tudatpy.estimation.observable_models_setup.biases.ObservationBiasSettings` derived :class:`~tudatpy.estimation.observable_models_setup.biases.multipleObservationBiasSettings` class, combining the settings for multiple observation biases.
 
  Examples

--- a/src/tudatpy/estimation/observable_models_setup/links/expose_links.cpp
+++ b/src/tudatpy/estimation/observable_models_setup/links/expose_links.cpp
@@ -116,11 +116,11 @@ Examples
 
  Parameters
  ----------
- transmitter : tuple[str, str]
-     List of :class:`~tudatpy.estimation.observable_models_setup.links.LinkEndId` types (tuple of strings), where, for each tuple, the first entry identifies the body and the second entry reference point of the single transmitter link end(s).
+ transmitter : LinkEndId
+     Identifier for the single transmitter link end.
 
- receivers : List[ tuple[str, str] ]
-     List of :class:`~tudatpy.estimation.observable_models_setup.links.LinkEndId` types (tuple of strings), where for each tuple the first entrance identifies the body and the second entry the reference point of the receiver link end(s).
+ receivers : list[LinkEndId]
+     List of identifiers for the receiver link ends.
 
  Returns
  -------
@@ -176,11 +176,11 @@ Examples
 
  Parameters
  ----------
- transmitters : List[ tuple[str, str] ]
-     List of :class:`~tudatpy.estimation.observable_models_setup.links.LinkEndId` types (tuple of strings), where, for each tuple, the first entry identifies the body and the second entry the reference point of the transmitter link end(s).
+ transmitters : list[LinkEndId]
+     List of identifiers for the transmitter link ends.
 
- receivers : tuple[str, str]
-     List of :class:`~tudatpy.estimation.observable_models_setup.links.LinkEndId` types (tuple of strings), where, for each tuple, the first entry identifies the body and the second entry the reference point of the single receiver link end(s).
+ receiver : LinkEndId
+     Identifier for the single receiver link end.
 
  Returns
  -------

--- a/src/tudatpy/estimation/observable_models_setup/links/expose_links.cpp
+++ b/src/tudatpy/estimation/observable_models_setup/links/expose_links.cpp
@@ -124,9 +124,9 @@ Examples
 
  Returns
  -------
- List[ LinkDefinition ]
-     List of one or more :class:`~tudatpy.estimation.observable_models_setup.links.LinkDefinition` types, each defining the geometry for one one-way downlink.
-     A `LinkDefinition` type for a one one-way link is composed a dict with one `receiver` and one `transmitter` :class:`~tudatpy.estimation.observable_models_setup.links.LinkEndType` key, to each of which a :class:`~tudatpy.estimation.observable_models_setup.links.LinkEndId` type is mapped.
+ list[dict[LinkEndType, LinkEndId]]
+     List of one or more link-end dictionaries, each defining the geometry for one one-way downlink.
+     Each dictionary has one `receiver` and one `transmitter` :class:`~tudatpy.estimation.observable_models_setup.links.LinkEndType` key, to each of which a :class:`~tudatpy.estimation.observable_models_setup.links.LinkEndId` is mapped.
 
  Examples
  --------
@@ -184,9 +184,9 @@ Examples
 
  Returns
  -------
- List[ LinkDefinition ]
-     List of one or more :class:`~tudatpy.estimation.observable_models_setup.links.LinkDefinition` types, each defining the geometry for one one-way uplink.
-     A :class:`~tudatpy.estimation.observable_models_setup.links.LinkEndId` type for a one one-way link is made of a dict with one `receiver` and one `transmitter` :class:`~tudatpy.estimation.observable_models_setup.links.LinkEndType` key, to each of which a :class:`~tudatpy.estimation.observable_models_setup.links.LinkEndId` type is mapped.
+ list[dict[LinkEndType, LinkEndId]]
+     List of one or more link-end dictionaries, each defining the geometry for one one-way uplink.
+     Each dictionary has one `receiver` and one `transmitter` :class:`~tudatpy.estimation.observable_models_setup.links.LinkEndType` key, to each of which a :class:`~tudatpy.estimation.observable_models_setup.links.LinkEndId` is mapped.
 
  Examples
  --------
@@ -483,8 +483,8 @@ Examples
 
          Returns
          -------
-         :type: dict[LinkEndType,LinkEndId]
-             Dictionary of link ends
+         LinkEndId
+             Identifier of the requested link end.
 
          Examples
          --------

--- a/src/tudatpy/estimation/observable_models_setup/model_settings/expose_model_settings.cpp
+++ b/src/tudatpy/estimation/observable_models_setup/model_settings/expose_model_settings.cpp
@@ -1402,10 +1402,10 @@ subtract_doppler_signature : bool, default = true
 
 Returns
 -------
-:class:`~tudatpy.estimation.observable_models_setup.model_settings.ObservationModelSettings`
+ObservationModelSettings
     Instance of the :class:`~tudatpy.estimation.observable_models_setup.model_settings.ObservationModelSettings` derived class defining the settings for doppler observable.
 
-.)doc" );
+)doc" );
 
     m.def( "two_way_doppler_instantaneous_frequency",
            py::overload_cast< const tom::LinkDefinition&,

--- a/src/tudatpy/estimation/observations/expose_observations.cpp
+++ b/src/tudatpy/estimation/observations/expose_observations.cpp
@@ -594,7 +594,7 @@ numpy.ndarray
             Definition of the link ends for the observation.
         observations : list[numpy.ndarray]
             List of observations. Each entry is a vector representing a single observation.
-        observation_times : list[float]
+        observation_times : list[astro.time_representation.Time]
             List of observation times.
         reference_link_end : :class:`~tudatpy.estimation.observable_models_setup.links.LinkEndType`
             Reference link end for the observation.

--- a/src/tudatpy/estimation/observations/expose_observations.cpp
+++ b/src/tudatpy/estimation/observations/expose_observations.cpp
@@ -536,7 +536,7 @@ return_first_compatible_settings : bool, optional
 
 Returns
 -------
-dict[float, numpy.ndarray]
+dict[astro.time_representation.Time, numpy.ndarray]
     A map from observation time to the value of the specified dependent variable.
 )doc" )
             .def_property_readonly( "dependent_variables_matrix",

--- a/src/tudatpy/estimation/observations/observations_geometry/expose_observations_geometry.cpp
+++ b/src/tudatpy/estimation/observations/observations_geometry/expose_observations_geometry.cpp
@@ -313,7 +313,7 @@ void expose_observations_geometry( py::module& m )
  target_body : str
      Name of body which is observed by ground station
 
- observation_times : list[:class:`~tudatpy.astro.time_representation.Time`]
+ observation_times : list[float]
      List of times at which the ground station observations are to be analyzed
 
  is_station_transmitting : bool
@@ -361,7 +361,7 @@ void expose_observations_geometry( py::module& m )
  target_body : str
      Name of body which is observed by ground station
 
- observation_times : list[:class:`~tudatpy.astro.time_representation.Time`]
+ observation_times : list[float]
      List of times at which the ground station observations are to be analyzed
 
  is_station_transmitting : bool

--- a/src/tudatpy/estimation/observations/observations_geometry/expose_observations_geometry.cpp
+++ b/src/tudatpy/estimation/observations/observations_geometry/expose_observations_geometry.cpp
@@ -322,8 +322,8 @@ void expose_observations_geometry( py::module& m )
 
  Returns
  -------
- dict[astro.time_representation.Time,numpy.ndarray[numpy.float64[3, 1]]]
-     Dictionary with the required output. Key defines the observation time, the value is an array of size three containing entry 0 - elevation angle, entry 1 - azimuth angle, entry 2 - range
+ tuple[list[float], list[numpy.ndarray]]
+     Pair containing the observation times and the corresponding arrays of elevation angle, azimuth angle, and range.
 
 
 

--- a/src/tudatpy/estimation/observations_setup/ancillary_settings/expose_ancillary_settings.cpp
+++ b/src/tudatpy/estimation/observations_setup/ancillary_settings/expose_ancillary_settings.cpp
@@ -197,11 +197,11 @@ void expose_ancillary_settings_types( py::module& m )
 
                 Parameters
                 ----------
-                setting_type : ObservationAncillarySimulationVariable
+                variable : ObservationAncillarySimulationVariable
                    Type of the setting for which the value is to be set
 
-                value : list[float]
-                   List of value that define the provided setting type
+                value : float
+                   Value for the setting
 
                 )doc" )
             .def( "set_float_list_settings",
@@ -214,11 +214,11 @@ void expose_ancillary_settings_types( py::module& m )
 
                 Parameters
                 ----------
-                setting_type : ObservationAncillarySimulationVariable
+                variable : ObservationAncillarySimulationVariable
                    Type of the setting for which the value is to be set
 
-                value : float
-                   Value for the setting
+                value : list[float]
+                   List of values that define the provided setting type
 
                 )doc" )
             .def( "set_intermediate_double_data",

--- a/src/tudatpy/estimation/observations_setup/observations_simulation_settings/expose_observations_simulation_settings_core.cpp
+++ b/src/tudatpy/estimation/observations_setup/observations_simulation_settings/expose_observations_simulation_settings_core.cpp
@@ -227,7 +227,7 @@ void expose_observation_simulation_settings_core_bindings( py::module& m )
 
  Returns
  -------
- list[ObservationSimulationSettings]
+ list[TabulatedObservationSimulationSettings]
      List of :class:`~tudatpy.estimation.observations_setup.observations_simulation_settings.ObservationSimulationSettings` derived :class:`~tudatpy.estimation.observations_setup.observations_simulation_settings.TabulatedObservationSimulationSettings` objects.
 
 
@@ -303,8 +303,8 @@ void expose_observation_simulation_settings_core_bindings( py::module& m )
      Function providing the observation noise factors as a function of observation time.
  Returns
  -------
- :class:`TabulatedObservationSimulationSettings`
-     Instance of the :class:`~tudatpy.estimation.observations_setup.observations_simulation_settings.ObservationSimulationSettings` derived :class:`~tudatpy.estimation.observations_setup.observations_simulation_settings.TabulatedObservationSimulationSettings` class.
+ ObservationSimulationSettings
+     Settings defining continuous observation arcs.
 
 
 

--- a/src/tudatpy/estimation/observations_setup/observations_simulation_settings/expose_observations_simulation_settings_core.cpp
+++ b/src/tudatpy/estimation/observations_setup/observations_simulation_settings/expose_observations_simulation_settings_core.cpp
@@ -227,7 +227,7 @@ void expose_observation_simulation_settings_core_bindings( py::module& m )
 
  Returns
  -------
- List[ TabulatedObservationSimulationSettings ]
+ list[ObservationSimulationSettings]
      List of :class:`~tudatpy.estimation.observations_setup.observations_simulation_settings.ObservationSimulationSettings` derived :class:`~tudatpy.estimation.observations_setup.observations_simulation_settings.TabulatedObservationSimulationSettings` objects.
 
 
@@ -361,8 +361,8 @@ void expose_observation_simulation_settings_core_bindings( py::module& m )
 
  Returns
  -------
- List[ :class:`TabulatedObservationSimulationSettings` ]
-     List of :class:`~tudatpy.estimation.observations_setup.observations_simulation_settings.ObservationSimulationSettings` derived :class:`~tudatpy.estimation.observations_setup.observations_simulation_settings.TabulatedObservationSimulationSettings` objects.
+ list[ObservationSimulationSettings]
+     List of settings defining continuous observation arcs.
 
 
 

--- a/src/tudatpy/estimation/observations_setup/observations_wrapper/expose_observations_wrapper_io.cpp
+++ b/src/tudatpy/estimation/observations_setup/observations_wrapper/expose_observations_wrapper_io.cpp
@@ -254,7 +254,7 @@ void expose_observations_wrapper_io_bindings( py::module& m )
             System of bodies.
         body_with_ground_stations_name : str, optional
             Name of the body in which the ground stations are located, by default "Earth".
-        turnaround_ratio_function : function, default = :func:`~tudatpy.estimation.observations_setup.ancillary_settings.dsn_default_turnaround_ratios`
+        turnaround_ratio_function : Callable[[FrequencyBands, FrequencyBands], float], default = :func:`~tudatpy.estimation.observations_setup.ancillary_settings.dsn_default_turnaround_ratios`
             Function returning the turnaround ratio as a function of the uplink and downlink bands.
         )doc" );
 
@@ -275,7 +275,7 @@ void expose_observations_wrapper_io_bindings( py::module& m )
             Processed ODF data.
         observable_types_to_process : list[tudatpy.estimation.observable_models_setup.model_settings.ObservableType]
             Observable types to process.
-        start_and_end_times_to_process : tuple[float, float]
+        start_and_end_times_to_process : tuple[astro.time_representation.Time, astro.time_representation.Time]
             Start and end times of the data to process.
         allow_duplicate_observations_within_single_set: bool
             Determines if duplicate observations should be erased on SingleObservationSet level before ObservationCollection creation, default is True.

--- a/src/tudatpy/estimation/observations_setup/random_noise/expose_random_noise.cpp
+++ b/src/tudatpy/estimation/observations_setup/random_noise/expose_random_noise.cpp
@@ -107,7 +107,7 @@ void expose_random_noise( py::module& m )
                               const std::function< Eigen::VectorXd( const double ) > >(
                    &tss::addNoiseFunctionToObservationSimulationSettingsPy ),
            py::arg( "observation_simulation_settings_list" ),
-           py::arg( "noise_amplitude" ),
+           py::arg( "noise_function" ),
            R"doc(
 
  Function for adding a custom noise function to all existing observation simulation settings.
@@ -125,7 +125,7 @@ void expose_random_noise( py::module& m )
  observation_simulation_settings_list : List[ :class:`~tudatpy.estimation.observations_setup.observations_simulation_settings.ObservationSimulationSettings` ]
      Observation simulation settings, given by a list of one or more existing :class:`~tudatpy.estimation.observations_setup.observations_simulation_settings.ObservationSimulationSettings` objects.
 
- noise_function : callable[ [:class:`~tudatpy.astro.time_representation.Time`], numpy.ndarray[numpy.float64[m, 1]] ]
+ noise_function : callable[[float], numpy.ndarray[numpy.float64[m, 1]]]
      Function providing the observation noise factors as a function of observation time.
 
  Returns
@@ -146,7 +146,7 @@ void expose_random_noise( py::module& m )
                               const std::function< Eigen::VectorXd( const double ) >,
                               const tom::ObservableType >( &tss::addNoiseFunctionToObservationSimulationSettingsPy ),
            py::arg( "observation_simulation_settings_list" ),
-           py::arg( "noise_amplitude" ),
+           py::arg( "noise_function" ),
            py::arg( "observable_type" ),
            R"doc(
 
@@ -161,7 +161,7 @@ void expose_random_noise( py::module& m )
  observation_simulation_settings_list : List[ :class:`~tudatpy.estimation.observations_setup.observations_simulation_settings.ObservationSimulationSettings` ]
      Observation simulation settings, given by a list of one or more existing :class:`~tudatpy.estimation.observations_setup.observations_simulation_settings.ObservationSimulationSettings` objects.
 
- noise_function : callable[ [:class:`~tudatpy.astro.time_representation.Time`], numpy.ndarray[numpy.float64[m, 1]] ]
+ noise_function : callable[[float], numpy.ndarray[numpy.float64[m, 1]]]
      Function providing the observation noise factors as a function of observation time.
 
  observable_type : :class:`~tudatpy.estimation.observable_models_setup.model_settings.ObservableType`
@@ -186,7 +186,7 @@ void expose_random_noise( py::module& m )
                               const tom::ObservableType,
                               const tom::LinkDefinition& >( &tss::addNoiseFunctionToObservationSimulationSettingsPy ),
            py::arg( "observation_simulation_settings_list" ),
-           py::arg( "noise_amplitude" ),
+           py::arg( "noise_function" ),
            py::arg( "observable_type" ),
            py::arg( "link_ends" ),
            R"doc(
@@ -199,16 +199,16 @@ void expose_random_noise( py::module& m )
 
  Parameters
  ----------
- observation_simulation_settings : List[ :class:`~tudatpy.estimation.observations_setup.observations_simulation_settings.ObservationSimulationSettings` ]
+ observation_simulation_settings_list : list[:class:`~tudatpy.estimation.observations_setup.observations_simulation_settings.ObservationSimulationSettings`]
      Observation simulation settings, given by a list of one or more existing :class:`~tudatpy.estimation.observations_setup.observations_simulation_settings.ObservationSimulationSettings` objects.
 
- noise_function : callable[ [:class:`~tudatpy.astro.time_representation.Time`], numpy.ndarray[numpy.float64[m, 1]] ]
+ noise_function : callable[[float], numpy.ndarray[numpy.float64[m, 1]]]
      Function providing the observation noise factors as a function of observation time.
 
  observable_type : :class:`~tudatpy.estimation.observable_models_setup.model_settings.ObservableType`
      Identifies the observable type in the observation simulation settings to which the noise is to be added.
 
- link_definition : :class:`~tudatpy.estimation.observable_models_setup.links.LinkDefinition`
+ link_ends : :class:`~tudatpy.estimation.observable_models_setup.links.LinkDefinition`
      Identifies the link definition in the observation simulation settings for which the noise is to be added.
 
  Returns

--- a/src/tudatpy/estimation/observations_setup/viability/expose_viability.cpp
+++ b/src/tudatpy/estimation/observations_setup/viability/expose_viability.cpp
@@ -186,8 +186,8 @@ Examples
 
     Returns
     -------
-    :class:`ObservationBoundariesViabilitySettings`
-    Instance of the :class:`~tudatpy.estimation.observations_setup.viability.ObservationBoundariesViabilitySettings`, defining the settings for observation viability.
+    ObservationViabilitySettings
+        Settings defining observation-boundary viability for the link end.
 
      )doc" );
 
@@ -222,7 +222,7 @@ Examples
 
  Returns
  -------
- :class:`ObservationViabilitySettings`
+ ObservationViabilitySettings
      Instance of the :class:`~tudatpy.estimation.observations_setup.viability.ObservationViabilitySettings` class, defining the settings for observation viability
 
      )doc" );
@@ -267,7 +267,7 @@ Examples
 
  Returns
  -------
- :class:`ObservationViabilitySettings`
+ ObservationViabilitySettings
      Instance of the :class:`~tudatpy.estimation.observations_setup.viability.ObservationViabilitySettings`, defining the settings for observation viability.
 
 
@@ -306,7 +306,7 @@ Examples
 
  Returns
  -------
- :class:`ObservationViabilitySettings`
+ ObservationViabilitySettings
      Instance of the :class:`~tudatpy.estimation.observations_setup.viability.ObservationViabilitySettings`, defining the settings for observation viability.
 
 
@@ -333,6 +333,11 @@ Examples
 
     boundaries : list[tuple[float, float]]
     List of pairs of minimum and maximum allowed values for the observation. Each entry on the list corresponds to minimum and maximum allowed for each entry in the observation vector.
+
+ Returns
+ -------
+ list[ObservationViabilitySettings]
+     List of observation viability settings, one for each link end.
     )doc" );
 
     m.def( "elevation_angle_viability_list",
@@ -358,7 +363,7 @@ Examples
 
  Returns
  -------
- :class:`ObservationViabilitySettings`
+ list[ObservationViabilitySettings]
      List of :class:`~tudatpy.estimation.observations_setup.viability.ObservationViabilitySettings` objects, each defining the settings for observation viability of one link end.
 
 
@@ -394,7 +399,7 @@ Examples
 
  Returns
  -------
- :class:`ObservationViabilitySettings`
+ list[ObservationViabilitySettings]
      List of :class:`~tudatpy.estimation.observations_setup.viability.ObservationViabilitySettings` objects, each defining the settings for observation viability of one link end.
 
 
@@ -427,7 +432,7 @@ Examples
 
  Returns
  -------
- :class:`ObservationViabilitySettings`
+ list[ObservationViabilitySettings]
      List of :class:`~tudatpy.estimation.observations_setup.viability.ObservationViabilitySettings` objects, each defining the settings for observation viability of one link end.
 
 

--- a/src/tudatpy/estimation/observations_setup/viability/expose_viability.cpp
+++ b/src/tudatpy/estimation/observations_setup/viability/expose_viability.cpp
@@ -186,8 +186,8 @@ Examples
 
     Returns
     -------
-    ObservationViabilitySettings
-        Settings defining observation-boundary viability for the link end.
+    ObservationBoundariesViabilitySettings
+        Observation-boundary viability settings for the link end.
 
      )doc" );
 
@@ -336,8 +336,8 @@ Examples
 
  Returns
  -------
- list[ObservationViabilitySettings]
-     List of observation viability settings, one for each link end.
+ list[ObservationBoundariesViabilitySettings]
+     List of observation-boundary viability settings, one for each link end.
     )doc" );
 
     m.def( "elevation_angle_viability_list",

--- a/src/tudatpy/interface/spice/expose_spice.cpp
+++ b/src/tudatpy/interface/spice/expose_spice.cpp
@@ -84,7 +84,8 @@ void expose_spice( py::module& m )
      Julian date that is to be converted to ephemeris time.
  Returns
  -------
- ephemeris_time : float    Julian date calculated from ephemeris time.
+ float
+     Ephemeris time corresponding to the given Julian date.
 
 
 
@@ -110,7 +111,7 @@ void expose_spice( py::module& m )
 
  Returns
  -------
- utc_time : float
+ float
      Approximate UTC time corresponding to the given ephemeris time.
 
      )doc" );
@@ -136,7 +137,8 @@ void expose_spice( py::module& m )
      Ephemeris time that is to be converted to Julian date.
  Returns
  -------
- julian_date : float    Julian date calculated from ephemeris time.
+ float
+     Julian date calculated from ephemeris time.
 
 
 
@@ -169,7 +171,8 @@ void expose_spice( py::module& m )
 
  Returns
  -------
- ephemeris_time : str    Ephemeris time corresponding to given date_string.
+ float
+     Ephemeris time corresponding to the given date string.
 
 
 
@@ -234,6 +237,11 @@ void expose_spice( py::module& m )
      Observation time (or transmission time of observed light, see description
      of aberrationCorrections).
 
+ Returns
+ -------
+ numpy.ndarray[3, 1]
+     Cartesian position vector of the target body relative to the observer.
+
 
 
 
@@ -295,7 +303,8 @@ void expose_spice( py::module& m )
 
  Returns
  -------
- cartesian_state_vector : numpy.ndarray[6,]    Cartesian state vector (x,y,z, position+velocity).
+ numpy.ndarray[6, 1]
+     Cartesian state vector containing position and velocity.
 
 
 
@@ -326,7 +335,8 @@ void expose_spice( py::module& m )
      Tle object containing the SGP/SDP model parameters as derived from the element set.
  Returns
  -------
- cartesian_state_vector : numpy.ndarray[6,]    Cartesian state vector (x,y,z, position+velocity).
+ numpy.ndarray[6, 1]
+     Cartesian state vector containing position and velocity.
 
 
 
@@ -362,7 +372,8 @@ void expose_spice( py::module& m )
      Value of ephemeris time at which rotation is to be determined.
  Returns
  -------
- Rotation matrix from original to new frame at given time.
+ numpy.ndarray[3, 3]
+     Rotation matrix from the original to the new frame at the given time.
 
 
 
@@ -397,7 +408,8 @@ void expose_spice( py::module& m )
      Value of ephemeris time at which rotation is to be determined.
  Returns
  -------
- State rotation matrix from original to new frame at given time.
+ numpy.ndarray[6, 6]
+     State rotation matrix from the original to the new frame at the given time.
 
 
 
@@ -439,7 +451,8 @@ void expose_spice( py::module& m )
      Value of ephemeris time at which rotation is to be determined.
  Returns
  -------
- Time derivative of rotation matrix from original to new frame at given time.
+ numpy.ndarray[3, 3]
+     Time derivative of the rotation matrix from the original to the new frame at the given time.
 
 
 
@@ -476,7 +489,8 @@ void expose_spice( py::module& m )
      Value of ephemeris time at which rotation is to be determined.
  Returns
  -------
- Angular velocity of newFrame w.r.t. originalFrame, expressed in originalFrame.
+ numpy.ndarray[3, 1]
+     Angular velocity of the new frame with respect to the original frame, expressed in the original frame.
 
 
      )doc" );
@@ -510,7 +524,8 @@ void expose_spice( py::module& m )
 
  Returns
  -------
- Property value(s) expressed in an STL vector of doubles.
+ list[float]
+     Requested property values.
 
 
 
@@ -548,7 +563,8 @@ void expose_spice( py::module& m )
      Name of the body of which the parameter is to be retrieved.
  Returns
  -------
- Gravitational parameter of requested body.
+ float
+     Gravitational parameter of the requested body.
 
 
 
@@ -576,7 +592,8 @@ void expose_spice( py::module& m )
      Name of the body of which the average radius is to be retrieved.
  Returns
  -------
- Arithmetic mean of principal axes of tri-axial ellipsoid shape model of body.
+ float
+     Arithmetic mean of the principal axes of the body's tri-axial ellipsoid shape model.
 
 
 
@@ -605,7 +622,8 @@ void expose_spice( py::module& m )
      Name of the body for which NAIF id is to be retrieved.
  Returns
  -------
- NAIF id number for the body with bodyName.
+ int
+     NAIF identification number for the body.
 
 
 
@@ -684,7 +702,8 @@ void expose_spice( py::module& m )
 
  Returns
  -------
- n_kernels : int    Number of spice kernels currently loaded.
+ int
+     Number of Spice kernels currently loaded.
 
 
 

--- a/src/tudatpy/interface/spice/expose_spice.cpp
+++ b/src/tudatpy/interface/spice/expose_spice.cpp
@@ -80,7 +80,7 @@ void expose_spice( py::module& m )
 
  Parameters
  ----------
- julian_date : int
+ julian_date : float
      Julian date that is to be converted to ephemeris time.
  Returns
  -------

--- a/src/tudatpy/math/interpolators/expose_interpolators.cpp
+++ b/src/tudatpy/math/interpolators/expose_interpolators.cpp
@@ -588,7 +588,7 @@ The program will terminate and throw a :class:`~tudatpy.exceptions.LagrangeInter
 
         Parameters
         ----------
-        independent_variable_value : float
+        independent_variable_value : astro.time_representation.Time
             Value of independent variable at which the interpolation is to be performed.
         Returns
         -------
@@ -671,7 +671,7 @@ The program will terminate and throw a :class:`~tudatpy.exceptions.LagrangeInter
 
         Parameters
         ----------
-        independent_variable_value : float
+        independent_variable_value : astro.time_representation.Time
             Value of independent variable at which the interpolation is to be performed.
         Returns
         -------
@@ -721,7 +721,7 @@ The program will terminate and throw a :class:`~tudatpy.exceptions.LagrangeInter
 
      Parameters
      ----------
-     data_to_interpolate : dict[Time, float]
+     data_to_interpolate : dict[float, float]
          Key-value container with pairs of independent variables (key) and dependent variables (value) from which the interpolation is to be performed
      interpolator_settings : InterpolatorSettings
          Settings that define the type of interpolator that is to be used

--- a/src/tudatpy/math/interpolators/expose_interpolators.cpp
+++ b/src/tudatpy/math/interpolators/expose_interpolators.cpp
@@ -717,7 +717,7 @@ The program will terminate and throw a :class:`~tudatpy.exceptions.LagrangeInter
            py::arg( "data_first_derivatives" ) = std::vector< double >( ),
            R"doc(
 
-     Same as :func:`~create_one_dimensional_scalar_interpolator`, but using the high-resolution :func:`~Time` type used as independent variable for interpolation
+     Creates a one-dimensional scalar interpolator with floating-point independent variables.
 
      Parameters
      ----------
@@ -729,7 +729,7 @@ The program will terminate and throw a :class:`~tudatpy.exceptions.LagrangeInter
          List of first derivative dependent variables w.r.t. independent variable from which the interpolation is to be performed. Must be of the same size as the number of data points in ``data_to_interpolate``. This input is *only* required if the requested interpolation algorithm requires first derivatives as input (such as the Hermite spline interpolator).
      Returns
      -------
-     OneDimensionalInterpolatorScalarTimeObject
+     OneDimensionalInterpolatorScalar
          Interpolator object
 
     )doc" );

--- a/src/tudatpy/trajectory_design/transfer_trajectory/expose_transfer_trajectory.cpp
+++ b/src/tudatpy/trajectory_design/transfer_trajectory/expose_transfer_trajectory.cpp
@@ -602,14 +602,14 @@ void expose_transfer_trajectory( py::module& m )
          node_times : list[float]
              List of the time at each node.
          leg_parameters : list[numpy.ndarray]
-             List of lists with the parameters characterizing each leg. Each inner list corresponds to the
-             parameters of one leg; if a leg does not require any parameter, its list can contain any value(s),
-             therefore it is recommended to leave it empty.
+             List of arrays with the parameters characterizing each leg. Each array corresponds to the
+             parameters of one leg; if a leg does not require any parameters, the corresponding array may contain any values,
+             but an empty array is recommended.
 
          node_parameters : list[numpy.ndarray]
-             List of lists with the parameters characterizing each node. Each inner list corresponds to the
-             parameters of one node; if a node does not require any parameter, its list can contain any value(s),
-             therefore it is recommended to leave it empty.
+             List of arrays with the parameters characterizing each node. Each array corresponds to the
+             parameters of one node; if a node does not require any parameters, the corresponding array may contain any values,
+             but an empty array is recommended.
 
          Returns
          -------

--- a/src/tudatpy/trajectory_design/transfer_trajectory/expose_transfer_trajectory.cpp
+++ b/src/tudatpy/trajectory_design/transfer_trajectory/expose_transfer_trajectory.cpp
@@ -601,12 +601,12 @@ void expose_transfer_trajectory( py::module& m )
          ----------
          node_times : list[float]
              List of the time at each node.
-         leg_parameters : list[list[float]]
+         leg_parameters : list[numpy.ndarray]
              List of lists with the parameters characterizing each leg. Each inner list corresponds to the
              parameters of one leg; if a leg does not require any parameter, its list can contain any value(s),
              therefore it is recommended to leave it empty.
 
-         node_parameters : list[list[float]]
+         node_parameters : list[numpy.ndarray]
              List of lists with the parameters characterizing each node. Each inner list corresponds to the
              parameters of one node; if a node does not require any parameter, its list can contain any value(s),
              therefore it is recommended to leave it empty.

--- a/src/tudatpy/trajectory_design/transfer_trajectory/expose_transfer_trajectory.cpp
+++ b/src/tudatpy/trajectory_design/transfer_trajectory/expose_transfer_trajectory.cpp
@@ -682,8 +682,8 @@ void expose_transfer_trajectory( py::module& m )
              Number of data points used to describe each leg.
          Returns
          -------
-         tuple[numpy.ndarray,numpy.ndarray]
-             Tuple of (state history, time history).
+         dict[float, numpy.ndarray]
+             State history keyed by time.
 
 
 
@@ -708,8 +708,8 @@ void expose_transfer_trajectory( py::module& m )
              Number of data points used to describe each leg.
          Returns
          -------
-         tuple[numpy.ndarray,numpy.ndarray]
-             Tuple of (state history, time history).
+         dict[float, numpy.ndarray]
+             Inertial thrust acceleration history keyed by time.
 
 
 
@@ -734,8 +734,8 @@ void expose_transfer_trajectory( py::module& m )
              Number of data points used to describe each leg.
          Returns
          -------
-         tuple[numpy.ndarray,numpy.ndarray]
-             Tuple of (state history, time history).
+         dict[float, numpy.ndarray]
+             RSW-frame thrust acceleration history keyed by time.
 
 
 
@@ -760,8 +760,8 @@ void expose_transfer_trajectory( py::module& m )
              Number of data points used to describe each leg.
          Returns
          -------
-         tuple[numpy.ndarray,numpy.ndarray]
-             Tuple of (state history, time history).
+         dict[float, numpy.ndarray]
+             TNW-frame thrust acceleration history keyed by time.
 
 
 

--- a/src/tudatpy/util/_support.py
+++ b/src/tudatpy/util/_support.py
@@ -6,7 +6,7 @@ import os
 from typing import Union, Callable
 
 
-def result2array(result: dict[float, np.ndarray]):
+def result2array(result: dict[float, np.ndarray]) -> np.ndarray:
     """Initial prototype function to convert dict result from DynamicsSimulator
 
     The `state_history` and `dependent_history` retrieved from classes
@@ -68,7 +68,7 @@ def compare_results(
     baseline_results: dict[float, np.ndarray],
     new_results: dict[float, np.ndarray],
     difference_epochs: list[float] | np.ndarray,
-):
+) -> dict[float, np.ndarray]:
     """Compare the results of a baseline simulation with the results of a new different simulation.
 
     This uses a 8th-order Lagrange interpolator to compute the difference in state of the two simulations at specified epochs.
@@ -336,7 +336,7 @@ def pareto_optimums(points: list | np.ndarray, operator: Union[None, list[Callab
 #     return state_history_book
 
 
-def vector2matrix(flat_matrix: np.ndarray):
+def vector2matrix(flat_matrix: np.ndarray) -> np.ndarray:
     """Convert a flattened matrix into a matrix.
 
     Following Tudat standards, a rotation matrix is returned as a nine-entry vector in the dependent variable output,

--- a/src/tudatpy/util/_support.py
+++ b/src/tudatpy/util/_support.py
@@ -67,7 +67,7 @@ def result2array(result: dict[float, np.ndarray]):
 def compare_results(
     baseline_results: dict[float, np.ndarray],
     new_results: dict[float, np.ndarray],
-    difference_epochs: list[float],
+    difference_epochs: list[float] | np.ndarray,
 ):
     """Compare the results of a baseline simulation with the results of a new different simulation.
 
@@ -195,7 +195,7 @@ class redirect_std:
             os.close(link)
 
 
-def pareto_optimums(_points: list, operator: Union[None, list[Callable]] = None):
+def pareto_optimums(points: list | np.ndarray, operator: Union[None, list[Callable]] = None):
     """Compute Pareto optimums from a set of points.
 
     These points are all individually optimums, meaning that to be better in one dimension, they have to be worse in another one.
@@ -209,7 +209,7 @@ def pareto_optimums(_points: list, operator: Union[None, list[Callable]] = None)
     points : list or numpy.ndarray
         Multi-dimensional list that contains the set of points to compute Pareto optimums from.
         If the points are spread in 3D, this list should have 3 columns, and as many rows as there are points.
-    operator : None or list[min or max], optional, default=None
+    operator : list[Callable] | None, optional, default=None
         If None, it will be considered that the optimums are the minimums of each axis (dimension).
         Otherwise, a list of `min` or `max` functions can be passed in this input, to specify whether a point along a given dimension should be minimum or maximum to be considered optimum.
 
@@ -247,7 +247,7 @@ def pareto_optimums(_points: list, operator: Union[None, list[Callable]] = None)
         # Show the plot
         plt.show()
     """
-    points = np.asarray(_points)
+    points = np.asarray(points)
     if operator is None:
         sign = np.ones(points.shape[1])
     else:

--- a/tests/test_tudatpy/test_api_docs.py
+++ b/tests/test_tudatpy/test_api_docs.py
@@ -1,0 +1,71 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def api_docs_conf():
+    conf_path = Path(__file__).resolve().parents[2] / "docs" / "tudatpy" / "source" / "conf.py"
+    spec = importlib.util.spec_from_file_location("tudatpy_api_docs_conf", conf_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    ("annotation", "expected"),
+    [
+        ("typing.SupportsInt | typing.SupportsIndex", "int"),
+        ("int | SupportsIndex", "int"),
+        ("typing.SupportsFloat | typing.SupportsIndex", "float"),
+        ("float | SupportsIndex", "float"),
+        (
+            "typing.SupportsComplex | typing.SupportsFloat | typing.SupportsIndex",
+            "complex",
+        ),
+        ("SupportsComplex | float | SupportsIndex", "complex"),
+        (
+            "collections.abc.Sequence[typing.SupportsFloat | typing.SupportsIndex]",
+            "list[float]",
+        ),
+        (
+            "collections.abc.Mapping[str, typing.SupportsInt | typing.SupportsIndex]",
+            "dict[str, int]",
+        ),
+        (
+            'typing.Annotated[numpy.typing.ArrayLike, numpy.float64, "[3, 1]"]',
+            "numpy.ndarray[numpy.float64[3, 1]]",
+        ),
+        (
+            "typing.Annotated[numpy.typing.ArrayLike, numpy.float64]",
+            "numpy.ndarray[numpy.float64]",
+        ),
+        (
+            "typing.Annotated[numpy.typing.NDArray[numpy.float64], '[m, n]']",
+            "numpy.ndarray[numpy.float64[m, n]]",
+        ),
+        (
+            "~tudatpy.kernel.dynamics.environment.SystemOfBodies",
+            "tudatpy.kernel.dynamics.environment.SystemOfBodies",
+        ),
+    ],
+)
+def test_simplify_type_annotations(api_docs_conf, annotation, expected):
+    assert api_docs_conf.simplify_type_annotations(annotation) == expected
+
+
+def test_overload_signatures_are_simplified(api_docs_conf):
+    lines = [
+        "Overloaded function.",
+        "",
+        "1. select(values: collections.abc.Sequence[typing.SupportsFloat | "
+        "typing.SupportsIndex]) -> typing.SupportsInt | typing.SupportsIndex",
+    ]
+
+    assert api_docs_conf._rewrite_overloaded_list_items(lines) == [
+        "Overloaded function.",
+        "",
+        "Overload 1:",
+        "``select(values: list[float]) -> int``",
+    ]

--- a/tests/test_tudatpy/test_api_docs.py
+++ b/tests/test_tudatpy/test_api_docs.py
@@ -69,3 +69,31 @@ def test_overload_signatures_are_simplified(api_docs_conf):
         "Overload 1:",
         "``select(values: list[float]) -> int``",
     ]
+
+
+def test_readonly_property_is_marked_once(api_docs_conf):
+    readonly_property = property(lambda instance: instance.value)
+    lines = ["Property description."]
+
+    api_docs_conf.mark_property_mutability(
+        None, "property", "Example.value", readonly_property, None, lines
+    )
+    api_docs_conf.mark_property_mutability(
+        None, "property", "Example.value", readonly_property, None, lines
+    )
+
+    assert lines == ["**read-only**", "", "Property description."]
+
+
+def test_writable_property_is_not_marked_readonly(api_docs_conf):
+    writable_property = property(
+        lambda instance: instance.value,
+        lambda instance, value: setattr(instance, "value", value),
+    )
+    lines = ["**read-only**", "", "Property description."]
+
+    api_docs_conf.mark_property_mutability(
+        None, "property", "Example.value", writable_property, None, lines
+    )
+
+    assert "**read-only**" not in lines

--- a/tests/test_tudatpy/test_api_docs.py
+++ b/tests/test_tudatpy/test_api_docs.py
@@ -46,6 +46,10 @@ def api_docs_conf():
             "numpy.ndarray[numpy.float64[m, n]]",
         ),
         (
+            "settings: tudatpy.Settings = " "<tudatpy.Settings object at 0x7f42A01b9cD0>",
+            "settings: tudatpy.Settings = ...",
+        ),
+        (
             "~tudatpy.kernel.dynamics.environment.SystemOfBodies",
             "tudatpy.kernel.dynamics.environment.SystemOfBodies",
         ),


### PR DESCRIPTION
  ## Summary

  - Simplify converter-oriented annotations in generated API signatures.
  - Align parameter and return documentation with the exposed API.
  - Derive read-only property markers from runtime mutability.
  - Prevent object memory addresses from appearing in generated signatures.

  ## Validation

  - Rebuilt the kernel and generated the complete documentation from it.
  - Scanned 2,266 signatures, 514 properties, and 98 HTML files.
  - Found zero type mismatches, verbose annotation remnants, or memory addresses.
  - API documentation tests: 16 passed.