### PR TITLE
Use initial parameter value for a priori constraint

### DIFF
--- a/include/tudat/astro/orbit_determination/podInputOutputTypes.h
+++ b/include/tudat/astro/orbit_determination/podInputOutputTypes.h
@@ -632,6 +632,8 @@ public:
      * \param observationCollection Total data structure of observations and associated times/link ends/type
      * \param inverseOfAprioriCovariance A priori covariance matrix (unnormalized) of estimated parameters. None (matrix of
      * size 0) by default
+     * \param applyAprioriParameterDeviation Whether to apply the a priori constraint to the total parameter deviation from
+     * the parameter vector at the start of the estimation. If false, the legacy correction-only regularization is used.
      */
     EstimationInput(
             const std::shared_ptr< observation_models::ObservationCollection< ObservationScalarType, TimeType > >& observationCollection,
@@ -639,11 +641,13 @@ public:
             const std::shared_ptr< EstimationConvergenceChecker > convergenceChecker = std::make_shared< EstimationConvergenceChecker >( ),
             const Eigen::MatrixXd considerCovariance = Eigen::MatrixXd::Zero( 0, 0 ),
             const Eigen::VectorXd considerParametersDeviations = Eigen::VectorXd::Zero( 0 ),
-            const bool applyFinalParameterCorrection = true ):
+            const bool applyFinalParameterCorrection = true,
+            const bool applyAprioriParameterDeviation = false ):
         CovarianceAnalysisInput< ObservationScalarType, TimeType >( observationCollection, inverseOfAprioriCovariance, considerCovariance ),
         saveResidualsAndParametersFromEachIteration_( true ), saveStateHistoryForEachIteration_( false ),
         convergenceChecker_( convergenceChecker ), considerParametersDeviations_( considerParametersDeviations ),
-        conditionNumberWarningEachIteration_( true ), applyFinalParameterCorrection_( applyFinalParameterCorrection )
+        conditionNumberWarningEachIteration_( true ), applyFinalParameterCorrection_( applyFinalParameterCorrection ),
+        applyAprioriParameterDeviation_( applyAprioriParameterDeviation )
 
     {
         if( this->areConsiderParametersIncluded( ) )
@@ -735,6 +739,12 @@ public:
         return saveStateHistoryForEachIteration_;
     }
 
+    //! Return whether the a priori constraint is applied to the total deviation from the initial parameter vector.
+    bool getApplyAprioriParameterDeviation( ) const
+    {
+        return applyAprioriParameterDeviation_;
+    }
+
     //! Boolean denoting whether the residuals and parameters from the each iteration are to be saved
     bool saveResidualsAndParametersFromEachIteration_;
 
@@ -749,6 +759,9 @@ public:
     bool conditionNumberWarningEachIteration_;
 
     bool applyFinalParameterCorrection_;
