### PR TITLE
Disable kernel PCH for clang-cl on Windows

### DIFF
--- a/src/tudatpy/CMakeLists.txt
+++ b/src/tudatpy/CMakeLists.txt
@@ -65,21 +65,29 @@ target_link_libraries(kernel PRIVATE
 # These headers are included by virtually every binding .cpp file.
 # PCH eliminates redundant parsing across all 86+ translation units.
 if (TUDAT_BUILD_WITH_PCH)
-    target_precompile_headers(kernel PRIVATE
-        <pybind11/pybind11.h>
-        <pybind11/stl.h>
-        <pybind11/eigen.h>
-        <pybind11/functional.h>
-        <pybind11/numpy.h>
-        <pybind11/chrono.h>
-        <Eigen/Core>
-        <Eigen/Geometry>
-        <memory>
-        <vector>
-        <string>
-        <map>
-        <functional>
-    )
+    # clang-cl can emit invalid exception copy metadata for types loaded from a
+    # PCH, causing pybind11 exception translation to corrupt the Windows heap.
+    # See https://github.com/llvm/llvm-project/issues/118276.
+    if (WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
+            AND CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")
+        message(STATUS "Disabling TudatPy kernel PCH for clang-cl on Windows")
+    else ()
+        target_precompile_headers(kernel PRIVATE
+            <pybind11/pybind11.h>
+            <pybind11/stl.h>
+            <pybind11/eigen.h>
+            <pybind11/functional.h>
+            <pybind11/numpy.h>
+            <pybind11/chrono.h>
+            <Eigen/Core>
+            <Eigen/Geometry>
+            <memory>
+            <vector>
+            <string>
+            <map>
+            <functional>
+        )
+    endif ()
 endif ()
 
 # Disable unity build for binding target (each file exposes unique symbols)

--- a/src/tudatpy/estimation/observable_models/observables_simulation/expose_observables_simulation.cpp
+++ b/src/tudatpy/estimation/observable_models/observables_simulation/expose_observables_simulation.cpp
@@ -11,6 +11,7 @@
 #define PYBIND11_DETAILED_ERROR_MESSAGES
 #endif
 #include "expose_observables_simulation.h"
+#include <pybind11/eigen.h>
 #include <pybind11/functional.h>
 #include "scalarTypes.h"
 #include "tudat/astro/observation_models/observationManager.h"


### PR DESCRIPTION
Disables PCH for the TudatPy kernel only when compiling with clang-cl on Windows, avoiding a [known LLVM clang-cl/MSVC-ABI PCH bug](https://github.com/llvm/llvm-project/issues/118276) involving exception-copy metadata that caused `0xc0000374` heap corruption.

It also explicitly includes the pybind11 Eigen caster required by the no-PCH build. PCH remains enabled on other toolchains, and compiler selection is unchanged.

Two Windows Azure builds succeeded, including all 56 time-conversion tests and both leap-second exception cases.