### PR TITLE
Improved GS Meteo interpolator selection

### DIFF
--- a/src/tudat/astro/ground_stations/meteorologicalConditions.cpp
+++ b/src/tudat/astro/ground_stations/meteorologicalConditions.cpp
@@ -77,7 +77,21 @@ void PiecewiseInterpolatedMeteoData::updateData( const double currentUtc )
     if( !( currentUtc == currentUtc_ ) )
     {
         currentUtc_ = currentUtc;
-        currentInterpolator_ = lookUpScheme_->findNearestLowerNeighbour( currentUtc_ );
+        int nearestIndex = lookUpScheme_->findNearestLowerNeighbour( currentUtc_ );
+
+        // If currentUtc falls in a gap between two segment's data, extrapolate from the segment
+        // that is closer in time, rather than always extrapolating forward from the lower segment.
+        if( currentUtc_ > endTimes_.at( nearestIndex ) && static_cast< unsigned int >( nearestIndex ) + 1 < startTimes_.size( ) )
+        {
+            double distanceToLowerSegment = currentUtc_ - endTimes_.at( nearestIndex );
+            double distanceToUpperSegment = startTimes_.at( nearestIndex + 1 ) - currentUtc_;
+            if( distanceToUpperSegment < distanceToLowerSegment )
+            {
+                nearestIndex += 1;
+            }
+        }
+
+        currentInterpolator_ = nearestIndex;
         try
         {
             currentData_ = meteoDataInterpolators_.at( currentInterpolator_ )->interpolate( currentUtc_ );

--- a/src/tudatpy/add_data_to_kernel.cpp
+++ b/src/tudatpy/add_data_to_kernel.cpp
@@ -59,6 +59,8 @@ void add_data_to_kernel( py::module_& m )
            py::arg( "bodies" ),
            py::arg( "weather_file_names" ),
            py::arg( "ground_station_name" ),
-           py::arg( "interpolator_settings" ) = tudat::interpolators::cubicSplineInterpolation( ),
+           py::arg( "interpolator_settings" ) = tudat::interpolators::cubicSplineInterpolation(
+                   tudat::interpolators::AvailableLookupScheme::huntingAlgorithm,
+                   tudat::interpolators::BoundaryInterpolationType::use_boundary_value_with_warning ),
            py::arg( "body_with_ground_stations_name" ) = "Earth" );
 }

--- a/src/tudatpy/dynamics/environment_setup/ground_station/expose_ground_station.cpp
+++ b/src/tudatpy/dynamics/environment_setup/ground_station/expose_ground_station.cpp
@@ -265,7 +265,9 @@ reference_epoch:
            py::arg( "ground_station_settings_list" ),
            py::arg( "weather_file_names" ),
            py::arg( "ground_station_name" ),
-           py::arg( "interpolator_settings" ) = tudat::interpolators::cubicSplineInterpolation( ),
+           py::arg( "interpolator_settings" ) = tudat::interpolators::cubicSplineInterpolation(
+                   tudat::interpolators::AvailableLookupScheme::huntingAlgorithm,
+                   tudat::interpolators::BoundaryInterpolationType::use_boundary_value_with_warning ),
            R"doc(
 
  Add ESTRACK weather data settings to a ground station in a list of ground station settings.

--- a/tests/test_tudat/src/io/unitTestReadTabulatedWeatherData.cpp
+++ b/tests/test_tudat/src/io/unitTestReadTabulatedWeatherData.cpp
@@ -8,18 +8,16 @@
  *    http://tudat.tudelft.nl/LICENSE.
  */
 
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MAIN
 
-#include "tudat/basics/testMacros.h"
+#include <boost/test/included/unit_test.hpp>
+
 #include "tudat/simulation/environment_setup/createBodiesFactory.h"
 #include "tudat/simulation/environment_setup/defaultBodies.h"
 
 #include "tudat/io/readTabulatedWeatherData.h"
 
 #include "tudat/simulation/estimation_setup/createLightTimeCorrection.h"
-
-#include "tudat/io/readIonexFile.h"
 
 namespace tudat
 {
@@ -490,6 +488,80 @@ BOOST_AUTO_TEST_CASE( setEstrackWeatherDataInGroundStationSettings )
                                 testHumidity * ground_stations::computeSaturationWaterVaporPressure( testTemperature ),
                                 tolerance );
     BOOST_CHECK_CLOSE_FRACTION( gs->getRelativeHumidityFunction( )( testEpoch ), testHumidity, tolerance );
