### PR TITLE
Run CI for data-refactor pull requests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches: [ "master", "develop"]
   pull_request:
-    branches: [ "master", "develop"]
+    branches: [ "master", "develop", "feature/data-refactor"]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Add `feature/data-refactor` to the build-and-test workflow's pull-request target filter. This must also exist on the default branch so GitHub registers the workflow for those PR events.