### PR TITLE
Normalize linear constraints in estimation

### DIFF
--- a/include/tudat/simulation/estimation_setup/orbitDeterminationManagerCovarianceImplementation.h
+++ b/include/tudat/simulation/estimation_setup/orbitDeterminationManagerCovarianceImplementation.h
@@ -17,6 +17,7 @@
 #include "tudat/math/basic/leastSquaresEstimation.h"
 #include "tudat/simulation/estimation_setup/interArcContinuityConstraint.h"
 #include "tudat/simulation/estimation_setup/orbitDeterminationManager.h"
+#include "tudat/simulation/estimation_setup/orbitDeterminationManagerHelpers.h"
 
 namespace tudat
 {
@@ -78,6 +79,7 @@ OrbitDeterminationManager< ObservationScalarType, TimeType, Dummy >::computeCova
     Eigen::MatrixXd constraintStateMultiplier;
     Eigen::VectorXd constraintRightHandSide;
     parametersToEstimate_->getConstraints( constraintStateMultiplier, constraintRightHandSide );
+    normalizeLinearConstraints( constraintStateMultiplier, constraintRightHandSide, normalizationTerms );
 
     // Compute inverse of updated covariance
     Eigen::MatrixXd inverseNormalizedCovariance = linear_algebra::calculateInverseOfUpdatedCovarianceMatrix(

--- a/include/tudat/simulation/estimation_setup/orbitDeterminationManagerEstimationImplementation.h
+++ b/include/tudat/simulation/estimation_setup/orbitDeterminationManagerEstimationImplementation.h
@@ -183,6 +183,7 @@ OrbitDeterminationManager< ObservationScalarType, TimeType, Dummy >::estimatePar
             Eigen::MatrixXd constraintStateMultiplier;
             Eigen::VectorXd constraintRightHandSide;
             parametersToEstimate_->getConstraints( constraintStateMultiplier, constraintRightHandSide );
+            normalizeLinearConstraints( constraintStateMultiplier, constraintRightHandSide, normalizationTerms );
 
             double conditionNumberCheck = estimationInput->getLimitConditionNumberForWarning( );
             if( numberOfIterations > 0 && estimationInput->conditionNumberWarningEachIteration_ == false )

--- a/include/tudat/simulation/estimation_setup/orbitDeterminationManagerHelpers.h
+++ b/include/tudat/simulation/estimation_setup/orbitDeterminationManagerHelpers.h
@@ -13,6 +13,8 @@
 
 #include <cmath>
 #include <iostream>
+#include <stdexcept>
+#include <string>
 
 #include "tudat/basics/timeType.h"
 #include "tudat/math/basic/mathematicalConstants.h"
@@ -25,6 +27,54 @@ namespace tudat
 
 namespace simulation_setup
 {
+
+//! Express physical-space linear constraints in normalized correction coordinates.
+/*!
+ * If design-matrix column j is divided by normalizationValues(j), the normalized least-squares variable is the physical
+ * correction multiplied by normalizationValues(j). Each constraint column is therefore divided by the same value. Each
+ * complete constraint equation is subsequently scaled to have a maximum absolute multiplier of one; the right-hand side is
+ * scaled with it, so the physical constraint is unchanged.
+ * \param constraintMatrix Multiplier in the physical-space linear constraint equation, modified in place.
+ * \param constraintRightHandSide Right-hand side of the physical-space constraint equation, modified in place.
+ * \param normalizationValues Design-matrix column normalization values.
+ */
+inline void normalizeLinearConstraints( Eigen::MatrixXd& constraintMatrix,
+                                        Eigen::VectorXd& constraintRightHandSide,
+                                        const Eigen::VectorXd& normalizationValues )
+{
+    if( constraintMatrix.cols( ) != normalizationValues.size( ) )
+    {
+        throw std::runtime_error( "Error when normalizing estimation constraints, constraint matrix has " +
+                                  std::to_string( constraintMatrix.cols( ) ) + " columns but " +
+                                  std::to_string( normalizationValues.size( ) ) + " normalization values were provided." );
+    }
+    if( constraintMatrix.rows( ) != constraintRightHandSide.size( ) )
+    {
+        throw std::runtime_error( "Error when normalizing estimation constraints, constraint matrix has " +
+                                  std::to_string( constraintMatrix.rows( ) ) + " rows but the right-hand side has size " +
+                                  std::to_string( constraintRightHandSide.size( ) ) + "." );
+    }
+
+    for( int i = 0; i < constraintMatrix.cols( ); i++ )
+    {
+        if( !std::isfinite( normalizationValues( i ) ) || normalizationValues( i ) == 0.0 )
+        {
+            throw std::runtime_error( "Error when normalizing estimation constraints, normalization value at index " + std::to_string( i ) +
+                                      " is zero or non-finite." );
+        }
+        constraintMatrix.col( i ) /= normalizationValues( i );
+    }
+
+    for( int i = 0; i < constraintMatrix.rows( ); i++ )
+    {
+        const double constraintScale = constraintMatrix.row( i ).cwiseAbs( ).maxCoeff( );
+        if( constraintScale > 0.0 )
+        {
+            constraintMatrix.row( i ) /= constraintScale;
+            constraintRightHandSide( i ) /= constraintScale;
+        }
+    }
+}
 
 template< typename ObservationScalarType >
 void checkObservationResidualDiscontinuities( Eigen::Matrix< ObservationScalarType, Eigen::Dynamic, 1 >& residuals,

--- a/tests/test_tudat/src/astro/orbit_determination/unitTestEstimationInput.cpp
+++ b/tests/test_tudat/src/astro/orbit_determination/unitTestEstimationInput.cpp
@@ -8,12 +8,11 @@
  *    http://tudat.tudelft.nl/LICENSE.
  */
 
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MAIN
 
-#include <limits>
+#include <boost/test/included/unit_test.hpp>
 
-#include <boost/test/unit_test.hpp>
+#include <limits>
 
 #include "tudat/math/basic/leastSquaresEstimation.h"
 #include "tudat/simulation/estimation_setup/executePlanetaryParameterEstimationTestCase.h"
@@ -195,7 +194,7 @@ BOOST_AUTO_TEST_CASE( test_LinearConstraintInEarthSatelliteEstimation )
         const double constraintResidual = stateCorrection( 0 ) + 1000.0 * stateCorrection( 4 );
         const double constraintScale =
                 std::max( 1.0, std::max( std::fabs( stateCorrection( 0 ) ), std::fabs( 1000.0 * stateCorrection( 4 ) ) ) );
-        BOOST_CHECK_SMALL( constraintResidual, 1.0E-10 * constraintScale );
+        BOOST_CHECK_SMALL( constraintResidual, 1.0E-9 * constraintScale );
     }
 
     const Eigen::Vector6d totalStateCorrection = initialStateHistory.col( initialStateHistory.cols( ) - 1 ) - initialStateHistory.col( 0 );

--- a/tests/test_tudat/src/astro/orbit_determination/unitTestEstimationInput.cpp
+++ b/tests/test_tudat/src/astro/orbit_determination/unitTestEstimationInput.cpp
@@ -11,15 +11,196 @@
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MAIN
 
+#include <limits>
+
 #include <boost/test/unit_test.hpp>
 
+#include "tudat/math/basic/leastSquaresEstimation.h"
 #include "tudat/simulation/estimation_setup/executePlanetaryParameterEstimationTestCase.h"
+#include "tudat/simulation/estimation_setup/orbitDeterminationManagerHelpers.h"
 
 namespace tudat
 {
 namespace unit_tests
 {
 BOOST_AUTO_TEST_SUITE( test_estimation_input_output )
+
+//! Initial translational state with a user-defined hard linear constraint on each estimated correction.
+class LinearlyConstrainedInitialTranslationalStateParameter : public estimatable_parameters::InitialTranslationalStateParameter< double >
+{
+public:
+    LinearlyConstrainedInitialTranslationalStateParameter( const std::string& associatedBody,
+                                                           const Eigen::Vector6d& initialState,
+                                                           const std::string& centralBody ):
+        InitialTranslationalStateParameter< double >( associatedBody, initialState, centralBody )
+    {}
+
+    int getConstraintSize( ) override
+    {
+        return 1;
+    }
+
+    Eigen::MatrixXd getConstraintStateMultipler( ) override
+    {
+        Eigen::MatrixXd constraintMultiplier = Eigen::MatrixXd::Zero( 1, 6 );
+        constraintMultiplier( 0, 0 ) = 1.0;
+        constraintMultiplier( 0, 4 ) = 1000.0;
+        return constraintMultiplier;
+    }
+
+    Eigen::VectorXd getConstraintRightHandSide( ) override
+    {
+        return Eigen::VectorXd::Zero( 1 );
+    }
+};
+
+//! Test that a physical-space constraint remains valid when design-matrix columns have mixed scales.
+BOOST_AUTO_TEST_CASE( test_NormalizedLinearConstraints )
+{
+    Eigen::MatrixXd normalizedDesignMatrix( 3, 2 );
+    normalizedDesignMatrix << 1.0, 0.0, 0.0, 1.0, 1.0, 1.0;
+    const Eigen::VectorXd designMatrixNormalization = ( Eigen::Vector2d( ) << 1.0E6, 1.0E-3 ).finished( );
+    const Eigen::VectorXd residuals = ( Eigen::Vector3d( ) << 0.25, -0.5, 0.1 ).finished( );
+    const Eigen::VectorXd weights = Eigen::Vector3d::Ones( );
+
+    Eigen::MatrixXd physicalConstraint( 1, 2 );
+    physicalConstraint << 1.0, 1.0;
+    const Eigen::VectorXd physicalConstraintRightHandSide = Eigen::VectorXd::Constant( 1, 1.0 );
+
+    Eigen::MatrixXd normalizedConstraint = physicalConstraint;
+    Eigen::VectorXd normalizedConstraintRightHandSide = physicalConstraintRightHandSide;
+    simulation_setup::normalizeLinearConstraints( normalizedConstraint, normalizedConstraintRightHandSide, designMatrixNormalization );
+
+    const auto leastSquaresOutput =
+            linear_algebra::performLeastSquaresAdjustmentFromDesignMatrix( normalizedDesignMatrix,
+                                                                           residuals,
+                                                                           weights,
+                                                                           Eigen::Matrix2d::Zero( ),
+                                                                           std::numeric_limits< double >::quiet_NaN( ),
+                                                                           normalizedConstraint,
+                                                                           normalizedConstraintRightHandSide );
+    const Eigen::Vector2d physicalCorrection = leastSquaresOutput.first.head( 2 ).cwiseQuotient( designMatrixNormalization );
+
+    BOOST_CHECK_SMALL( std::fabs( ( physicalConstraint * physicalCorrection - physicalConstraintRightHandSide )( 0 ) ), 1.0E-12 );
+    BOOST_CHECK_CLOSE_FRACTION( normalizedConstraint.cwiseAbs( ).maxCoeff( ), 1.0, 1.0E-15 );
+}
+
+//! Test a constrained least-squares orbit estimation with position and velocity corrections at different scales.
+BOOST_AUTO_TEST_CASE( test_LinearConstraintInEarthSatelliteEstimation )
+{
+    using namespace observation_models;
+    using namespace orbital_element_conversions;
+
+    spice_interface::loadStandardSpiceKernels( );
+
+    const double initialTime = 1.0E7;
+    const double finalTime = initialTime + 3.0 * 3600.0;
+
+    BodyListSettings bodySettings = getDefaultBodySettings( { "Earth", "Sun", "Moon" }, "Earth", "ECLIPJ2000" );
+    SystemOfBodies bodies = createSystemOfBodies( bodySettings );
+    bodies.createEmptyBody( "Satellite" );
+    bodies.at( "Satellite" )->setConstantBodyMass( 400.0 );
+
+    // Use a modestly perturbed Earth-orbit model: Earth degree/order 2 gravity and point-mass Sun/Moon gravity.
+    SelectedAccelerationMap accelerationSettings;
+    accelerationSettings[ "Satellite" ][ "Earth" ].push_back( std::make_shared< SphericalHarmonicAccelerationSettings >( 2, 2 ) );
+    accelerationSettings[ "Satellite" ][ "Sun" ].push_back( std::make_shared< AccelerationSettings >( point_mass_gravity ) );
+    accelerationSettings[ "Satellite" ][ "Moon" ].push_back( std::make_shared< AccelerationSettings >( point_mass_gravity ) );
+
+    const std::vector< std::string > bodiesToPropagate = { "Satellite" };
+    const std::vector< std::string > centralBodies = { "Earth" };
+    const AccelerationMap accelerationModels =
+            createAccelerationModelsMap( bodies, accelerationSettings, bodiesToPropagate, centralBodies );
+
+    Eigen::Vector6d initialKeplerianState;
+    initialKeplerianState << 7200.0E3, 0.01, unit_conversions::convertDegreesToRadians( 55.0 ),
+            unit_conversions::convertDegreesToRadians( 40.0 ), unit_conversions::convertDegreesToRadians( 20.0 ),
+            unit_conversions::convertDegreesToRadians( 10.0 );
+    const Eigen::Vector6d trueInitialState = convertKeplerianToCartesianElements(
+            initialKeplerianState, bodies.at( "Earth" )->getGravityFieldModel( )->getGravitationalParameter( ) );
+
+    const std::shared_ptr< IntegratorSettings< double > > integratorSettings =
+            rungeKuttaFixedStepSettings( 60.0, CoefficientSets::rungeKuttaFehlberg78 );
+    const std::shared_ptr< TranslationalStatePropagatorSettings< double, double > > propagatorSettings =
+            std::make_shared< TranslationalStatePropagatorSettings< double, double > >( centralBodies,
+                                                                                        accelerationModels,
+                                                                                        bodiesToPropagate,
+                                                                                        trueInitialState,
+                                                                                        initialTime,
+                                                                                        integratorSettings,
+                                                                                        propagationTimeTerminationSettings( finalTime ),
+                                                                                        cowell );
+
+    const std::shared_ptr< LinearlyConstrainedInitialTranslationalStateParameter > constrainedInitialState =
+            std::make_shared< LinearlyConstrainedInitialTranslationalStateParameter >( "Satellite", trueInitialState, "Earth" );
+    constrainedInitialState->addStateClosureFunctions(
+            [ propagatorSettings ]( ) { return propagatorSettings->getStateOfBody( 0 ); },
+            [ propagatorSettings ]( const Eigen::VectorXd& state ) { propagatorSettings->setStateOfBody( 0, state ); } );
+
+    const std::vector< std::shared_ptr< estimatable_parameters::EstimatableParameter< double > > > scalarParameters;
+    const std::vector< std::shared_ptr< estimatable_parameters::EstimatableParameter< Eigen::VectorXd > > > vectorParameters;
+    const std::vector< std::shared_ptr< estimatable_parameters::EstimatableParameter< Eigen::VectorXd > > > initialStateParameters = {
+        constrainedInitialState
+    };
+    const std::shared_ptr< estimatable_parameters::EstimatableParameterSet< double > > parametersToEstimate =
+            std::make_shared< estimatable_parameters::EstimatableParameterSet< double > >(
+                    scalarParameters, vectorParameters, initialStateParameters );
+
+    LinkEnds linkEnds;
+    linkEnds[ observed_body ] = LinkEndId( "Satellite", "" );
+    const std::vector< std::shared_ptr< ObservationModelSettings > > observationModelSettings = {
+        std::make_shared< ObservationModelSettings >( position_observable, linkEnds )
+    };
+
+    OrbitDeterminationManager< double, double > orbitDeterminationManager(
+            bodies, parametersToEstimate, observationModelSettings, propagatorSettings );
+
+    std::vector< double > observationTimes;
+    for( double observationTime = initialTime; observationTime <= finalTime; observationTime += 300.0 )
+    {
+        observationTimes.push_back( observationTime );
+    }
+    const std::vector< std::shared_ptr< ObservationSimulationSettings< double > > > observationSimulationSettings = {
+        std::make_shared< TabulatedObservationSimulationSettings< double > >(
+                position_observable, linkEnds, observationTimes, observed_body )
+    };
+    const std::shared_ptr< ObservationCollection< double, double > > simulatedObservations = simulateObservations< double, double >(
+            observationSimulationSettings, orbitDeterminationManager.getObservationSimulators( ), bodies );
+
+    Eigen::Vector6d initialStatePerturbation;
+    initialStatePerturbation << 1.0E3, 1.0E3, 1.0E3, 1.0, 1.0, 1.0;
+    const Eigen::Vector6d perturbedInitialState = trueInitialState + initialStatePerturbation;
+    orbitDeterminationManager.resetParameterEstimate( perturbedInitialState, true );
+
+    const std::shared_ptr< EstimationInput< double, double > > estimationInput = std::make_shared< EstimationInput< double, double > >(
+            simulatedObservations, Eigen::MatrixXd::Zero( 0, 0 ), estimationConvergenceChecker( 4, 0.0, 0.0, 100 ) );
+    estimationInput->defineEstimationSettings( true, true, true, true, true );
+
+    const std::shared_ptr< EstimationOutput< double, double > > estimationOutput =
+            orbitDeterminationManager.estimateParameters( estimationInput );
+    BOOST_REQUIRE( !estimationOutput->exceptionDuringInversion_ );
+    BOOST_REQUIRE( !estimationOutput->exceptionDuringPropagation_ );
+
+    const Eigen::MatrixXd initialStateHistory = estimationOutput->getParameterHistoryMatrix( );
+    BOOST_REQUIRE_EQUAL( initialStateHistory.rows( ), 6 );
+    BOOST_REQUIRE_GE( initialStateHistory.cols( ), 2 );
+    for( int stateIndex = 0; stateIndex < 6; stateIndex++ )
+    {
+        BOOST_CHECK_SMALL( initialStateHistory( stateIndex, 0 ) - perturbedInitialState( stateIndex ), 1.0E-12 );
+    }
+
+    for( int iteration = 1; iteration < initialStateHistory.cols( ); iteration++ )
+    {
+        const Eigen::Vector6d stateCorrection = initialStateHistory.col( iteration ) - initialStateHistory.col( iteration - 1 );
+        const double constraintResidual = stateCorrection( 0 ) + 1000.0 * stateCorrection( 4 );
+        const double constraintScale =
+                std::max( 1.0, std::max( std::fabs( stateCorrection( 0 ) ), std::fabs( 1000.0 * stateCorrection( 4 ) ) ) );
+        BOOST_CHECK_SMALL( constraintResidual, 1.0E-10 * constraintScale );
+    }
+
+    const Eigen::Vector6d totalStateCorrection = initialStateHistory.col( initialStateHistory.cols( ) - 1 ) - initialStateHistory.col( 0 );
+    BOOST_CHECK_SMALL( totalStateCorrection( 0 ) + 1000.0 * totalStateCorrection( 4 ), 1.0E-7 );
+}
 
 //! This test checks whether the input/output of the estimation (weights, a priori covariance, unscaled covariance) are
 //! correctly handed


### PR DESCRIPTION
  Fixes #958.

  Normalize linear constraints consistently with the design matrix during estimation and covariance analysis.

  Adds regression tests, including an Earth-orbit estimation verifying that every correction satisfies (arbitrarily chosen):

  `Δr_x + 1000 Δv_y = 0`
