### PR TITLE
Publish pip wheels by repacking the official conda package

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,131 @@
+name: Wheels
+
+# Publishes pip/uv wheels by *repacking* the official conda tudatpy builds.
+# Does not compile C++.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      only-os:
+        description: "If set, only this runner (ubuntu-latest, macos-14, macos-15-intel, windows-latest)"
+        required: false
+        default: ""
+      only-python:
+        description: "If set, only this Python (3.10, 3.11, 3.12)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      os: ${{ steps.set.outputs.os }}
+      python: ${{ steps.set.outputs.python }}
+    steps:
+      - id: set
+        env:
+          ONLY_OS: ${{ inputs.only-os }}
+          ONLY_PYTHON: ${{ inputs.only-python }}
+        run: |
+          if [ -n "$ONLY_OS" ]; then
+            echo "os=[\"$ONLY_OS\"]" >> "$GITHUB_OUTPUT"
+          else
+            echo 'os=["ubuntu-latest","macos-14","macos-15-intel","windows-latest"]' >> "$GITHUB_OUTPUT"
+          fi
+          if [ -n "$ONLY_PYTHON" ]; then
+            echo "python=[\"$ONLY_PYTHON\"]" >> "$GITHUB_OUTPUT"
+          else
+            echo 'python=["3.10","3.11","3.12"]' >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: ${{ matrix.os }} py${{ matrix.python }}
+    needs: matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(needs.matrix.outputs.os) }}
+        python: ${{ fromJSON(needs.matrix.outputs.python) }}
+    defaults:
+      run:
+        shell: bash -el {0}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: mamba-org/setup-micromamba@v3
+        with:
+          environment-name: pack
+          create-args: python=${{ matrix.python }} tudatpy=1.0.0
+          condarc: |
+            channels:
+              - conda-forge
+              - tudat-team
+            channel_priority: flexible
+          cache-environment: true
+
+      - name: Linux patchelf
+        if: runner.os == 'Linux'
+        run: micromamba install -y patchelf
+
+      - name: Extra Windows unpack helper
+        if: runner.os == 'Windows'
+        run: python -m pip install pefile
+
+      - name: Pack wheel
+        run: python tools/pack_conda_wheel.py -o wheels
+
+      - name: Smoke import in a clean venv
+        run: |
+          python -m venv "${RUNNER_TEMP}/smoke"
+          if [ -x "${RUNNER_TEMP}/smoke/Scripts/python.exe" ]; then
+            PY="${RUNNER_TEMP}/smoke/Scripts/python.exe"
+          else
+            PY="${RUNNER_TEMP}/smoke/bin/python"
+          fi
+          "$PY" -m pip install --upgrade pip
+          "$PY" -m pip install ./wheels/*.whl
+          "$PY" -c "import tudatpy; print(tudatpy.__version__, tudatpy.__file__)"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: wheels-${{ matrix.os }}-py${{ matrix.python }}
+          path: wheels/*.whl
+          if-no-files-found: error
+
+  publish:
+    needs: [matrix, build]
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          path: artifacts
+          merge-multiple: true
+      - name: Collect wheels and index
+        run: |
+          mkdir -p dist
+          find artifacts -name '*.whl' -exec cp {} dist/ \;
+          ls -lh dist
+          python tools/pack_conda_wheel.py --help >/dev/null
+          python - <<'PY'
+          from pathlib import Path
+          import sys
+          sys.path.insert(0, "tools")
+          from pack_conda_wheel import write_index
+          write_index(Path("dist"))
+          PY
+      - name: Upload to release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: dist/*
+          tag_name: ${{ github.event.release.tag_name }}
+          fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The **TU Delft Astrodynamics Toolbox in Python**, or **Tudatpy**, is a library t
 libraries](https://tudat.tudelft.nl/) aiming at accelerating the implementation of simulations, real-data processing and analysis, and quality education in the field of Astrodynamics.
 See the [documentation](https://tudat-space.readthedocs.io) for more.
 
-For nominal usage, the use of our distributed **conda package** is recommended. For more details on the project, please refer to the [project website](https://docs.tudat.space/en/latest/) and the [project's Github page](https://github.com/tudat-team).
+For nominal usage, the use of our distributed **conda package** is recommended. Pip wheels, produced by repacking that conda package (no extra C++ compile), are documented in [WHEELS.md](WHEELS.md). For more details on the project, please refer to the [project website](https://docs.tudat.space/en/latest/) and the [project's Github page](https://github.com/tudat-team).
 
 ## Structure of the `Tudatpy` Repository
 

--- a/WHEELS.md
+++ b/WHEELS.md
@@ -1,0 +1,49 @@
+# Pip wheels from the official conda builds
+
+Conda remains the supported way to install TudatPy. This repository can also publish **pip wheels** so students who already use `venv` + `pip` (or [uv](https://docs.astral.sh/uv/), a faster drop-in for pip) do not need a conda distribution.
+
+Nothing is compiled here. GitHub Actions installs the existing `tudat-team::tudatpy` conda package and **repacks** `kernel.so` / `kernel.pyd` plus the native libraries it links (Boost, CSPICE, NRLMSISE-00) into a standard `.whl`.
+
+## Install a wheel
+
+Wheels are attached to GitHub Releases (Linux x86_64, macOS arm64, macOS Intel, Windows amd64 × CPython 3.10/3.11/3.12). After a release tagged `v1.0.0`:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate          # Windows: .venv\Scripts\activate
+python -m pip install tudatpy \
+  --find-links https://github.com/tudat-team/tudatpy/releases/download/v1.0.0/index.html
+```
+
+Optional, same command with uv:
+
+```bash
+uv pip install tudatpy \
+  --find-links https://github.com/tudat-team/tudatpy/releases/download/v1.0.0/index.html
+```
+
+SPICE kernels and other data files are **not** inside the wheel. Unpack [tudat-resources v2.4](https://github.com/tudat-team/tudat-resources/releases/download/v2.4/resource.tar.gz) into `~/.tudat` so that `~/.tudat/resource/quadrature/gaussianNodes.txt` exists.
+
+## Produce wheels
+
+The **Wheels** workflow does **not** run on push or pull request. It runs on:
+
+- **`release` published** — builds wheels and uploads them (plus `index.html`) to that release
+- **`workflow_dispatch`** — builds wheels as Actions artifacts only (nothing attached to a release)
+
+### First 1.0.0 wheel release
+
+CI installs conda `tudatpy=1.0.0` (pinned in the workflow). Merging this PR does not publish wheels.
+
+1. Merge the workflow to the default branch (so `release` / `workflow_dispatch` are available).
+2. GitHub → **Releases → Draft a new release**.
+3. Create tag **`v1.0.0`** on that commit (or any commit that contains `.github/workflows/wheels.yml`).
+4. Publish the release.
+
+That is the first trigger that both builds and attaches wheels. `workflow_dispatch` is only for a dry run.
+
+## What this does not replace
+
+- The conda `environment.yaml` path in the docs.
+- Building Tudat from this source tree (`install.py` / CMake).
+- Optional conda-only extras (FFTW, PaGMO, Mars Climate Database).

--- a/tools/pack_conda_wheel.py
+++ b/tools/pack_conda_wheel.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""Repack an installed conda tudatpy into a pip/uv wheel.
+
+Run inside the conda/pixi/micromamba env that has tudatpy. Does not compile
+anything: it copies kernel.so/.pyd and vendors the native libs it links.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import sysconfig
+import tempfile
+import zipfile
+from pathlib import Path
+
+SKIP_SUFFIXES = {".cpp", ".cc", ".cxx", ".h", ".hpp", ".c", ".cmake", ".so", ".pyd", ".dylib"}
+SKIP_NAMES = {"CMakeLists.txt"}
+SKIP_DIR_NAMES = {"__pycache__", "temp"}
+
+LINUX_SKIP_SONAMES = {
+    "linux-vdso.so.1",
+    "ld-linux-x86-64.so.2",
+    "ld-linux-aarch64.so.1",
+    "libc.so.6",
+    "libm.so.6",
+    "libdl.so.2",
+    "librt.so.1",
+    "libpthread.so.0",
+    "libresolv.so.2",
+}
+
+
+def conda_prefix() -> Path:
+    prefix = os.environ.get("CONDA_PREFIX") or sys.prefix
+    return Path(prefix).resolve()
+
+
+def site_packages() -> Path:
+    return Path(sysconfig.get_path("purelib")).resolve()
+
+
+def copy_python_package(src: Path, dst: Path) -> None:
+    for path in src.rglob("*"):
+        rel = path.relative_to(src)
+        if any(part in SKIP_DIR_NAMES for part in rel.parts):
+            continue
+        if path.is_dir():
+            (dst / rel).mkdir(exist_ok=True)
+            continue
+        if path.suffix.lower() in SKIP_SUFFIXES or path.name in SKIP_NAMES:
+            continue
+        (dst / rel.parent).mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, dst / rel)
+
+
+def kernel_path(pkg: Path) -> Path:
+    for name in ("kernel.so", "kernel.pyd", "kernel.abi3.so"):
+        candidate = pkg / name
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError(f"No kernel extension in {pkg}")
+
+
+def wheel_tag() -> str:
+    impl = f"cp{sys.version_info.major}{sys.version_info.minor}"
+    machine = platform.machine().lower()
+    if sys.platform == "darwin":
+        arch = "arm64" if machine in {"arm64", "aarch64"} else "x86_64"
+        return f"{impl}-{impl}-macosx_13_0_{arch}"
+    if sys.platform.startswith("linux"):
+        arch = "aarch64" if machine in {"arm64", "aarch64"} else "x86_64"
+        return f"{impl}-{impl}-linux_{arch}"
+    if sys.platform == "win32":
+        arch = "win_arm64" if machine in {"arm64", "aarch64"} else "win_amd64"
+        return f"{impl}-{impl}-{arch}"
+    raise SystemExit(f"Unsupported platform: {sys.platform} {machine}")
+
+
+def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, check=True, text=True, capture_output=True, **kwargs)
+
+
+def macos_deps(binary: Path) -> list[str]:
+    out = run(["otool", "-L", str(binary)]).stdout
+    deps = []
+    for line in out.splitlines()[1:]:
+        name = line.strip().split(" ", 1)[0]
+        if name.startswith("/usr/lib/") or name.startswith("/System/"):
+            continue
+        deps.append(name)
+    return deps
+
+
+def linux_deps(binary: Path) -> list[tuple[str, str]]:
+    out = run(["ldd", str(binary)]).stdout
+    found = []
+    for line in out.splitlines():
+        line = line.strip()
+        if " => " in line:
+            soname, rest = line.split(" => ", 1)
+            soname = soname.strip()
+            path = rest.split(" ", 1)[0].strip()
+            if path in {"not", "not found"} or rest.startswith("not found"):
+                if soname not in LINUX_SKIP_SONAMES:
+                    raise RuntimeError(f"{binary} has unresolved dependency {soname}")
+                continue
+            if soname in LINUX_SKIP_SONAMES:
+                continue
+            found.append((soname, path))
+        elif line.startswith("/") and "ld-linux" not in line:
+            found.append((Path(line.split()[0]).name, line.split()[0]))
+    return found
+
+
+def resolve_in_prefix(name: str, prefix: Path) -> Path | None:
+    base = Path(name.split("/")[-1]).name
+    candidates = [
+        prefix / "lib" / Path(name).name,
+        prefix / "lib" / name,
+        prefix / "lib" / base,
+        prefix / "Library" / "bin" / Path(name).name,
+        prefix / "Library" / "lib" / Path(name).name,
+        prefix / "Library" / "bin" / base,
+        prefix / "DLLs" / Path(name).name,
+        prefix / "bin" / Path(name).name,
+    ]
+    for path in candidates:
+        if path.exists():
+            return path
+    for folder in (prefix / "lib", prefix / "Library" / "bin"):
+        if folder.is_dir():
+            matches = list(folder.glob(base)) + list(folder.glob(base + "*"))
+            if matches:
+                return matches[0]
+    return None
+
+
+def vendor_macos(kernel: Path, prefix: Path, dest_dir: Path) -> None:
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    queue = [kernel]
+    seen: set[str] = set()
+    while queue:
+        current = queue.pop()
+        for dep in macos_deps(current):
+            base = Path(dep).name
+            if base == "libc++.1.dylib":
+                run(
+                    [
+                        "install_name_tool",
+                        "-change",
+                        dep,
+                        "/usr/lib/libc++.1.dylib",
+                        str(current),
+                    ]
+                )
+                continue
+            if base in seen:
+                rel = (
+                    f"@loader_path/.dylibs/{base}" if current == kernel else f"@loader_path/{base}"
+                )
+                run(["install_name_tool", "-change", dep, rel, str(current)])
+                continue
+            src = resolve_in_prefix(dep, prefix)
+            if src is None:
+                raise RuntimeError(
+                    f"{current.name} links {dep} which is not in {prefix} and was not vendored"
+                )
+            seen.add(base)
+            shutil.copy2(src, dest_dir / base)
+            copied = dest_dir / base
+            rel = f"@loader_path/.dylibs/{base}" if current == kernel else f"@loader_path/{base}"
+            run(["install_name_tool", "-change", dep, rel, str(current)])
+            run(["install_name_tool", "-id", f"@loader_path/.dylibs/{base}", str(copied)])
+            queue.append(copied)
+    for path in [kernel, *dest_dir.glob("*")]:
+        run(["codesign", "--force", "--sign", "-", str(path)])
+
+
+def vendor_linux(kernel: Path, prefix: Path, dest_dir: Path) -> None:
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    queue = [kernel]
+    seen: set[str] = set()
+    while queue:
+        current = queue.pop()
+        for soname, path in linux_deps(current):
+            if soname in LINUX_SKIP_SONAMES or soname in seen:
+                continue
+            src = (
+                Path(path)
+                if path.startswith("/") and Path(path).exists()
+                else resolve_in_prefix(soname, prefix)
+            )
+            if src is None:
+                raise RuntimeError(f"{current.name} links {soname} which could not be resolved")
+            resolved = src.resolve()
+            if resolved.is_relative_to(Path("/usr")) and not str(resolved).startswith(str(prefix)):
+                continue
+            if not str(resolved).startswith(str(prefix)):
+                if soname.startswith(("libstdc++", "libgcc_s", "libgomp")):
+                    continue
+                raise RuntimeError(
+                    f"{current.name} links {soname} -> {resolved}, outside conda prefix {prefix}"
+                )
+            seen.add(soname)
+            shutil.copy2(src, dest_dir / src.name)
+            queue.append(dest_dir / src.name)
+    run(["patchelf", "--set-rpath", "$ORIGIN/.libs", str(kernel)])
+    for path in dest_dir.glob("*.so*"):
+        run(["patchelf", "--set-rpath", "$ORIGIN", str(path)])
+
+
+def windows_imports(dll: Path) -> list[str]:
+    try:
+        import pefile  # type: ignore
+    except ImportError as exc:
+        raise RuntimeError("pefile is required to vendor Windows DLLs") from exc
+    # Parse from bytes so Windows does not keep a file lock on the copy
+    # (TemporaryDirectory cleanup otherwise hits WinError 32).
+    pe = pefile.PE(data=dll.read_bytes())
+    names = []
+    try:
+        if not hasattr(pe, "DIRECTORY_ENTRY_IMPORT"):
+            return names
+        for entry in pe.DIRECTORY_ENTRY_IMPORT:
+            names.append(entry.dll.decode("ascii", "ignore"))
+    finally:
+        pe.close()
+    return names
+
+
+def vendor_windows(kernel: Path, prefix: Path, dest_dir: Path) -> None:
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    search_dirs = [
+        prefix / "Library" / "bin",
+        prefix / "Library" / "lib",
+        prefix / "DLLs",
+        prefix / "bin",
+        prefix / "Library" / "mingw-w64" / "bin",
+    ]
+    queue = [kernel]
+    seen: set[str] = set()
+    systemish = {
+        "kernel32.dll",
+        "user32.dll",
+        "advapi32.dll",
+        "shell32.dll",
+        "ole32.dll",
+        "oleaut32.dll",
+        "ws2_32.dll",
+        "ntdll.dll",
+        "msvcrt.dll",
+        "vcruntime140.dll",
+        "vcruntime140_1.dll",
+        "msvcp140.dll",
+        "python3.dll",
+        f"python{sys.version_info.major}{sys.version_info.minor}.dll",
+    }
+    while queue:
+        current = queue.pop()
+        for name in windows_imports(current):
+            key = name.lower()
+            if key in seen or key in systemish or key.startswith(("api-ms-win-", "ext-ms-")):
+                continue
+            src = None
+            for folder in search_dirs:
+                if not folder.is_dir():
+                    continue
+                direct = folder / name
+                if direct.exists():
+                    src = direct
+                    break
+                for candidate in folder.iterdir():
+                    if candidate.name.lower() == key:
+                        src = candidate
+                        break
+                if src is not None:
+                    break
+            if src is None:
+                if any(token in key for token in ("boost", "cspice", "nrlmsise", "sofa")):
+                    raise RuntimeError(
+                        f"{current.name} imports {name} which was not found under {prefix}"
+                    )
+                continue
+            seen.add(key)
+            shutil.copy2(src, dest_dir / src.name)
+            queue.append(dest_dir / src.name)
+
+
+def write_dist_info(stage: Path, version: str, tag: str) -> None:
+    dist = stage / f"tudatpy-{version}.dist-info"
+    dist.mkdir()
+    (dist / "METADATA").write_text(
+        "\n".join(
+            [
+                "Metadata-Version: 2.1",
+                "Name: tudatpy",
+                f"Version: {version}",
+                "Summary: TU Delft Astrodynamics Toolbox (repacked official conda build)",
+                f"Requires-Python: =={sys.version_info.major}.{sys.version_info.minor}.*",
+                "Requires-Dist: numpy>=1.26.4,<2",
+                "Requires-Dist: scipy",
+                "Requires-Dist: pandas",
+                "Requires-Dist: matplotlib",
+                "Requires-Dist: astropy",
+                "Requires-Dist: astropy-healpix",
+                "Requires-Dist: astroquery>=0.4.8",
+                "Requires-Dist: spiceypy",
+                "Requires-Dist: tabulate",
+                "Requires-Dist: colorama",
+                "Requires-Dist: tqdm",
+                "Requires-Dist: requests",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (dist / "WHEEL").write_text(
+        "\n".join(
+            [
+                "Wheel-Version: 1.0",
+                "Generator: pack_conda_wheel.py",
+                "Root-Is-Purelib: false",
+                f"Tag: {tag}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (dist / "top_level.txt").write_text("tudatpy\n", encoding="utf-8")
+    license_src = Path(__file__).resolve().parents[1] / "LICENSE"
+    if license_src.is_file():
+        shutil.copy2(license_src, dist / "LICENSE")
+
+
+def write_record(stage: Path, version: str) -> None:
+    dist = stage / f"tudatpy-{version}.dist-info"
+    lines = []
+    for path in sorted(stage.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(stage).as_posix()
+        data = path.read_bytes()
+        digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=").decode()
+        lines.append(f"{rel},sha256={digest},{len(data)}")
+    lines.append(f"tudatpy-{version}.dist-info/RECORD,,")
+    (dist / "RECORD").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_index(directory: Path) -> None:
+    files = sorted(
+        p.name for p in directory.iterdir() if p.suffix == ".whl" or p.name.endswith(".tar.gz")
+    )
+    links = "\n".join(f'    <a href="{name}">{name}</a><br/>' for name in files)
+    (directory / "index.html").write_text(
+        "<!DOCTYPE html>\n<html><head><title>tudatpy wheels</title></head>\n"
+        f"<body>\n<h1>tudatpy</h1>\n{links}\n</body></html>\n",
+        encoding="utf-8",
+    )
+
+
+def pack(output_dir: Path) -> Path:
+    import tudatpy
+
+    version = getattr(tudatpy, "__version__", "0.0.0")
+    src = site_packages() / "tudatpy"
+    if not src.is_dir():
+        raise SystemExit(f"tudatpy is not installed in {site_packages()}")
+    prefix = conda_prefix()
+    tag = wheel_tag()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="tudatpy-wheel-", ignore_cleanup_errors=True) as raw:
+        stage = Path(raw)
+        pkg = stage / "tudatpy"
+        pkg.mkdir()
+        copy_python_package(src, pkg)
+        src_kernel = kernel_path(src)
+        dst_kernel = pkg / src_kernel.name
+        shutil.copy2(src_kernel, dst_kernel)
+
+        if sys.platform == "darwin":
+            vendor_macos(dst_kernel, prefix, pkg / ".dylibs")
+        elif sys.platform.startswith("linux"):
+            vendor_linux(dst_kernel, prefix, pkg / ".libs")
+        elif sys.platform == "win32":
+            vendor_windows(dst_kernel, prefix, pkg)
+
+        write_dist_info(stage, version, tag)
+        write_record(stage, version)
+        wheel_path = output_dir / f"tudatpy-{version}-{tag}.whl"
+        if wheel_path.exists():
+            wheel_path.unlink()
+        with zipfile.ZipFile(wheel_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for path in stage.rglob("*"):
+                if path.is_file():
+                    zf.write(path, path.relative_to(stage).as_posix())
+        return wheel_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-o", "--output-dir", type=Path, default=Path("wheels"))
+    parser.add_argument("--index", action="store_true", help="Write index.html in the output dir")
+    args = parser.parse_args()
+    wheel = pack(args.output_dir)
+    print(f"wrote {wheel} ({wheel.stat().st_size} bytes)")
+    if args.index:
+        write_index(args.output_dir)
+        print(f"wrote {args.output_dir / 'index.html'}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Repack conda `tudatpy` into pip wheels. No extra C++ build. Conda stays the recommended install.

**Does not run on commit / PR / push.** Triggers:

- `workflow_dispatch` — artifacts only, nothing published
- `release` published — builds and attaches `.whl` + `index.html` to that release

**First 1.0.0 wheels:** merge (or otherwise have `wheels.yml` on the tagged commit) → Releases → Draft a new release → tag **`v1.0.0`** → Publish. CI installs conda `tudatpy=1.0.0` (pinned in the workflow) and uploads the wheels onto that release. Merging this PR by itself does not publish anything.

```bash
pip install tudatpy --find-links https://github.com/tudat-team/tudatpy/releases/download/v1.0.0/index.html
```

`--find-links` needs a public repo (or `gh release download` if private).

Matrix: linux-64, osx-arm64 (`macos-14`), osx-64 (`macos-15-intel`), win-64 × cp310–312.