+}
+
+BOOST_AUTO_TEST_CASE( testEstrackWeatherDataGapExtrapolation )
+{
+    // When the query epoch falls in a gap between two ESTRACK meteo file segment,
+    // PiecewiseInterpolatedMeteoData should extrapolate from whichever segment is closer
+    // in time, not always from the earlier (lower) one.
+    double tolerance = 1e-10;
+
+    spice_interface::loadStandardSpiceKernels( );
+
+    std::vector< std::string > bodiesToCreate = { "Earth" };
+    simulation_setup::BodyListSettings bodySettings = simulation_setup::getDefaultBodySettings( bodiesToCreate );
+    bodySettings.at( "Earth" )->groundStationSettings = simulation_setup::getRadioTelescopeStationSettings( );
+    simulation_setup::SystemOfBodies bodies = createSystemOfBodies( bodySettings );
+
+    // Load meteo files with a gap in between, so that the meteo data object will have two segments.
+    std::vector< std::string > estrackDataFiles = { tudat::paths::getTudatTestDataPath( ) + "M32ICL2L1B_MET_133621727_00.TAB",
+                                                    tudat::paths::getTudatTestDataPath( ) + "M32ICL2L1B_MET_133621727_04.TAB" };
+    setEstrackWeatherDataInGroundStation( bodies, estrackDataFiles, "NWNORCIA", interpolators::linearInterpolation( ) );
+
+    std::shared_ptr< ground_stations::GroundStation > gs = bodies.getBody( "Earth" )->getGroundStation( "NWNORCIA" );
+    std::shared_ptr< ground_stations::PiecewiseInterpolatedMeteoData > meteoDataObject =
+            std::dynamic_pointer_cast< ground_stations::PiecewiseInterpolatedMeteoData >( gs->getMeteoData( ) );
+
+    BOOST_CHECK_EQUAL( meteoDataObject->getMeteoDataInterpolators( ).size( ), 2 );
+
+    double lowerSegmentEnd = meteoDataObject->getEndTimes( ).at( 0 );
+    double upperSegmentStart = meteoDataObject->getStartTimes( ).at( 1 );
+    BOOST_CHECK( upperSegmentStart > lowerSegmentEnd );
+
+    int temperatureIndex = 2;
+
+    // Query point closer to the start of the upper segment than to the end of the lower segment:
+    // extrapolation must come from the upper segment.
+    {
+        double testEpoch = upperSegmentStart - 0.1 * ( upperSegmentStart - lowerSegmentEnd );
+
+        double expectedTemperature = meteoDataObject->getMeteoDataInterpolators( ).at( 1 )->interpolate( testEpoch )( temperatureIndex );
+        double wrongTemperature = meteoDataObject->getMeteoDataInterpolators( ).at( 0 )->interpolate( testEpoch )( temperatureIndex );
+
+        // Check that the two segments actually extrapolate to different values
+        BOOST_CHECK( std::fabs( expectedTemperature - wrongTemperature ) > 1.0E-6 );
+
+        BOOST_CHECK_CLOSE_FRACTION( gs->getTemperatureFunction( )( testEpoch ), expectedTemperature, tolerance );
+    }
+
+    // Query point closer to the end of the lower segment than to the start of the upper segment:
+    // extrapolation must still come from the lower segment.
+    {
+        double testEpoch = lowerSegmentEnd + 0.1 * ( upperSegmentStart - lowerSegmentEnd );
+
+        double expectedTemperature = meteoDataObject->getMeteoDataInterpolators( ).at( 0 )->interpolate( testEpoch )( temperatureIndex );
+        double wrongTemperature = meteoDataObject->getMeteoDataInterpolators( ).at( 1 )->interpolate( testEpoch )( temperatureIndex );
+
+        // Check that the two segments actually extrapolate to different values
+        BOOST_CHECK( std::fabs( expectedTemperature - wrongTemperature ) > 1.0E-6 );
+
+        BOOST_CHECK_CLOSE_FRACTION( gs->getTemperatureFunction( )( testEpoch ), expectedTemperature, tolerance );
+    }
+
+    // Query point beyond the end of the upper segment, should extrapolate from the upper segment.
+    {
+        double upperSegmentEnd = meteoDataObject->getEndTimes( ).at( 1 );
+        double testEpoch = upperSegmentEnd + 0.1 * ( upperSegmentStart - lowerSegmentEnd );
+
+        double expectedTemperature = meteoDataObject->getMeteoDataInterpolators( ).at( 1 )->interpolate( testEpoch )( temperatureIndex );
+        double wrongTemperature = meteoDataObject->getMeteoDataInterpolators( ).at( 0 )->interpolate( testEpoch )( temperatureIndex );
+
+        // Check that the two segments actually extrapolate to different values
+        BOOST_CHECK( std::fabs( expectedTemperature - wrongTemperature ) > 1.0E-6 );
+
+        BOOST_CHECK_CLOSE_FRACTION( gs->getTemperatureFunction( )( testEpoch ), expectedTemperature, tolerance );
+    }
 }
 
 BOOST_AUTO_TEST_CASE( testReadIonexFile )


### PR DESCRIPTION
This PR modifies the behavior of the `PiecewiseInterpolatedMeteoData` class such that, when extrapolating data to an epoch that is not covered by the meteo data, it uses the interpolator corresponding to the meteo data that is closest to the epoch at which the meteo data should be retrieved.
Additionally, the default interpolation settings of the estrack weather data are modified to use the boundary value instead of extrapolating. Since the meteorological conditions should (typically) not change a lot over short time frames, this should be more reliable than extrapolating from a cubic spline/linearly using meteo data sampled every 60s.

@DominicDirkx I opened the PR on top of the data-refactor branch since I've been using it with the new tracking data interface, I figured that would also avoid more merge conflicts than we will already have