+
+    //! Whether to use the total parameter deviation for the iterative a priori constraint.
+    bool applyAprioriParameterDeviation_;
 };
 
 inline std::shared_ptr< EstimationConvergenceChecker > estimationConvergenceChecker( const unsigned int maximumNumberOfIterations = 5,

--- a/include/tudat/math/basic/leastSquaresEstimation.h
+++ b/include/tudat/math/basic/leastSquaresEstimation.h
@@ -124,6 +124,8 @@ Eigen::MatrixXd calculateConsiderParametersCovarianceContribution( const Eigen::
  * \param limitConditionNumberForWarning Maximum value of the condition number of the covariance matrix that is allowed
  * \param constraintMultiplier Multiplier for estimated parameter that defines linear constraint
  * \param constraintRightHandside Right-hand side estimation linear constraint
+ * \param aprioriParameterDeviation Deviation of the current parameter estimate from the a priori parameter vector, expressed in
+ * the same normalized coordinates as the parameter correction
  * \return Pair containing: (first: parameter adjustment, second: inverse covariance)
  */
 std::pair< Eigen::VectorXd, Eigen::MatrixXd > performLeastSquaresAdjustmentFromDesignMatrix(
@@ -137,7 +139,8 @@ std::pair< Eigen::VectorXd, Eigen::MatrixXd > performLeastSquaresAdjustmentFromD
         const Eigen::MatrixXd& designMatrixConsiderParameters = Eigen::MatrixXd( 0, 0 ),
         const Eigen::VectorXd& considerParametersDeviations = Eigen::VectorXd( 0 ),
         const Eigen::MatrixXd& additionalNormalMatrix = Eigen::MatrixXd( 0, 0 ),
-        const Eigen::VectorXd& additionalRightHandSide = Eigen::VectorXd( 0 ) );
+        const Eigen::VectorXd& additionalRightHandSide = Eigen::VectorXd( 0 ),
+        const Eigen::VectorXd& aprioriParameterDeviation = Eigen::VectorXd( 0 ) );
 
 //! Function to perform an iteration of least squares estimation from information matrix, weights and residuals
 /*!

--- a/include/tudat/simulation/estimation_setup/orbitDeterminationManagerEstimationImplementation.h
+++ b/include/tudat/simulation/estimation_setup/orbitDeterminationManagerEstimationImplementation.h
@@ -102,6 +102,7 @@ OrbitDeterminationManager< ObservationScalarType, TimeType, Dummy >::estimatePar
     // Set current parameter estimate as both previous and current estimate
     ParameterVectorType newParameterEstimate = currentParameterEstimate_;
     ParameterVectorType oldParameterEstimate = currentParameterEstimate_;
+    const ParameterVectorType aprioriParameterEstimate = currentParameterEstimate_;
 
     bool exceptionDuringPropagation = false, exceptionDuringInversion = false;
 
@@ -132,6 +133,8 @@ OrbitDeterminationManager< ObservationScalarType, TimeType, Dummy >::estimatePar
         Eigen::VectorXd normalizationTerms = normalizeDesignMatrix( designMatrixEstimatedParameters );
         Eigen::MatrixXd normalizedInverseAprioriCovarianceMatrix = normalizeAprioriCovariance(
                 estimationInput->getInverseOfAprioriCovariance( numberEstimatedParameters_ ), normalizationTerms );
+        const Eigen::VectorXd normalizedAprioriParameterDeviation =
+                ( oldParameterEstimate - aprioriParameterEstimate ).template cast< double >( ).cwiseProduct( normalizationTerms );
 
         InterArcConstraintContribution interArcContribution;
         if( !interArcConstraints.empty( ) )
@@ -191,18 +194,19 @@ OrbitDeterminationManager< ObservationScalarType, TimeType, Dummy >::estimatePar
                 conditionNumberCheck = TUDAT_NAN;
             }
             // Perform LSQ inversion
-            leastSquaresOutput = std::move(
-                    linear_algebra::performLeastSquaresAdjustmentFromDesignMatrix( designMatrixEstimatedParameters,
-                                                                                   residuals.template cast< double >( ),
-                                                                                   weightsMatrixDiagonals,
-                                                                                   normalizedInverseAprioriCovarianceMatrix,
-                                                                                   conditionNumberCheck,
-                                                                                   constraintStateMultiplier,
-                                                                                   constraintRightHandSide,
-                                                                                   designMatrixConsiderParameters,
-                                                                                   normalizedConsiderParametersDeviation,
-                                                                                   interArcContribution.additionalNormalMatrix,
-                                                                                   interArcContribution.additionalRightHandSide ) );
+            leastSquaresOutput =
+                    std::move( linear_algebra::performLeastSquaresAdjustmentFromDesignMatrix( designMatrixEstimatedParameters,
+                                                                                              residuals.template cast< double >( ),
+                                                                                              weightsMatrixDiagonals,
+                                                                                              normalizedInverseAprioriCovarianceMatrix,
+                                                                                              conditionNumberCheck,
+                                                                                              constraintStateMultiplier,
+                                                                                              constraintRightHandSide,
+                                                                                              designMatrixConsiderParameters,
+                                                                                              normalizedConsiderParametersDeviation,
+                                                                                              interArcContribution.additionalNormalMatrix,
+                                                                                              interArcContribution.additionalRightHandSide,
+                                                                                              normalizedAprioriParameterDeviation ) );
 
             if( constraintStateMultiplier.rows( ) > 0 )
             {
@@ -241,10 +245,11 @@ OrbitDeterminationManager< ObservationScalarType, TimeType, Dummy >::estimatePar
         // Calculate mean residual for current iteration.
         residualRms = linear_algebra::getVectorEntryRootMeanSquare( residuals.template cast< double >( ) );
         costFunction = linear_algebra::computeLeastSquaresCostFunction( weightsMatrixDiagonals, residuals.template cast< double >( ) );
-        // The cost driving best-iteration selection combines the observation cost with the inter-arc continuity-prior
-        // cost (zero when no continuity priors are attached). Residual RMS is unchanged so observation-only diagnostics
-        // remain meaningful.
-        costFunction += interArcContribution.totalConstraintCost;
+        const double aprioriCost = 0.5 *
+                normalizedAprioriParameterDeviation.dot( normalizedInverseAprioriCovarianceMatrix * normalizedAprioriParameterDeviation );
+        // The cost driving best-iteration selection combines the observation cost with all prior costs. Residual RMS is
+        // unchanged so observation-only diagnostics remain meaningful.
+        costFunction += aprioriCost + interArcContribution.totalConstraintCost;
         rmsResidualHistory.push_back( residualRms );
         costFunctionHistory.push_back( costFunction );
 

--- a/include/tudat/simulation/estimation_setup/orbitDeterminationManagerEstimationImplementation.h
+++ b/include/tudat/simulation/estimation_setup/orbitDeterminationManagerEstimationImplementation.h
@@ -131,10 +131,16 @@ OrbitDeterminationManager< ObservationScalarType, TimeType, Dummy >::estimatePar
 
         // Normalise estimated parameters partials and inverse apriori covariance
         Eigen::VectorXd normalizationTerms = normalizeDesignMatrix( designMatrixEstimatedParameters );
+        const Eigen::VectorXd estimatedParameterNormalizationTerms = normalizationTerms.segment( 0, numberEstimatedParameters_ );
         Eigen::MatrixXd normalizedInverseAprioriCovarianceMatrix = normalizeAprioriCovariance(
-                estimationInput->getInverseOfAprioriCovariance( numberEstimatedParameters_ ), normalizationTerms );
-        const Eigen::VectorXd normalizedAprioriParameterDeviation =
-                ( oldParameterEstimate - aprioriParameterEstimate ).template cast< double >( ).cwiseProduct( normalizationTerms );
+                estimationInput->getInverseOfAprioriCovariance( numberEstimatedParameters_ ), estimatedParameterNormalizationTerms );
+        Eigen::VectorXd normalizedAprioriParameterDeviation = Eigen::VectorXd::Zero( 0 );
+        if( estimationInput->getApplyAprioriParameterDeviation( ) )
+        {
+            normalizedAprioriParameterDeviation = ( oldParameterEstimate - aprioriParameterEstimate )
+                                                          .template cast< double >( )
+                                                          .cwiseProduct( estimatedParameterNormalizationTerms );
+        }
 
         InterArcConstraintContribution interArcContribution;
         if( !interArcConstraints.empty( ) )
@@ -222,9 +228,8 @@ OrbitDeterminationManager< ObservationScalarType, TimeType, Dummy >::estimatePar
             break;
         }
 
-        ParameterVectorType parameterAddition =
-                ( leastSquaresOutput.first.cwiseQuotient( normalizationTerms.segment( 0, numberEstimatedParameters_ ) ) )
-                        .template cast< ObservationScalarType >( );
+        ParameterVectorType parameterAddition = ( leastSquaresOutput.first.cwiseQuotient( estimatedParameterNormalizationTerms ) )
+                                                        .template cast< ObservationScalarType >( );
 
         // Compute contribution consider parameters
         Eigen::MatrixXd covarianceContributionConsiderParameters;
@@ -245,10 +250,15 @@ OrbitDeterminationManager< ObservationScalarType, TimeType, Dummy >::estimatePar
         // Calculate mean residual for current iteration.
         residualRms = linear_algebra::getVectorEntryRootMeanSquare( residuals.template cast< double >( ) );
         costFunction = linear_algebra::computeLeastSquaresCostFunction( weightsMatrixDiagonals, residuals.template cast< double >( ) );
-        const double aprioriCost = 0.5 *
-                normalizedAprioriParameterDeviation.dot( normalizedInverseAprioriCovarianceMatrix * normalizedAprioriParameterDeviation );
-        // The cost driving best-iteration selection combines the observation cost with all prior costs. Residual RMS is
-        // unchanged so observation-only diagnostics remain meaningful.
+        double aprioriCost = 0.0;
+        if( estimationInput->getApplyAprioriParameterDeviation( ) )
+        {
+            aprioriCost = 0.5 *
+                    normalizedAprioriParameterDeviation.dot( normalizedInverseAprioriCovarianceMatrix *
+                                                             normalizedAprioriParameterDeviation );
+        }
+        // In deviation-based mode, best-iteration selection additionally includes the absolute a priori cost. Residual RMS
+        // is unchanged so observation-only diagnostics remain meaningful.
         costFunction += aprioriCost + interArcContribution.totalConstraintCost;
         rmsResidualHistory.push_back( residualRms );
         costFunctionHistory.push_back( costFunction );

--- a/src/tudat/math/basic/leastSquaresEstimation.cpp
+++ b/src/tudat/math/basic/leastSquaresEstimation.cpp
@@ -133,7 +133,8 @@ std::pair< Eigen::VectorXd, Eigen::MatrixXd > performLeastSquaresAdjustmentFromD
         const Eigen::MatrixXd& designMatrixConsiderParameters,
         const Eigen::VectorXd& considerParametersDeviations,
         const Eigen::MatrixXd& additionalNormalMatrix,
-        const Eigen::VectorXd& additionalRightHandSide )
+        const Eigen::VectorXd& additionalRightHandSide,
+        const Eigen::VectorXd& aprioriParameterDeviation )
 {
     Eigen::VectorXd rightHandSide = Eigen::VectorXd::Zero( observationResiduals.size( ) );
     if( considerParametersDeviations.size( ) > 0 && designMatrixConsiderParameters.size( ) > 0 )
@@ -150,6 +151,19 @@ std::pair< Eigen::VectorXd, Eigen::MatrixXd > performLeastSquaresAdjustmentFromD
     Eigen::MatrixXd inverseOfCovarianceMatrix = calculateInverseOfUpdatedCovarianceMatrix(
             designMatrix, diagonalOfWeightMatrix, inverseOfAPrioriCovarianceMatrix, constraintMultiplier, constraintRightHandside );
 
+    const int nParams = static_cast< int >( designMatrix.cols( ) );
+    if( aprioriParameterDeviation.size( ) > 0 )
+    {
+        if( aprioriParameterDeviation.size( ) != nParams )
+        {
+            throw std::runtime_error( "Error in performLeastSquaresAdjustmentFromDesignMatrix: aprioriParameterDeviation has size " +
+                                      std::to_string( aprioriParameterDeviation.size( ) ) + ", expected " + std::to_string( nParams ) +
+                                      "." );
+        }
+        // The prior residual is the a priori parameter vector minus the current estimate, i.e. the negative deviation.
+        rightHandSide -= inverseOfAPrioriCovarianceMatrix * aprioriParameterDeviation;
+    }
+
     // Add constraints to inverse covariance matrix if required
     if( constraintMultiplier.rows( ) != 0 )
     {
@@ -162,7 +176,6 @@ std::pair< Eigen::VectorXd, Eigen::MatrixXd > performLeastSquaresAdjustmentFromD
 
     // Soft-constraint additions (e.g. inter-arc continuity): inject into the parameter block of the LHS/RHS,
     // leaving any Lagrange-multiplier rows from the hard equality constraint above untouched.
-    const int nParams = static_cast< int >( designMatrix.cols( ) );
     if( additionalNormalMatrix.size( ) > 0 )
     {
         if( additionalNormalMatrix.rows( ) != nParams || additionalNormalMatrix.cols( ) != nParams )

--- a/src/tudat/math/basic/leastSquaresEstimation.cpp
+++ b/src/tudat/math/basic/leastSquaresEstimation.cpp
@@ -148,10 +148,15 @@ std::pair< Eigen::VectorXd, Eigen::MatrixXd > performLeastSquaresAdjustmentFromD
         rightHandSide = designMatrix.transpose( ) * ( diagonalOfWeightMatrix.cwiseProduct( observationResiduals ) );
     }
 
-    Eigen::MatrixXd inverseOfCovarianceMatrix = calculateInverseOfUpdatedCovarianceMatrix(
-            designMatrix, diagonalOfWeightMatrix, inverseOfAPrioriCovarianceMatrix, constraintMultiplier, constraintRightHandside );
-
     const int nParams = static_cast< int >( designMatrix.cols( ) );
+    if( inverseOfAPrioriCovarianceMatrix.rows( ) != nParams || inverseOfAPrioriCovarianceMatrix.cols( ) != nParams )
+    {
+        throw std::runtime_error(
+                "Error in performLeastSquaresAdjustmentFromDesignMatrix: inverseOfAPrioriCovarianceMatrix has dimensions " +
+                std::to_string( inverseOfAPrioriCovarianceMatrix.rows( ) ) + "x" +
+                std::to_string( inverseOfAPrioriCovarianceMatrix.cols( ) ) + ", expected " + std::to_string( nParams ) + "x" +
+                std::to_string( nParams ) + "." );
+    }
     if( aprioriParameterDeviation.size( ) > 0 )
     {
         if( aprioriParameterDeviation.size( ) != nParams )
@@ -163,6 +168,9 @@ std::pair< Eigen::VectorXd, Eigen::MatrixXd > performLeastSquaresAdjustmentFromD
         // The prior residual is the a priori parameter vector minus the current estimate, i.e. the negative deviation.
         rightHandSide -= inverseOfAPrioriCovarianceMatrix * aprioriParameterDeviation;
     }
+
+    Eigen::MatrixXd inverseOfCovarianceMatrix = calculateInverseOfUpdatedCovarianceMatrix(
+            designMatrix, diagonalOfWeightMatrix, inverseOfAPrioriCovarianceMatrix, constraintMultiplier, constraintRightHandside );
 
     // Add constraints to inverse covariance matrix if required
     if( constraintMultiplier.rows( ) != 0 )

--- a/src/tudatpy/estimation/estimation_analysis/expose_estimation_analysis.cpp
+++ b/src/tudatpy/estimation/estimation_analysis/expose_estimation_analysis.cpp
@@ -603,6 +603,7 @@ containing the data, see `user guide description <https://docs.tudat.space/en/la
                             std::shared_ptr< tss::EstimationConvergenceChecker >,
                             const Eigen::MatrixXd,
                             const Eigen::VectorXd,
+                            const bool,
                             const bool >( ),
                   py::arg( "observations_and_times" ),
                   py::arg( "inverse_apriori_covariance" ) = Eigen::MatrixXd::Zero( 0, 0 ),
@@ -612,6 +613,7 @@ containing the data, see `user guide description <https://docs.tudat.space/en/la
                   py::arg( "consider_covariance" ) = Eigen::MatrixXd::Zero( 0, 0 ),
                   py::arg( "consider_parameters_deviations" ) = Eigen::VectorXd::Zero( 0 ),
                   py::arg( "apply_final_parameter_correction" ) = true,
+                  py::arg( "apply_apriori_parameter_deviation" ) = false,
                   R"doc(
 
          Class constructor.
@@ -633,6 +635,10 @@ containing the data, see `user guide description <https://docs.tudat.space/en/la
              Deviations of the consider parameters from their nominal values. This should be either a size 0 vector (no consider-parameter deviations), or a vector with the same size as the number of consider parameters.
          apply_final_parameter_correction : bool, default = True
              Whether to apply the final estimated parameter correction to the simulation models after convergence.
+         apply_apriori_parameter_deviation : bool, default = False
+             Whether to apply the a priori constraint to the total parameter deviation from the parameter vector at the start
+             of the estimation. The default preserves the legacy behavior, in which the inverse a priori covariance regularizes
+             each differential correction independently.
          Returns
          -------
          :class:`~tudatpy.estimation.estimation_analysis.EstimationInput`

--- a/tests/test_tudat/src/astro/orbit_determination/unitTestEstimationInput.cpp
+++ b/tests/test_tudat/src/astro/orbit_determination/unitTestEstimationInput.cpp
@@ -86,8 +86,8 @@ BOOST_AUTO_TEST_CASE( test_NormalizedLinearConstraints )
     BOOST_CHECK_CLOSE_FRACTION( normalizedConstraint.cwiseAbs( ).maxCoeff( ), 1.0, 1.0E-15 );
 }
 
-//! Test that a priori information constrains the total deviation from the initial parameter vector.
-BOOST_AUTO_TEST_CASE( test_APrioriParameterDeviation )
+//! Test the direct a priori parameter-deviation contribution to the normal-equation right-hand side.
+BOOST_AUTO_TEST_CASE( test_APrioriParameterDeviationNormalEquations )
 {
     Eigen::MatrixXd designMatrix( 3, 2 );
     designMatrix << 1.0, 2.0, -1.0, 0.5, 0.0, 1.0;
@@ -119,11 +119,14 @@ BOOST_AUTO_TEST_CASE( test_APrioriParameterDeviation )
 
     BOOST_CHECK_SMALL( ( leastSquaresOutput.second - expectedNormalMatrix ).norm( ), 1.0E-14 );
     BOOST_CHECK_SMALL( ( leastSquaresOutput.first - expectedParameterCorrection ).norm( ), 1.0E-14 );
+}
 
-    // Exercise the constraint through a realistic iterative orbit determination. Simulate one day of position data for
-    // a low Earth orbiter subject to gravity and atmospheric drag, then estimate its initial state and drag coefficient.
-    // The a priori parameter vector is deliberately offset from truth. The converged MAP estimate must move toward the
-    // data while retaining a non-zero offset from truth due to the prior.
+//! Test that a priori information constrains the total deviation in a realistic iterative orbit determination.
+BOOST_AUTO_TEST_CASE( test_APrioriParameterDeviation )
+{
+    // Simulate one day of position data for a low Earth orbiter subject to gravity and atmospheric drag, then estimate
+    // its initial state and drag coefficient. The a priori parameter vector is deliberately offset from truth. The
+    // converged MAP estimate must move toward the data while retaining a non-zero offset from truth due to the prior.
     using namespace observation_models;
     using namespace orbital_element_conversions;
 
@@ -191,18 +194,15 @@ BOOST_AUTO_TEST_CASE( test_APrioriParameterDeviation )
     {
         observationTimes.push_back( observationTime );
     }
-    BOOST_REQUIRE_EQUAL( observationTimes.size( ), 1441 );
     const std::vector< std::shared_ptr< ObservationSimulationSettings< double > > > observationSimulationSettings = {
         std::make_shared< TabulatedObservationSimulationSettings< double > >(
                 position_observable, linkEnds, observationTimes, observed_body )
     };
     const std::shared_ptr< ObservationCollection< double, double > > simulatedObservations = simulateObservations< double, double >(
             observationSimulationSettings, orbitDeterminationManager.getObservationSimulators( ), bodies );
-    BOOST_REQUIRE_EQUAL( simulatedObservations->getTotalObservableSize( ), 3 * 1441 );
     simulatedObservations->setConstantWeight( 1.0 );
 
     const Eigen::VectorXd trueParameters = parametersToEstimate->getFullParameterValues< double >( );
-    BOOST_REQUIRE_EQUAL( trueParameters.size( ), 7 );
     Eigen::VectorXd aprioriParameters = trueParameters;
     aprioriParameters.segment( 0, 3 ).array( ) += 1.0;
     aprioriParameters( 6 ) += 0.5;
@@ -214,55 +214,89 @@ BOOST_AUTO_TEST_CASE( test_APrioriParameterDeviation )
     fullEstimationInverseAprioriCovariance( 6, 6 ) =
             1.0 / ( dragCoefficientAprioriStandardDeviation * dragCoefficientAprioriStandardDeviation );
     const std::shared_ptr< EstimationInput< double, double > > estimationInput = std::make_shared< EstimationInput< double, double > >(
-            simulatedObservations, fullEstimationInverseAprioriCovariance, estimationConvergenceChecker( 6, -1.0, -1.0, 100 ) );
+            simulatedObservations, fullEstimationInverseAprioriCovariance, estimationConvergenceChecker( 3, -1.0, -1.0, 100 ) );
     estimationInput->defineEstimationSettings( true, true, true, false, true, false );
 
     const std::shared_ptr< EstimationOutput< double, double > > estimationOutput =
             orbitDeterminationManager.estimateParameters( estimationInput );
     BOOST_REQUIRE( !estimationOutput->exceptionDuringInversion_ );
     BOOST_REQUIRE( !estimationOutput->exceptionDuringPropagation_ );
-    BOOST_REQUIRE_EQUAL( estimationOutput->residualHistory_.size( ), 6 );
+    BOOST_REQUIRE_EQUAL( estimationOutput->residualHistory_.size( ), 3 );
 
     const Eigen::MatrixXd parameterHistory = estimationOutput->getParameterHistoryMatrix( );
     BOOST_REQUIRE_EQUAL( parameterHistory.rows( ), 7 );
-    BOOST_REQUIRE_EQUAL( parameterHistory.cols( ), 7 );
+    BOOST_REQUIRE_EQUAL( parameterHistory.cols( ), 4 );
     BOOST_CHECK_SMALL( ( parameterHistory.col( 0 ) - aprioriParameters ).norm( ), 1.0E-12 );
 
-    const Eigen::VectorXd finalParameters = parameterHistory.col( parameterHistory.cols( ) - 1 );
-    const double initialPositionError = ( aprioriParameters.segment( 0, 3 ) - trueParameters.segment( 0, 3 ) ).norm( );
-    const double finalPositionError = ( finalParameters.segment( 0, 3 ) - trueParameters.segment( 0, 3 ) ).norm( );
-    const double finalPositionDeviationFromApriori = ( finalParameters.segment( 0, 3 ) - aprioriParameters.segment( 0, 3 ) ).norm( );
-    const double finalDragCoefficientOffset = finalParameters( 6 ) - trueParameters( 6 );
-    const double finalDragCoefficientDeviationFromApriori = aprioriParameters( 6 ) - finalParameters( 6 );
+    const int convergedIteration = 2;
+    BOOST_CHECK_EQUAL( estimationOutput->bestIteration_, convergedIteration );
+    const int balanceIteration = estimationOutput->bestIteration_;
+    const Eigen::VectorXd constrainedParameters = parameterHistory.col( balanceIteration );
     const double initialResidualRms = linear_algebra::getVectorEntryRootMeanSquare( estimationOutput->residualHistory_.front( ) );
-    const double finalResidualRms = linear_algebra::getVectorEntryRootMeanSquare( estimationOutput->residualHistory_.back( ) );
+    const double constrainedResidualRms = linear_algebra::getVectorEntryRootMeanSquare( estimationOutput->residuals_ );
 
-    BOOST_TEST_MESSAGE( "Final initial-position offset from truth: "
-                        << ( finalParameters.segment( 0, 3 ) - trueParameters.segment( 0, 3 ) ).transpose( ) << " m; error norm: "
-                        << finalPositionError << " m; deviation from prior: " << finalPositionDeviationFromApriori << " m" );
-    BOOST_TEST_MESSAGE( "Final drag coefficient offset from truth: " << finalDragCoefficientOffset << "; deviation from prior: "
-                                                                     << finalDragCoefficientDeviationFromApriori );
-    BOOST_TEST_MESSAGE( "Position-observation residual RMS reduced from " << initialResidualRms << " m to " << finalResidualRms << " m" );
-
-    // Every constrained parameter settles strictly between truth and its a priori value: the data move the estimate
-    // toward truth, while the prior prevents convergence to the data-only solution.
-    BOOST_CHECK_LT( finalPositionError, initialPositionError );
-    for( int positionIndex = 0; positionIndex < 3; positionIndex++ )
+    // The nonlinear differential corrections decrease monotonically until the fixed third iteration converges.
+    std::vector< double > correctionNorms;
+    for( int iteration = 1; iteration < parameterHistory.cols( ); iteration++ )
     {
-        const double finalPositionOffset = finalParameters( positionIndex ) - trueParameters( positionIndex );
-        BOOST_CHECK_GT( finalPositionOffset, positionAprioriStandardDeviation );
-        BOOST_CHECK_LT( finalPositionOffset, 1.0 - positionAprioriStandardDeviation );
+        const Eigen::VectorXd correction = parameterHistory.col( iteration ) - parameterHistory.col( iteration - 1 );
+        correctionNorms.push_back( correction.norm( ) );
+        BOOST_TEST_MESSAGE( "Constrained correction "
+                            << iteration << ": total=" << correction.norm( ) << ", position=" << correction.segment( 0, 3 ).norm( )
+                            << ", velocity=" << correction.segment( 3, 3 ).norm( ) << ", Cd=" << std::fabs( correction( 6 ) ) );
     }
-    BOOST_CHECK_GT( finalDragCoefficientOffset, 0.5 * dragCoefficientAprioriStandardDeviation );
-    BOOST_CHECK_LT( finalDragCoefficientOffset, 0.5 - dragCoefficientAprioriStandardDeviation );
-    BOOST_CHECK_GT( finalDragCoefficientDeviationFromApriori, dragCoefficientAprioriStandardDeviation );
+    for( unsigned int iteration = 1; iteration < correctionNorms.size( ); iteration++ )
+    {
+        BOOST_CHECK_LT( correctionNorms.at( iteration ), correctionNorms.at( iteration - 1 ) );
+    }
+    BOOST_CHECK_LT( correctionNorms.back( ), 1.0E-6 * correctionNorms.front( ) );
 
-    BOOST_CHECK_LT( finalResidualRms, initialResidualRms );
-    BOOST_CHECK_GT( finalResidualRms, 1.0E-3 );
-    const Eigen::VectorXd finalCorrection =
-            parameterHistory.col( parameterHistory.cols( ) - 1 ) - parameterHistory.col( parameterHistory.cols( ) - 2 );
-    BOOST_CHECK_SMALL( finalCorrection.segment( 0, 3 ).norm( ), 1.0E-5 );
-    BOOST_CHECK_SMALL( finalCorrection( 6 ), 1.0E-6 );
+    // At the converged linearization point, separately map the observation and a priori right-hand-side terms to
+    // parameter corrections. They must be non-negligible, opposite contributions whose sum equals the final negligible
+    // correction recorded in the parameter history.
+    const Eigen::MatrixXd normalizedDesignMatrix = estimationOutput->getNormalizedDesignMatrix( );
+    const Eigen::VectorXd normalizationTerms = estimationOutput->getNormalizationTerms( );
+    const Eigen::MatrixXd normalizedInverseAprioriCovariance =
+            orbitDeterminationManager.normalizeAprioriCovariance( fullEstimationInverseAprioriCovariance, normalizationTerms );
+    const Eigen::VectorXd normalizedAprioriDeviation = ( constrainedParameters - aprioriParameters ).cwiseProduct( normalizationTerms );
+    const Eigen::VectorXd observationRightHandSide = normalizedDesignMatrix.transpose( ) *
+            estimationInput->getWeightsMatrixDiagonals( ).cwiseProduct( estimationOutput->residuals_ );
+    const Eigen::VectorXd aprioriRightHandSide = -normalizedInverseAprioriCovariance * normalizedAprioriDeviation;
+    const Eigen::MatrixXd normalizedCovariance = estimationOutput->getNormalizedCovarianceMatrix( );
+    const Eigen::VectorXd observationCorrection = ( normalizedCovariance * observationRightHandSide ).cwiseQuotient( normalizationTerms );
+    const Eigen::VectorXd aprioriCorrection = ( normalizedCovariance * aprioriRightHandSide ).cwiseQuotient( normalizationTerms );
+    const Eigen::VectorXd balancedCorrection = observationCorrection + aprioriCorrection;
+    const Eigen::VectorXd finalCorrection = parameterHistory.col( balanceIteration + 1 ) - constrainedParameters;
+    const double individualCorrectionScale = std::max( observationCorrection.norm( ), aprioriCorrection.norm( ) );
+    BOOST_TEST_MESSAGE( "Observation correction at balance: " << observationCorrection.transpose( ) );
+    BOOST_TEST_MESSAGE( "A priori correction at balance: " << aprioriCorrection.transpose( ) );
+    BOOST_TEST_MESSAGE( "Correction sum at balance: " << balancedCorrection.transpose( ) );
+    BOOST_CHECK_GT( observationCorrection.norm( ), 1.0E-2 );
+    BOOST_CHECK_GT( aprioriCorrection.norm( ), 1.0E-2 );
+    BOOST_CHECK_SMALL( balancedCorrection.norm( ), 1.0E-6 * individualCorrectionScale );
+    BOOST_CHECK_SMALL( ( balancedCorrection - finalCorrection ).norm( ), 1.0E-8 * individualCorrectionScale );
+
+    // Repeat the estimation from the same perturbed parameters without an a priori constraint. The noise-free synthetic
+    // observations must then recover the true parameters and zero post-fit residuals to numerical precision.
+    orbitDeterminationManager.resetParameterEstimate( aprioriParameters, true );
+    const std::shared_ptr< EstimationInput< double, double > > unconstrainedEstimationInput =
+            std::make_shared< EstimationInput< double, double > >(
+                    simulatedObservations, Eigen::MatrixXd::Zero( 7, 7 ), estimationConvergenceChecker( 3, -1.0, -1.0, 100 ) );
+    unconstrainedEstimationInput->defineEstimationSettings( true, true, true, false, true, false );
+    const std::shared_ptr< EstimationOutput< double, double > > unconstrainedEstimationOutput =
+            orbitDeterminationManager.estimateParameters( unconstrainedEstimationInput );
+    BOOST_REQUIRE( !unconstrainedEstimationOutput->exceptionDuringInversion_ );
+    BOOST_REQUIRE( !unconstrainedEstimationOutput->exceptionDuringPropagation_ );
+    BOOST_REQUIRE_EQUAL( unconstrainedEstimationOutput->bestIteration_, convergedIteration );
+    const Eigen::VectorXd unconstrainedParameterError = unconstrainedEstimationOutput->parameterEstimate_ - trueParameters;
+    const double unconstrainedResidualRms = linear_algebra::getVectorEntryRootMeanSquare( unconstrainedEstimationOutput->residuals_ );
+    BOOST_TEST_MESSAGE( "Constrained residual RMS reduced from " << initialResidualRms << " m to " << constrainedResidualRms << " m" );
+    BOOST_TEST_MESSAGE( "Unconstrained parameter error: " << unconstrainedParameterError.transpose( ) );
+    BOOST_TEST_MESSAGE( "Unconstrained residual RMS: " << unconstrainedResidualRms );
+    BOOST_CHECK_SMALL( unconstrainedParameterError.segment( 0, 3 ).norm( ), 1.0E-5 );
+    BOOST_CHECK_SMALL( unconstrainedParameterError.segment( 3, 3 ).norm( ), 1.0E-8 );
+    BOOST_CHECK_SMALL( unconstrainedParameterError( 6 ), 1.0E-6 );
+    BOOST_CHECK_SMALL( unconstrainedResidualRms, 1.0E-5 );
 }
 
 //! Test a constrained least-squares orbit estimation with position and velocity corrections at different scales.

--- a/tests/test_tudat/src/astro/orbit_determination/unitTestEstimationInput.cpp
+++ b/tests/test_tudat/src/astro/orbit_determination/unitTestEstimationInput.cpp
@@ -13,6 +13,7 @@
 #include <boost/test/included/unit_test.hpp>
 #include <Eigen/LU>
 
+#include <cmath>
 #include <limits>
 
 #include "tudat/math/basic/leastSquaresEstimation.h"
@@ -119,27 +120,48 @@ BOOST_AUTO_TEST_CASE( test_APrioriParameterDeviation )
     BOOST_CHECK_SMALL( ( leastSquaresOutput.second - expectedNormalMatrix ).norm( ), 1.0E-14 );
     BOOST_CHECK_SMALL( ( leastSquaresOutput.first - expectedParameterCorrection ).norm( ), 1.0E-14 );
 
-    // Exercise the same constraint through a complete iterative estimation. With zero acceleration and a position
-    // observation at the initial epoch, the estimation problem is linear. The first update therefore reaches the MAP
-    // solution. Although an observation residual remains, the second update must be zero because the growing deviation
-    // from the fixed initial parameter vector supplies an equal and opposite a priori contribution.
+    // Exercise the constraint through a realistic iterative orbit determination. Simulate one day of position data for
+    // a low Earth orbiter subject to gravity and atmospheric drag, then estimate its initial state and drag coefficient.
+    // The a priori parameter vector is deliberately offset from truth. The converged MAP estimate must move toward the
+    // data while retaining a non-zero offset from truth due to the prior.
     using namespace observation_models;
+    using namespace orbital_element_conversions;
 
     const double initialTime = 1.0E7;
-    const double finalTime = initialTime + 60.0;
-    SystemOfBodies bodies( "SSB", "ECLIPJ2000" );
+    const double finalTime = initialTime + physical_constants::JULIAN_DAY;
+    const double trueDragCoefficient = 2.2;
+    const double positionAprioriStandardDeviation = 0.02;
+    const double dragCoefficientAprioriStandardDeviation = 0.05;
+
+    spice_interface::loadStandardSpiceKernels( );
+    BodyListSettings bodySettings = getDefaultBodySettings( { "Earth" }, "Earth", "ECLIPJ2000" );
+    bodySettings.at( "Earth" )->atmosphereSettings = std::make_shared< ExponentialAtmosphereSettings >( aerodynamics::earth );
+    SystemOfBodies bodies = createSystemOfBodies( bodySettings );
     bodies.createEmptyBody( "Satellite" );
-    bodies.at( "Satellite" )->setConstantBodyMass( 100.0 );
+    bodies.at( "Satellite" )->setConstantBodyMass( 400.0 );
+    const std::shared_ptr< AerodynamicCoefficientSettings > aerodynamicCoefficientSettings =
+            std::make_shared< ConstantAerodynamicCoefficientSettings >(
+                    4.0, trueDragCoefficient * Eigen::Vector3d::UnitX( ), negative_aerodynamic_frame_coefficients );
+    bodies.at( "Satellite" )
+            ->setAerodynamicCoefficientInterface(
+                    createAerodynamicCoefficientInterface( aerodynamicCoefficientSettings, "Satellite", bodies ) );
 
     const std::vector< std::string > bodiesToPropagate = { "Satellite" };
-    const std::vector< std::string > centralBodies = { "SSB" };
-    AccelerationMap accelerationModels;
-    accelerationModels[ "Satellite" ] = basic_astrodynamics::SingleBodyAccelerationMap( );
+    const std::vector< std::string > centralBodies = { "Earth" };
+    SelectedAccelerationMap accelerationSettings;
+    accelerationSettings[ "Satellite" ][ "Earth" ].push_back( std::make_shared< AccelerationSettings >( point_mass_gravity ) );
+    accelerationSettings[ "Satellite" ][ "Earth" ].push_back( std::make_shared< AccelerationSettings >( aerodynamic ) );
+    const AccelerationMap accelerationModels =
+            createAccelerationModelsMap( bodies, accelerationSettings, bodiesToPropagate, centralBodies );
 
-    Eigen::Vector6d trueInitialState;
-    trueInitialState << 7.0E6, 2.0E6, -1.0E6, 100.0, 200.0, -50.0;
+    Eigen::Vector6d initialKeplerianState;
+    initialKeplerianState << bodies.at( "Earth" )->getShapeModel( )->getAverageRadius( ) + 240.0E3, 1.0E-3,
+            unit_conversions::convertDegreesToRadians( 45.0 ), unit_conversions::convertDegreesToRadians( 20.0 ),
+            unit_conversions::convertDegreesToRadians( 40.0 ), unit_conversions::convertDegreesToRadians( 10.0 );
+    const Eigen::Vector6d trueInitialState = convertKeplerianToCartesianElements(
+            initialKeplerianState, bodies.at( "Earth" )->getGravityFieldModel( )->getGravitationalParameter( ) );
     const std::shared_ptr< IntegratorSettings< double > > integratorSettings =
-            rungeKuttaFixedStepSettings( 10.0, CoefficientSets::rungeKuttaFehlberg78 );
+            rungeKuttaFixedStepSettings( 60.0, CoefficientSets::rungeKuttaFehlberg78 );
     const std::shared_ptr< TranslationalStatePropagatorSettings< double, double > > propagatorSettings =
             std::make_shared< TranslationalStatePropagatorSettings< double, double > >( centralBodies,
                                                                                         accelerationModels,
@@ -150,10 +172,11 @@ BOOST_AUTO_TEST_CASE( test_APrioriParameterDeviation )
                                                                                         propagationTimeTerminationSettings( finalTime ),
                                                                                         cowell );
 
-    const std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterSettings =
+    std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterSettings =
             getInitialStateParameterSettings< double, double >( propagatorSettings, bodies );
+    parameterSettings.push_back( estimatable_parameters::constantDragCoefficient( "Satellite" ) );
     const std::shared_ptr< estimatable_parameters::EstimatableParameterSet< double > > parametersToEstimate =
-            createParametersToEstimate< double, double >( parameterSettings, bodies );
+            createParametersToEstimate< double, double >( parameterSettings, bodies, propagatorSettings );
 
     LinkEnds linkEnds;
     linkEnds[ observed_body ] = LinkEndId( "Satellite", "" );
@@ -163,39 +186,83 @@ BOOST_AUTO_TEST_CASE( test_APrioriParameterDeviation )
     OrbitDeterminationManager< double, double > orbitDeterminationManager(
             bodies, parametersToEstimate, observationModelSettings, propagatorSettings );
 
+    std::vector< double > observationTimes;
+    for( double observationTime = initialTime; observationTime <= finalTime; observationTime += 60.0 )
+    {
+        observationTimes.push_back( observationTime );
+    }
+    BOOST_REQUIRE_EQUAL( observationTimes.size( ), 1441 );
     const std::vector< std::shared_ptr< ObservationSimulationSettings< double > > > observationSimulationSettings = {
         std::make_shared< TabulatedObservationSimulationSettings< double > >(
-                position_observable, linkEnds, std::vector< double >{ finalTime }, observed_body )
+                position_observable, linkEnds, observationTimes, observed_body )
     };
     const std::shared_ptr< ObservationCollection< double, double > > simulatedObservations = simulateObservations< double, double >(
             observationSimulationSettings, orbitDeterminationManager.getObservationSimulators( ), bodies );
+    BOOST_REQUIRE_EQUAL( simulatedObservations->getTotalObservableSize( ), 3 * 1441 );
     simulatedObservations->setConstantWeight( 1.0 );
 
-    Eigen::Vector6d aprioriInitialState = trueInitialState;
-    aprioriInitialState( 0 ) += 10.0;
-    orbitDeterminationManager.resetParameterEstimate( aprioriInitialState, true );
+    const Eigen::VectorXd trueParameters = parametersToEstimate->getFullParameterValues< double >( );
+    BOOST_REQUIRE_EQUAL( trueParameters.size( ), 7 );
+    Eigen::VectorXd aprioriParameters = trueParameters;
+    aprioriParameters.segment( 0, 3 ).array( ) += 1.0;
+    aprioriParameters( 6 ) += 0.5;
+    orbitDeterminationManager.resetParameterEstimate( aprioriParameters, true );
 
-    const Eigen::MatrixXd fullEstimationInverseAprioriCovariance = 1.0E4 * Eigen::MatrixXd::Identity( 6, 6 );
+    Eigen::MatrixXd fullEstimationInverseAprioriCovariance = Eigen::MatrixXd::Zero( 7, 7 );
+    fullEstimationInverseAprioriCovariance.diagonal( ).segment( 0, 3 ).setConstant(
+            1.0 / ( positionAprioriStandardDeviation * positionAprioriStandardDeviation ) );
+    fullEstimationInverseAprioriCovariance( 6, 6 ) =
+            1.0 / ( dragCoefficientAprioriStandardDeviation * dragCoefficientAprioriStandardDeviation );
     const std::shared_ptr< EstimationInput< double, double > > estimationInput = std::make_shared< EstimationInput< double, double > >(
-            simulatedObservations, fullEstimationInverseAprioriCovariance, estimationConvergenceChecker( 2, -1.0, -1.0, 100 ) );
+            simulatedObservations, fullEstimationInverseAprioriCovariance, estimationConvergenceChecker( 6, -1.0, -1.0, 100 ) );
     estimationInput->defineEstimationSettings( true, true, true, false, true, false );
 
     const std::shared_ptr< EstimationOutput< double, double > > estimationOutput =
             orbitDeterminationManager.estimateParameters( estimationInput );
     BOOST_REQUIRE( !estimationOutput->exceptionDuringInversion_ );
     BOOST_REQUIRE( !estimationOutput->exceptionDuringPropagation_ );
-    BOOST_REQUIRE_EQUAL( estimationOutput->residualHistory_.size( ), 2 );
+    BOOST_REQUIRE_EQUAL( estimationOutput->residualHistory_.size( ), 6 );
 
     const Eigen::MatrixXd parameterHistory = estimationOutput->getParameterHistoryMatrix( );
-    BOOST_REQUIRE_EQUAL( parameterHistory.rows( ), 6 );
-    BOOST_REQUIRE_EQUAL( parameterHistory.cols( ), 3 );
-    const Eigen::Vector6d deviationAfterFirstIteration = parameterHistory.col( 1 ) - parameterHistory.col( 0 );
-    const Eigen::Vector6d secondParameterCorrection = parameterHistory.col( 2 ) - parameterHistory.col( 1 );
+    BOOST_REQUIRE_EQUAL( parameterHistory.rows( ), 7 );
+    BOOST_REQUIRE_EQUAL( parameterHistory.cols( ), 7 );
+    BOOST_CHECK_SMALL( ( parameterHistory.col( 0 ) - aprioriParameters ).norm( ), 1.0E-12 );
 
-    BOOST_CHECK_GT( deviationAfterFirstIteration.norm( ), 1.0E-3 );
-    BOOST_CHECK_GT( estimationOutput->residualHistory_.at( 1 ).norm( ), 1.0 );
-    BOOST_CHECK_LT( estimationOutput->residualHistory_.at( 1 ).norm( ), estimationOutput->residualHistory_.at( 0 ).norm( ) );
-    BOOST_CHECK_SMALL( secondParameterCorrection.norm( ), 1.0E-6 * deviationAfterFirstIteration.norm( ) );
+    const Eigen::VectorXd finalParameters = parameterHistory.col( parameterHistory.cols( ) - 1 );
+    const double initialPositionError = ( aprioriParameters.segment( 0, 3 ) - trueParameters.segment( 0, 3 ) ).norm( );
+    const double finalPositionError = ( finalParameters.segment( 0, 3 ) - trueParameters.segment( 0, 3 ) ).norm( );
+    const double finalPositionDeviationFromApriori = ( finalParameters.segment( 0, 3 ) - aprioriParameters.segment( 0, 3 ) ).norm( );
+    const double finalDragCoefficientOffset = finalParameters( 6 ) - trueParameters( 6 );
+    const double finalDragCoefficientDeviationFromApriori = aprioriParameters( 6 ) - finalParameters( 6 );
+    const double initialResidualRms = linear_algebra::getVectorEntryRootMeanSquare( estimationOutput->residualHistory_.front( ) );
+    const double finalResidualRms = linear_algebra::getVectorEntryRootMeanSquare( estimationOutput->residualHistory_.back( ) );
+
+    BOOST_TEST_MESSAGE( "Final initial-position offset from truth: "
+                        << ( finalParameters.segment( 0, 3 ) - trueParameters.segment( 0, 3 ) ).transpose( ) << " m; error norm: "
+                        << finalPositionError << " m; deviation from prior: " << finalPositionDeviationFromApriori << " m" );
+    BOOST_TEST_MESSAGE( "Final drag coefficient offset from truth: " << finalDragCoefficientOffset << "; deviation from prior: "
+                                                                     << finalDragCoefficientDeviationFromApriori );
+    BOOST_TEST_MESSAGE( "Position-observation residual RMS reduced from " << initialResidualRms << " m to " << finalResidualRms << " m" );
+
+    // Every constrained parameter settles strictly between truth and its a priori value: the data move the estimate
+    // toward truth, while the prior prevents convergence to the data-only solution.
+    BOOST_CHECK_LT( finalPositionError, initialPositionError );
+    for( int positionIndex = 0; positionIndex < 3; positionIndex++ )
+    {
+        const double finalPositionOffset = finalParameters( positionIndex ) - trueParameters( positionIndex );
+        BOOST_CHECK_GT( finalPositionOffset, positionAprioriStandardDeviation );
+        BOOST_CHECK_LT( finalPositionOffset, 1.0 - positionAprioriStandardDeviation );
+    }
+    BOOST_CHECK_GT( finalDragCoefficientOffset, 0.5 * dragCoefficientAprioriStandardDeviation );
+    BOOST_CHECK_LT( finalDragCoefficientOffset, 0.5 - dragCoefficientAprioriStandardDeviation );
+    BOOST_CHECK_GT( finalDragCoefficientDeviationFromApriori, dragCoefficientAprioriStandardDeviation );
+
+    BOOST_CHECK_LT( finalResidualRms, initialResidualRms );
+    BOOST_CHECK_GT( finalResidualRms, 1.0E-3 );
+    const Eigen::VectorXd finalCorrection =
+            parameterHistory.col( parameterHistory.cols( ) - 1 ) - parameterHistory.col( parameterHistory.cols( ) - 2 );
+    BOOST_CHECK_SMALL( finalCorrection.segment( 0, 3 ).norm( ), 1.0E-5 );
+    BOOST_CHECK_SMALL( finalCorrection( 6 ), 1.0E-6 );
 }
 
 //! Test a constrained least-squares orbit estimation with position and velocity corrections at different scales.

--- a/tests/test_tudat/src/astro/orbit_determination/unitTestEstimationInput.cpp
+++ b/tests/test_tudat/src/astro/orbit_determination/unitTestEstimationInput.cpp
@@ -11,6 +11,7 @@
 #define BOOST_TEST_MAIN
 
 #include <boost/test/included/unit_test.hpp>
+#include <Eigen/LU>
 
 #include <limits>
 
@@ -82,6 +83,119 @@ BOOST_AUTO_TEST_CASE( test_NormalizedLinearConstraints )
 
     BOOST_CHECK_SMALL( std::fabs( ( physicalConstraint * physicalCorrection - physicalConstraintRightHandSide )( 0 ) ), 1.0E-12 );
     BOOST_CHECK_CLOSE_FRACTION( normalizedConstraint.cwiseAbs( ).maxCoeff( ), 1.0, 1.0E-15 );
+}
+
+//! Test that a priori information constrains the total deviation from the initial parameter vector.
+BOOST_AUTO_TEST_CASE( test_APrioriParameterDeviation )
+{
+    Eigen::MatrixXd designMatrix( 3, 2 );
+    designMatrix << 1.0, 2.0, -1.0, 0.5, 0.0, 1.0;
+    const Eigen::Vector3d residuals = ( Eigen::Vector3d( ) << 4.0, -2.0, 1.0 ).finished( );
+    const Eigen::Vector3d weights = ( Eigen::Vector3d( ) << 2.0, 3.0, 5.0 ).finished( );
+    Eigen::Matrix2d inverseAprioriCovariance;
+    inverseAprioriCovariance << 4.0, 1.0, 1.0, 3.0;
+    const Eigen::Vector2d aprioriParameterDeviation = ( Eigen::Vector2d( ) << 0.5, -0.25 ).finished( );
+
+    const auto leastSquaresOutput =
+            linear_algebra::performLeastSquaresAdjustmentFromDesignMatrix( designMatrix,
+                                                                           residuals,
+                                                                           weights,
+                                                                           inverseAprioriCovariance,
+                                                                           std::numeric_limits< double >::quiet_NaN( ),
+                                                                           Eigen::MatrixXd( 0, 0 ),
+                                                                           Eigen::VectorXd( 0 ),
+                                                                           Eigen::MatrixXd( 0, 0 ),
+                                                                           Eigen::VectorXd( 0 ),
+                                                                           Eigen::MatrixXd( 0, 0 ),
+                                                                           Eigen::VectorXd( 0 ),
+                                                                           aprioriParameterDeviation );
+
+    const Eigen::Matrix2d expectedNormalMatrix =
+            designMatrix.transpose( ) * weights.asDiagonal( ) * designMatrix + inverseAprioriCovariance;
+    const Eigen::Vector2d expectedRightHandSide =
+            designMatrix.transpose( ) * weights.asDiagonal( ) * residuals - inverseAprioriCovariance * aprioriParameterDeviation;
+    const Eigen::Vector2d expectedParameterCorrection = expectedNormalMatrix.inverse( ) * expectedRightHandSide;
+
+    BOOST_CHECK_SMALL( ( leastSquaresOutput.second - expectedNormalMatrix ).norm( ), 1.0E-14 );
+    BOOST_CHECK_SMALL( ( leastSquaresOutput.first - expectedParameterCorrection ).norm( ), 1.0E-14 );
+
+    // Exercise the same constraint through a complete iterative estimation. With zero acceleration and a position
+    // observation at the initial epoch, the estimation problem is linear. The first update therefore reaches the MAP
+    // solution. Although an observation residual remains, the second update must be zero because the growing deviation
+    // from the fixed initial parameter vector supplies an equal and opposite a priori contribution.
+    using namespace observation_models;
+
+    const double initialTime = 1.0E7;
+    const double finalTime = initialTime + 60.0;
+    SystemOfBodies bodies( "SSB", "ECLIPJ2000" );
+    bodies.createEmptyBody( "Satellite" );
+    bodies.at( "Satellite" )->setConstantBodyMass( 100.0 );
+
+    const std::vector< std::string > bodiesToPropagate = { "Satellite" };
+    const std::vector< std::string > centralBodies = { "SSB" };
+    AccelerationMap accelerationModels;
+    accelerationModels[ "Satellite" ] = basic_astrodynamics::SingleBodyAccelerationMap( );
+
+    Eigen::Vector6d trueInitialState;
+    trueInitialState << 7.0E6, 2.0E6, -1.0E6, 100.0, 200.0, -50.0;
+    const std::shared_ptr< IntegratorSettings< double > > integratorSettings =
+            rungeKuttaFixedStepSettings( 10.0, CoefficientSets::rungeKuttaFehlberg78 );
+    const std::shared_ptr< TranslationalStatePropagatorSettings< double, double > > propagatorSettings =
+            std::make_shared< TranslationalStatePropagatorSettings< double, double > >( centralBodies,
+                                                                                        accelerationModels,
+                                                                                        bodiesToPropagate,
+                                                                                        trueInitialState,
+                                                                                        initialTime,
+                                                                                        integratorSettings,
+                                                                                        propagationTimeTerminationSettings( finalTime ),
+                                                                                        cowell );
+
+    const std::vector< std::shared_ptr< EstimatableParameterSettings > > parameterSettings =
+            getInitialStateParameterSettings< double, double >( propagatorSettings, bodies );
+    const std::shared_ptr< estimatable_parameters::EstimatableParameterSet< double > > parametersToEstimate =
+            createParametersToEstimate< double, double >( parameterSettings, bodies );
+
+    LinkEnds linkEnds;
+    linkEnds[ observed_body ] = LinkEndId( "Satellite", "" );
+    const std::vector< std::shared_ptr< ObservationModelSettings > > observationModelSettings = {
+        std::make_shared< ObservationModelSettings >( position_observable, linkEnds )
+    };
+    OrbitDeterminationManager< double, double > orbitDeterminationManager(
+            bodies, parametersToEstimate, observationModelSettings, propagatorSettings );
+
+    const std::vector< std::shared_ptr< ObservationSimulationSettings< double > > > observationSimulationSettings = {
+        std::make_shared< TabulatedObservationSimulationSettings< double > >(
+                position_observable, linkEnds, std::vector< double >{ finalTime }, observed_body )
+    };
+    const std::shared_ptr< ObservationCollection< double, double > > simulatedObservations = simulateObservations< double, double >(
+            observationSimulationSettings, orbitDeterminationManager.getObservationSimulators( ), bodies );
+    simulatedObservations->setConstantWeight( 1.0 );
+
+    Eigen::Vector6d aprioriInitialState = trueInitialState;
+    aprioriInitialState( 0 ) += 10.0;
+    orbitDeterminationManager.resetParameterEstimate( aprioriInitialState, true );
+
+    const Eigen::MatrixXd fullEstimationInverseAprioriCovariance = 1.0E4 * Eigen::MatrixXd::Identity( 6, 6 );
+    const std::shared_ptr< EstimationInput< double, double > > estimationInput = std::make_shared< EstimationInput< double, double > >(
+            simulatedObservations, fullEstimationInverseAprioriCovariance, estimationConvergenceChecker( 2, -1.0, -1.0, 100 ) );
+    estimationInput->defineEstimationSettings( true, true, true, false, true, false );
+
+    const std::shared_ptr< EstimationOutput< double, double > > estimationOutput =
+            orbitDeterminationManager.estimateParameters( estimationInput );
+    BOOST_REQUIRE( !estimationOutput->exceptionDuringInversion_ );
+    BOOST_REQUIRE( !estimationOutput->exceptionDuringPropagation_ );
+    BOOST_REQUIRE_EQUAL( estimationOutput->residualHistory_.size( ), 2 );
+
+    const Eigen::MatrixXd parameterHistory = estimationOutput->getParameterHistoryMatrix( );
+    BOOST_REQUIRE_EQUAL( parameterHistory.rows( ), 6 );
+    BOOST_REQUIRE_EQUAL( parameterHistory.cols( ), 3 );
+    const Eigen::Vector6d deviationAfterFirstIteration = parameterHistory.col( 1 ) - parameterHistory.col( 0 );
+    const Eigen::Vector6d secondParameterCorrection = parameterHistory.col( 2 ) - parameterHistory.col( 1 );
+
+    BOOST_CHECK_GT( deviationAfterFirstIteration.norm( ), 1.0E-3 );
+    BOOST_CHECK_GT( estimationOutput->residualHistory_.at( 1 ).norm( ), 1.0 );
+    BOOST_CHECK_LT( estimationOutput->residualHistory_.at( 1 ).norm( ), estimationOutput->residualHistory_.at( 0 ).norm( ) );
+    BOOST_CHECK_SMALL( secondParameterCorrection.norm( ), 1.0E-6 * deviationAfterFirstIteration.norm( ) );
 }
 
 //! Test a constrained least-squares orbit estimation with position and velocity corrections at different scales.

--- a/tests/test_tudat/src/astro/orbit_determination/unitTestEstimationInput.cpp
+++ b/tests/test_tudat/src/astro/orbit_determination/unitTestEstimationInput.cpp
@@ -97,19 +97,21 @@ BOOST_AUTO_TEST_CASE( test_APrioriParameterDeviationNormalEquations )
     inverseAprioriCovariance << 4.0, 1.0, 1.0, 3.0;
     const Eigen::Vector2d aprioriParameterDeviation = ( Eigen::Vector2d( ) << 0.5, -0.25 ).finished( );
 
-    const auto leastSquaresOutput =
-            linear_algebra::performLeastSquaresAdjustmentFromDesignMatrix( designMatrix,
-                                                                           residuals,
-                                                                           weights,
-                                                                           inverseAprioriCovariance,
-                                                                           std::numeric_limits< double >::quiet_NaN( ),
-                                                                           Eigen::MatrixXd( 0, 0 ),
-                                                                           Eigen::VectorXd( 0 ),
-                                                                           Eigen::MatrixXd( 0, 0 ),
-                                                                           Eigen::VectorXd( 0 ),
-                                                                           Eigen::MatrixXd( 0, 0 ),
-                                                                           Eigen::VectorXd( 0 ),
-                                                                           aprioriParameterDeviation );
+    const auto performAdjustment = [ & ]( const Eigen::MatrixXd& inversePrior ) {
+        return linear_algebra::performLeastSquaresAdjustmentFromDesignMatrix( designMatrix,
+                                                                              residuals,
+                                                                              weights,
+                                                                              inversePrior,
+                                                                              std::numeric_limits< double >::quiet_NaN( ),
+                                                                              Eigen::MatrixXd( 0, 0 ),
+                                                                              Eigen::VectorXd( 0 ),
+                                                                              Eigen::MatrixXd( 0, 0 ),
+                                                                              Eigen::VectorXd( 0 ),
+                                                                              Eigen::MatrixXd( 0, 0 ),
+                                                                              Eigen::VectorXd( 0 ),
+                                                                              aprioriParameterDeviation );
+    };
+    const auto leastSquaresOutput = performAdjustment( inverseAprioriCovariance );
 
     const Eigen::Matrix2d expectedNormalMatrix =
             designMatrix.transpose( ) * weights.asDiagonal( ) * designMatrix + inverseAprioriCovariance;
@@ -119,6 +121,8 @@ BOOST_AUTO_TEST_CASE( test_APrioriParameterDeviationNormalEquations )
 
     BOOST_CHECK_SMALL( ( leastSquaresOutput.second - expectedNormalMatrix ).norm( ), 1.0E-14 );
     BOOST_CHECK_SMALL( ( leastSquaresOutput.first - expectedParameterCorrection ).norm( ), 1.0E-14 );
+    BOOST_CHECK_THROW( performAdjustment( Eigen::MatrixXd::Zero( 0, 0 ) ), std::runtime_error );
+    BOOST_CHECK_THROW( performAdjustment( Eigen::MatrixXd::Zero( 2, 1 ) ), std::runtime_error );
 }
 
 //! Test that a priori information constrains the total deviation in a realistic iterative orbit determination.
@@ -213,8 +217,14 @@ BOOST_AUTO_TEST_CASE( test_APrioriParameterDeviation )
             1.0 / ( positionAprioriStandardDeviation * positionAprioriStandardDeviation ) );
     fullEstimationInverseAprioriCovariance( 6, 6 ) =
             1.0 / ( dragCoefficientAprioriStandardDeviation * dragCoefficientAprioriStandardDeviation );
-    const std::shared_ptr< EstimationInput< double, double > > estimationInput = std::make_shared< EstimationInput< double, double > >(
-            simulatedObservations, fullEstimationInverseAprioriCovariance, estimationConvergenceChecker( 3, -1.0, -1.0, 100 ) );
+    const std::shared_ptr< EstimationInput< double, double > > estimationInput =
+            std::make_shared< EstimationInput< double, double > >( simulatedObservations,
+                                                                   fullEstimationInverseAprioriCovariance,
+                                                                   estimationConvergenceChecker( 3, -1.0, -1.0, 100 ),
+                                                                   Eigen::MatrixXd::Zero( 0, 0 ),
+                                                                   Eigen::VectorXd::Zero( 0 ),
+                                                                   true,
+                                                                   true );
     estimationInput->defineEstimationSettings( true, true, true, false, true, false );
 
     const std::shared_ptr< EstimationOutput< double, double > > estimationOutput =


### PR DESCRIPTION
 Adds an optional setting to apply a priori constraints to parameter deviations from the initial parameter values (as optional input, current behaviour will be default)
